### PR TITLE
docs: rewrite README with architecture, setup, badges, and features

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GitError
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,144 @@
-# Tauri + React + Typescript
+# Portfolio Tracker
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+[![CI](https://github.com/GitError/portfolio-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/GitError/portfolio-tracker/actions/workflows/ci.yml)
+[![Rust](https://img.shields.io/badge/rust-1.94+-orange?style=flat-square&logo=rust)](https://www.rust-lang.org)
+[![Node](https://img.shields.io/badge/node-22+-green?style=flat-square&logo=node.js)](https://nodejs.org)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
-## Recommended IDE Setup
+A macOS desktop portfolio tracker built with Tauri v2. Tracks stocks, ETFs, crypto, and multi-currency cash positions with live pricing from Yahoo Finance and real-time stress-test simulations. All values are displayed in CAD.
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+The app runs as a native macOS window with a Bloomberg-inspired dark terminal UI. Holdings are stored locally in SQLite — no cloud account required.
+
+---
+
+## Screenshot
+
+> _Dashboard showing portfolio value, allocation breakdown, and top movers._
+
+![Dashboard](docs/screenshot-dashboard.png)
+
+---
+
+## Tech Stack
+
+| Layer     | Technology                                        |
+|-----------|---------------------------------------------------|
+| Shell     | [Tauri v2](https://tauri.app)                     |
+| Backend   | Rust — tokio, reqwest, rusqlite                   |
+| Frontend  | React 18 + TypeScript + Vite                      |
+| Styling   | Tailwind CSS v4                                   |
+| Charts    | [Recharts](https://recharts.org)                  |
+| Icons     | [lucide-react](https://lucide.dev)                |
+| Router    | react-router-dom v7                               |
+| Database  | SQLite (bundled via rusqlite)                     |
+
+---
+
+## Architecture
+
+```
+portfolio-tracker/
+├── src-tauri/          # Rust backend
+│   └── src/
+│       ├── main.rs     # Tauri bootstrap + state
+│       ├── commands.rs # Tauri command handlers
+│       ├── db.rs       # SQLite schema + CRUD
+│       ├── price.rs    # Yahoo Finance price fetching
+│       ├── fx.rs       # FX rate fetching + conversion
+│       └── stress.rs   # Stress test engine
+└── src/                # React frontend
+    ├── components/     # Views: Dashboard, Holdings, Performance, StressTest
+    ├── hooks/          # usePortfolio, useStressTest
+    ├── lib/            # Formatters, colours, constants
+    └── types/          # TypeScript types (mirrors Rust structs)
+```
+
+The Rust backend exposes Tauri commands that the React frontend calls via `invoke()`. The SQLite database lives in the macOS app data directory. Price data is fetched from Yahoo Finance on demand and cached locally.
+
+---
+
+## Features
+
+- **Dashboard** — portfolio value, daily P&L, asset allocation donut, currency exposure, top movers
+- **Holdings** — sortable table with add/edit/delete; supports stocks, ETFs, crypto, and multi-currency cash
+- **Performance** — 2-year area chart with range selector (1D–ALL), daily returns bar chart, drawdown/volatility stats
+- **Stress Test** — live slider-driven scenario simulation; preset scenarios (Bear Market, Crypto Winter, CAD Crash, Stagflation); waterfall chart with per-holding impact breakdown
+- **Multi-currency** — USD, EUR, GBP, and more; all converted to CAD at live rates
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Rust** 1.70+ — [rustup.rs](https://rustup.rs)
+- **Node.js** 22+ — [nodejs.org](https://nodejs.org)
+- macOS 11+
+
+### Install
+
+```bash
+git clone https://github.com/GitError/portfolio-tracker.git
+cd portfolio-tracker
+npm install
+git config core.hooksPath .githooks
+```
+
+### Run in development
+
+```bash
+npm run tauri dev
+```
+
+Starts both the Vite dev server and the Tauri window. The frontend falls back to mock data in browser-only mode (`npm run dev`).
+
+### First-time setup
+
+1. Launch with `npm run tauri dev`
+2. Navigate to **Holdings** (sidebar or press `2`)
+3. Click **Add Holding** and enter your first position
+4. Return to the **Dashboard** to see live values
+
+---
+
+## Development
+
+```bash
+# Frontend
+npm run dev           # Vite dev server (browser, mock data)
+npm run lint          # ESLint
+npm run typecheck     # TypeScript check
+npm run format        # Prettier (write)
+npm run format:check  # Prettier (check only)
+npm run test          # Vitest (run once)
+npm run test:watch    # Vitest (watch)
+npm run test:coverage # Coverage report (v8)
+
+# Rust
+cd src-tauri
+cargo test            # Unit tests (db, stress engine, fx)
+cargo clippy          # Linter
+cargo fmt             # Formatter
+```
+
+### Git hooks
+
+Located in `.githooks/`, activated during install above.
+
+| Hook | Runs |
+|------|------|
+| pre-commit | lint, typecheck, format check, cargo fmt |
+| pre-push | full test suite (frontend + Rust) |
+| post-merge | reinstalls deps if lock files changed |
+
+---
+
+## Contributing
+
+PRs and issues are welcome. Open an issue before making large changes.
+
+---
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Fixes #11

## Summary
- Full project README replacing the scaffold placeholder
- CI/Rust/Node/license badges (flat-square style)
- Architecture section with directory tree, tech stack table, features list
- Getting started: prerequisites, install, dev run, first-time setup steps
- Development commands for both frontend (`npm run *`) and Rust (`cargo *`)
- Git hooks reference table
- MIT `LICENSE` file (required by the badge link)

## Test plan
- [ ] Verify badges render on GitHub (CI badge shows status after merge)
- [ ] Confirm all links in the README resolve correctly
- [ ] Clone to a temp directory and follow the Getting Started steps to validate accuracy
- [ ] Check no references to mock data, agent prompts, or scaffold docs remain