### PR TITLE
ci: skip CI for docs-only changes; add job-level path filtering

### DIFF
--- a/.github/setup-branch-protection.sh
+++ b/.github/setup-branch-protection.sh
@@ -26,8 +26,7 @@ gh api repos/$REPO/branches/main/protection \
   "required_status_checks": {
     "strict": true,
     "contexts": [
-      "Frontend",
-      "Backend (Rust)"
+      "CI Status"
     ]
   },
   "enforce_admins": false,
@@ -43,7 +42,7 @@ EOF
 
 echo "  ✓ main protected"
 echo "    - PRs required (no direct push)"
-echo "    - CI must pass (Frontend + Backend + Claude Review)"
+echo "    - CI Status roll-up must pass"
 echo "    - Stale reviews dismissed on new commits"
 
 # ── dev branch: lighter protection ────────────────────────────
@@ -55,8 +54,7 @@ gh api repos/$REPO/branches/dev/protection \
   "required_status_checks": {
     "strict": false,
     "contexts": [
-      "Frontend",
-      "Backend (Rust)"
+      "CI Status"
     ]
   },
   "enforce_admins": false,
@@ -68,7 +66,7 @@ gh api repos/$REPO/branches/dev/protection \
 EOF
 
 echo "  ✓ dev protected"
-echo "    - CI must pass (Frontend + Backend)"
+echo "    - CI Status roll-up must pass"
 echo "    - Direct push allowed (for agent merges)"
 echo "    - Force push allowed (for rebases)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'agent-prompts/**'
+      - '.githooks/**'
+      - '*.sh'
+      - '.github/dependabot.yml'
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'agent-prompts/**'
+      - '.githooks/**'
+      - '*.sh'
+      - '.github/dependabot.yml'
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,9 +30,37 @@ env:
   RUST_TOOLCHAIN: stable
 
 jobs:
+  # ── Detect which parts of the codebase changed ──────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - 'vite.config.ts'
+              - 'vitest.config.ts'
+              - 'eslint.config.js'
+              - '.prettierrc'
+              - 'index.html'
+            backend:
+              - 'src-tauri/**'
+
   # ── Frontend: Lint + Type Check + Format + Test + Build ────
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -49,6 +95,8 @@ jobs:
   # ── Backend: Lint + Build + Test ────────────────────────────
   backend:
     name: Backend (Rust)
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,3 +136,18 @@ jobs:
 
       - name: Build
         run: cargo build
+
+  # ── Roll-up: single required status check for branch protection ──
+  ci-status:
+    name: CI Status
+    if: always()
+    needs: [frontend, backend]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          if [[ "${{ needs.frontend.result }}" == "failure" || "${{ needs.backend.result }}" == "failure" ]]; then
+            echo "One or more CI jobs failed."
+            exit 1
+          fi
+          echo "CI passed (skipped jobs count as success)."


### PR DESCRIPTION
Closes #17

## What changed

### Top-level \`paths-ignore\`
CI is skipped entirely for pushes/PRs that only touch non-code files:
\`**.md\`, \`docs/**\`, \`LICENSE\`, \`.gitignore\`, \`agent-prompts/**\`, \`.githooks/**\`, \`*.sh\`, \`.github/dependabot.yml\`

### \`changes\` detection job (\`dorny/paths-filter@v3\`)
Determines which jobs need to run before anything spins up:

| Output | Triggers on |
|--------|------------|
| \`frontend\` | \`src/**\`, \`package*.json\`, \`tsconfig.json\`, \`vite.config.ts\`, \`vitest.config.ts\`, \`eslint.config.js\`, \`.prettierrc\`, \`index.html\` |
| \`backend\` | \`src-tauri/**\` |

### Per-job \`if\` conditions
- \`Frontend\` only runs when \`needs.changes.outputs.frontend == 'true'\`
- \`Backend (Rust)\` only runs when \`needs.changes.outputs.backend == 'true'\`

### \`CI Status\` roll-up job
A single \`if: always()\` job that fails if either real job failed, but passes when jobs are skipped. This replaces the individual \`Frontend\` / \`Backend (Rust)\` entries as the required branch protection check.

### \`setup-branch-protection.sh\` updated
Required status check changed from \`["Frontend", "Backend (Rust)"]\` to \`["CI Status"]\` for both \`main\` and \`dev\`.

## Test plan
- [ ] Push a markdown-only change — CI Status passes, no Frontend/Backend jobs run
- [ ] Push a \`src/\` change — only Frontend job runs
- [ ] Push a \`src-tauri/\` change — only Backend job runs
- [ ] Push a change touching both — both jobs run
- [ ] Docs-only PR merges without blocked checks
- [ ] Re-run \`setup-branch-protection.sh\` to update required check to "CI Status"