### PR TITLE
feat: flexible symbol parsing and enriched import preview for CSV

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,8 @@ use crate::search::search_symbols_yahoo;
 use crate::stress::run_stress_test;
 use crate::types::{
     AccountType, AssetType, FxRate, Holding, HoldingInput, HoldingWithPrice, ImportError,
-    ImportResult, PortfolioSnapshot, PriceData, StressResult, StressScenario, SymbolResult,
+    ImportResult, PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceData, StressResult,
+    StressScenario, SymbolResult,
 };
 
 const MAX_IMPORT_ROWS: usize = 500;
@@ -133,6 +134,28 @@ fn parse_optional_field(record: &StringRecord, index: Option<usize>) -> String {
         .to_string()
 }
 
+/// Convert `SYMBOL:COUNTRY` notation to a Yahoo Finance symbol.
+/// Plain symbols are returned unchanged (uppercased).
+/// Examples: `BMO:CA` → `BMO.TO`, `AAPL:US` → `AAPL`, `BARC:GB` → `BARC.L`
+fn normalize_symbol_for_import(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if let Some((sym, country)) = trimmed.split_once(':') {
+        let sym = sym.trim().to_uppercase();
+        match country.trim().to_uppercase().as_str() {
+            "CA" => format!("{}.TO", sym),
+            "GB" => format!("{}.L", sym),
+            "AU" => format!("{}.AX", sym),
+            "DE" => format!("{}.DE", sym),
+            "FR" => format!("{}.PA", sym),
+            "JP" => format!("{}.T", sym),
+            "HK" => format!("{}.HK", sym),
+            _ => sym, // US or unrecognised: no exchange suffix
+        }
+    } else {
+        trimmed.to_uppercase()
+    }
+}
+
 fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> {
     let content = csv_content.trim_start_matches('\u{feff}');
     let mut reader = ReaderBuilder::new()
@@ -194,12 +217,12 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
             if raw_symbol.is_empty() || raw_symbol.eq_ignore_ascii_case("CASH") {
                 format!("{}-CASH", currency)
             } else {
-                raw_symbol.to_uppercase()
+                normalize_symbol_for_import(&raw_symbol)
             }
         } else if raw_symbol.is_empty() {
             return Err(format!("Row {}: missing_symbol", row));
         } else {
-            raw_symbol.to_uppercase()
+            normalize_symbol_for_import(&raw_symbol)
         };
 
         let quantity = parse_required_field(&record, quantity_index, row, "quantity")?
@@ -553,6 +576,125 @@ pub async fn import_holdings_csv(
 }
 
 #[tauri::command]
+pub async fn preview_import_csv(
+    db: State<'_, DbState>,
+    client: State<'_, HttpClient>,
+    csv_content: String,
+) -> Result<PreviewImportResult, String> {
+    let parsed_rows = parse_import_rows(&csv_content)?;
+    let existing_symbols: HashSet<String> = {
+        let conn = db.0.lock().map_err(|e| e.to_string())?;
+        db::get_all_holdings(&conn)?
+            .into_iter()
+            .map(|h| h.symbol.to_uppercase())
+            .collect()
+    };
+
+    let mut preview_rows: Vec<PreviewRow> = Vec::new();
+    let mut seen: HashSet<String> = existing_symbols;
+
+    for row in parsed_rows {
+        let sym_upper = row.symbol.to_uppercase();
+
+        if seen.contains(&sym_upper) {
+            preview_rows.push(PreviewRow {
+                row: row.row,
+                original_symbol: row.symbol.clone(),
+                resolved_symbol: row.symbol.clone(),
+                name: row.name,
+                asset_type: row.asset_type.as_str().to_string(),
+                currency: row.currency,
+                exchange: String::new(),
+                quantity: row.quantity,
+                cost_basis: row.cost_basis,
+                status: "duplicate".to_string(),
+            });
+            continue;
+        }
+
+        if matches!(row.asset_type, AssetType::Cash) {
+            seen.insert(sym_upper);
+            preview_rows.push(PreviewRow {
+                row: row.row,
+                original_symbol: row.symbol.clone(),
+                resolved_symbol: row.symbol.clone(),
+                name: if row.name.is_empty() {
+                    format!("{} Cash", row.currency)
+                } else {
+                    row.name
+                },
+                asset_type: "cash".to_string(),
+                currency: row.currency,
+                exchange: String::new(),
+                quantity: row.quantity,
+                cost_basis: row.cost_basis,
+                status: "ready".to_string(),
+            });
+            continue;
+        }
+
+        match validate_symbol(&db, &client, &row.symbol).await {
+            Ok(Some(result)) => {
+                seen.insert(result.symbol.to_uppercase());
+                preview_rows.push(PreviewRow {
+                    row: row.row,
+                    original_symbol: row.symbol,
+                    resolved_symbol: result.symbol,
+                    name: if row.name.is_empty() {
+                        result.name
+                    } else {
+                        row.name
+                    },
+                    asset_type: result.asset_type.as_str().to_string(),
+                    currency: result.currency,
+                    exchange: result.exchange,
+                    quantity: row.quantity,
+                    cost_basis: row.cost_basis,
+                    status: "ready".to_string(),
+                });
+            }
+            Ok(None) => {
+                preview_rows.push(PreviewRow {
+                    row: row.row,
+                    original_symbol: row.symbol.clone(),
+                    resolved_symbol: String::new(),
+                    name: row.name,
+                    asset_type: row.asset_type.as_str().to_string(),
+                    currency: row.currency,
+                    exchange: String::new(),
+                    quantity: row.quantity,
+                    cost_basis: row.cost_basis,
+                    status: "invalid_symbol".to_string(),
+                });
+            }
+            Err(_) => {
+                preview_rows.push(PreviewRow {
+                    row: row.row,
+                    original_symbol: row.symbol.clone(),
+                    resolved_symbol: String::new(),
+                    name: row.name,
+                    asset_type: row.asset_type.as_str().to_string(),
+                    currency: row.currency,
+                    exchange: String::new(),
+                    quantity: row.quantity,
+                    cost_basis: row.cost_basis,
+                    status: "validation_failed".to_string(),
+                });
+            }
+        }
+    }
+
+    let ready_count = preview_rows.iter().filter(|r| r.status == "ready").count();
+    let skip_count = preview_rows.len() - ready_count;
+
+    Ok(PreviewImportResult {
+        rows: preview_rows,
+        ready_count,
+        skip_count,
+    })
+}
+
+#[tauri::command]
 pub async fn refresh_prices(
     db: State<'_, DbState>,
     client: State<'_, HttpClient>,
@@ -702,6 +844,36 @@ pub async fn get_performance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_symbol_strips_country_suffix() {
+        assert_eq!(normalize_symbol_for_import("BMO:CA"), "BMO.TO");
+        assert_eq!(normalize_symbol_for_import("AAPL:US"), "AAPL");
+        assert_eq!(normalize_symbol_for_import("BARC:GB"), "BARC.L");
+        assert_eq!(normalize_symbol_for_import("CBA:AU"), "CBA.AX");
+        assert_eq!(normalize_symbol_for_import("SAP:DE"), "SAP.DE");
+        assert_eq!(normalize_symbol_for_import("AIR:FR"), "AIR.PA");
+        assert_eq!(normalize_symbol_for_import("7203:JP"), "7203.T");
+        assert_eq!(normalize_symbol_for_import("0700:HK"), "0700.HK");
+    }
+
+    #[test]
+    fn normalize_symbol_passes_through_plain_symbols() {
+        assert_eq!(normalize_symbol_for_import("AAPL"), "AAPL");
+        assert_eq!(normalize_symbol_for_import("BMO.TO"), "BMO.TO");
+        assert_eq!(normalize_symbol_for_import("bmo"), "BMO");
+        assert_eq!(normalize_symbol_for_import(" MSFT "), "MSFT");
+    }
+
+    #[test]
+    fn parse_import_rows_normalizes_country_suffix() {
+        let csv =
+            "symbol,name,type,quantity,cost_basis,currency\nBMO:CA,Bank of Montreal,stock,10,80,CAD\n";
+        let rows = parse_import_rows(csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].symbol, "BMO.TO");
+    }
 
     #[test]
     fn parse_import_rows_supports_cash_defaults() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ pub fn run() {
             commands::update_holding,
             commands::delete_holding,
             commands::import_holdings_csv,
+            commands::preview_import_csv,
             commands::export_holdings_csv,
             commands::refresh_prices,
             commands::run_stress_test_cmd,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -207,3 +207,29 @@ pub struct StressResult {
     pub total_impact_percent: f64,
     pub holding_breakdown: Vec<StressHoldingResult>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewRow {
+    pub row: usize,
+    /// Symbol as written in the CSV (e.g. "BMO:CA")
+    pub original_symbol: String,
+    /// Resolved Yahoo Finance symbol (e.g. "BMO.TO"), empty when unresolvable
+    pub resolved_symbol: String,
+    pub name: String,
+    pub asset_type: String,
+    pub currency: String,
+    pub exchange: String,
+    pub quantity: f64,
+    pub cost_basis: f64,
+    /// "ready" | "cash" | "duplicate" | "invalid_symbol" | "validation_failed"
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreviewImportResult {
+    pub rows: Vec<PreviewRow>,
+    pub ready_count: usize,
+    pub skip_count: usize,
+}

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -76,6 +76,7 @@ export function Holdings() {
     updateHolding,
     deleteHolding,
     importHoldingsCsv,
+    previewImportCsv,
     exportHoldingsCsv,
   } = usePortfolio();
   const { showToast } = useToast();
@@ -660,6 +661,7 @@ export function Holdings() {
         isOpen={importOpen}
         onClose={() => setImportOpen(false)}
         onImport={handleImport}
+        onPreview={previewImportCsv}
       />
     </div>
   );

--- a/src/components/ImportHoldingsModal.tsx
+++ b/src/components/ImportHoldingsModal.tsx
@@ -1,38 +1,45 @@
-import { useMemo, useState } from 'react';
-import type { ImportResult } from '../types/portfolio';
+import { useState } from 'react';
+import type { ImportResult, PreviewImportResult, PreviewRow } from '../types/portfolio';
+import { ASSET_TYPE_CONFIG } from '../lib/constants';
+import { Badge } from './ui/Badge';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   onImport: (csvContent: string) => Promise<ImportResult>;
+  onPreview: (csvContent: string) => Promise<PreviewImportResult>;
 }
 
-const DROP_STYLE: React.CSSProperties = {
-  border: '1px dashed var(--border-primary)',
-  background: 'var(--bg-primary)',
-  padding: '24px 20px',
-  color: 'var(--text-secondary)',
-  fontFamily: 'var(--font-mono)',
-  fontSize: 12,
-  textAlign: 'center',
-  cursor: 'pointer',
+const MONO: React.CSSProperties = { fontFamily: 'var(--font-mono)' };
+
+const STATUS_LABEL: Record<string, { label: string; color: string }> = {
+  ready: { label: 'Ready', color: 'var(--color-gain)' },
+  cash: { label: 'Cash', color: 'var(--color-cash)' },
+  duplicate: { label: 'Duplicate', color: 'var(--color-warning)' },
+  invalid_symbol: { label: 'Invalid symbol', color: 'var(--color-loss)' },
+  validation_failed: { label: 'Check failed', color: 'var(--color-loss)' },
 };
 
-function parsePreview(csvContent: string): string[][] {
-  return csvContent
-    .replace(/^\uFEFF/, '')
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0)
-    .slice(0, 6)
-    .map((line) => line.split(/[;,]/).map((cell) => cell.trim()));
+function statusCell(status: string) {
+  const s = STATUS_LABEL[status] ?? { label: status, color: 'var(--text-muted)' };
+  return <span style={{ ...MONO, fontSize: 11, color: s.color, fontWeight: 600 }}>{s.label}</span>;
+}
+
+function assetTypeBadge(type: string) {
+  const cfg = ASSET_TYPE_CONFIG[type as keyof typeof ASSET_TYPE_CONFIG];
+  if (!cfg)
+    return <span style={{ ...MONO, fontSize: 10, color: 'var(--text-muted)' }}>{type}</span>;
+  return <Badge type={type as 'stock' | 'etf' | 'crypto' | 'cash'} />;
 }
 
 function downloadTemplate() {
   const template = [
     'symbol,name,type,account,quantity,cost_basis,currency',
     'AAPL,Apple Inc.,stock,tfsa,50,142.50,USD',
-    'VOO,Vanguard S&P 500 ETF,etf,rrsp,100,380.00,USD',
-    'BTC-CAD,Bitcoin,crypto,taxable,0.5,45000.00,CAD',
+    'BMO:CA,Bank of Montreal,stock,rrsp,100,80.00,CAD',
+    'VOO,Vanguard S&P 500 ETF,etf,rrsp,20,380.00,USD',
+    'BTC-USD,Bitcoin,crypto,taxable,0.5,45000.00,USD',
+    ',US Dollar Cash,cash,taxable,5000,1.00,USD',
   ].join('\n');
 
   const blob = new Blob([template], { type: 'text/csv;charset=utf-8' });
@@ -44,21 +51,124 @@ function downloadTemplate() {
   URL.revokeObjectURL(url);
 }
 
-export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
+const TD: React.CSSProperties = {
+  padding: '6px 10px',
+  borderBottom: '1px solid var(--border-subtle)',
+  verticalAlign: 'middle',
+};
+
+function PreviewTable({ rows }: { rows: PreviewRow[] }) {
+  return (
+    <div style={{ border: '1px solid var(--border-primary)', overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
+        <thead>
+          <tr style={{ background: 'var(--bg-surface-alt)' }}>
+            {[
+              '#',
+              'Symbol (CSV)',
+              'Resolved',
+              'Name',
+              'Type',
+              'Exch',
+              'CCY',
+              'Qty',
+              'Cost',
+              'Status',
+            ].map((h) => (
+              <th
+                key={h}
+                style={{
+                  ...TD,
+                  ...MONO,
+                  textAlign: 'left',
+                  color: 'var(--text-muted)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  fontWeight: 400,
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr
+              key={`${r.row}-${r.originalSymbol}`}
+              style={{
+                background: r.status === 'ready' ? 'transparent' : 'rgba(255,71,87,0.04)',
+                opacity:
+                  r.status === 'duplicate' ||
+                  r.status.startsWith('invalid') ||
+                  r.status === 'validation_failed'
+                    ? 0.65
+                    : 1,
+              }}
+            >
+              <td style={{ ...TD, ...MONO, color: 'var(--text-muted)' }}>{r.row}</td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)' }}>
+                {r.originalSymbol || '—'}
+              </td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-primary)', fontWeight: 600 }}>
+                {r.resolvedSymbol || '—'}
+              </td>
+              <td
+                style={{
+                  ...TD,
+                  fontFamily: 'var(--font-sans)',
+                  color: 'var(--text-secondary)',
+                  maxWidth: 160,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {r.name || '—'}
+              </td>
+              <td style={TD}>{assetTypeBadge(r.assetType)}</td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-muted)' }}>{r.exchange || '—'}</td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-muted)' }}>{r.currency}</td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)', textAlign: 'right' }}>
+                {r.quantity.toLocaleString()}
+              </td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)', textAlign: 'right' }}>
+                {r.costBasis.toFixed(2)}
+              </td>
+              <td style={TD}>{statusCell(r.status)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function ImportHoldingsModal({ isOpen, onClose, onImport, onPreview }: Props) {
   const [filename, setFilename] = useState('');
   const [csvContent, setCsvContent] = useState('');
+  const [previewing, setPreviewing] = useState(false);
+  const [preview, setPreview] = useState<PreviewImportResult | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<ImportResult | null>(null);
 
-  const previewRows = useMemo(() => parsePreview(csvContent), [csvContent]);
-
   async function loadFile(file: File) {
     setError(null);
     setResult(null);
-    setFilename(file.name);
+    setPreview(null);
     const text = await file.text();
+    setFilename(file.name);
     setCsvContent(text);
+
+    setPreviewing(true);
+    try {
+      setPreview(await onPreview(text));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPreviewing(false);
+    }
   }
 
   async function handleImport() {
@@ -66,11 +176,11 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
       setError('Select a CSV file first');
       return;
     }
-
     setRunning(true);
     setError(null);
     try {
       setResult(await onImport(csvContent));
+      setPreview(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -79,6 +189,8 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
   }
 
   if (!isOpen) return null;
+
+  const canImport = !!preview && preview.readyCount > 0 && !running && !previewing;
 
   return (
     <div
@@ -92,26 +204,27 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
         justifyContent: 'center',
         zIndex: 1100,
       }}
-      onClick={(event) => {
-        if (event.target === event.currentTarget && !running) onClose();
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !running && !previewing) onClose();
       }}
     >
       <div
         style={{
           width: '100%',
-          maxWidth: 760,
+          maxWidth: 880,
           background: 'var(--bg-surface)',
           border: '1px solid var(--border-primary)',
           padding: 20,
-          maxHeight: '85vh',
+          maxHeight: '88vh',
           overflow: 'auto',
         }}
       >
+        {/* Header */}
         <div
           style={{
             display: 'flex',
             justifyContent: 'space-between',
-            alignItems: 'center',
+            alignItems: 'flex-start',
             marginBottom: 16,
           }}
         >
@@ -126,59 +239,66 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
             >
               Import Holdings
             </div>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 11,
-                color: 'var(--text-muted)',
-                marginTop: 4,
-              }}
-            >
-              Upload a CSV with `symbol,name,type,account,quantity,cost_basis,currency`
+            <div style={{ ...MONO, fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}>
+              Supports <code style={{ color: 'var(--text-secondary)' }}>SYMBOL:COUNTRY</code> (e.g.{' '}
+              <code style={{ color: 'var(--text-secondary)' }}>BMO:CA</code>), plain symbols, and
+              cash rows.
             </div>
           </div>
           <button
             onClick={onClose}
-            disabled={running}
+            disabled={running || previewing}
             style={{
               background: 'none',
               border: '1px solid var(--border-primary)',
               color: 'var(--text-secondary)',
-              fontFamily: 'var(--font-mono)',
+              ...MONO,
               fontSize: 11,
               padding: '6px 10px',
-              cursor: running ? 'not-allowed' : 'pointer',
+              cursor: running || previewing ? 'not-allowed' : 'pointer',
             }}
           >
             Close
           </button>
         </div>
 
-        <label style={{ display: 'block' }}>
-          <div style={DROP_STYLE}>
-            <div>{filename || 'Choose a .csv file or drop one here'}</div>
-            <div style={{ marginTop: 8, fontSize: 11, color: 'var(--text-muted)' }}>
-              Max 500 rows. Comma or semicolon delimiters accepted.
+        {/* File picker */}
+        <label style={{ display: 'block', marginBottom: 12 }}>
+          <div
+            style={{
+              border: '1px dashed var(--border-primary)',
+              background: 'var(--bg-primary)',
+              padding: '20px',
+              color: 'var(--text-secondary)',
+              ...MONO,
+              fontSize: 12,
+              textAlign: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <div>{filename || 'Choose a .csv file'}</div>
+            <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+              Max 500 rows · comma or semicolon delimiters accepted
             </div>
           </div>
           <input
             type="file"
             accept=".csv,text/csv"
             style={{ display: 'none' }}
-            onChange={(event) => {
-              const file = event.target.files?.[0];
+            onChange={(e) => {
+              const file = e.target.files?.[0];
               if (file) void loadFile(file);
             }}
           />
         </label>
 
+        {/* Action bar */}
         <div
           style={{
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            marginTop: 12,
-            marginBottom: 12,
+            marginBottom: 14,
           }}
         >
           <button
@@ -187,7 +307,7 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
               background: 'none',
               border: '1px solid var(--border-primary)',
               color: 'var(--text-secondary)',
-              fontFamily: 'var(--font-mono)',
+              ...MONO,
               fontSize: 11,
               padding: '6px 10px',
               cursor: 'pointer',
@@ -197,23 +317,27 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
           </button>
           <button
             onClick={() => void handleImport()}
-            disabled={running || !csvContent.trim()}
+            disabled={!canImport}
             style={{
-              background: 'var(--color-accent)',
+              background: canImport ? 'var(--color-accent)' : 'var(--border-primary)',
               border: 'none',
-              color: '#fff',
+              color: canImport ? '#fff' : 'var(--text-muted)',
               fontFamily: 'var(--font-sans)',
               fontSize: 12,
               fontWeight: 600,
-              padding: '8px 14px',
-              cursor: running || !csvContent.trim() ? 'not-allowed' : 'pointer',
-              opacity: running || !csvContent.trim() ? 0.6 : 1,
+              padding: '8px 16px',
+              cursor: canImport ? 'pointer' : 'not-allowed',
             }}
           >
-            {running ? 'Importing...' : 'Import'}
+            {running
+              ? 'Importing…'
+              : preview
+                ? `Import ${preview.readyCount} row${preview.readyCount !== 1 ? 's' : ''}`
+                : 'Import'}
           </button>
         </div>
 
+        {/* Error */}
         {error ? (
           <div
             style={{
@@ -223,60 +347,46 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
               background: 'rgba(255,71,87,0.08)',
               padding: '10px 12px',
               fontSize: 12,
-              fontFamily: 'var(--font-mono)',
+              ...MONO,
             }}
           >
             {error}
           </div>
         ) : null}
 
-        {previewRows.length > 0 ? (
-          <div style={{ marginBottom: 16 }}>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 11,
-                color: 'var(--text-muted)',
-                marginBottom: 8,
-                textTransform: 'uppercase',
-                letterSpacing: '0.08em',
-              }}
-            >
-              Preview
-            </div>
-            <div style={{ border: '1px solid var(--border-primary)', overflowX: 'auto' }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                <tbody>
-                  {previewRows.map((cells, rowIndex) => (
-                    <tr
-                      key={`${rowIndex}-${cells.join('|')}`}
-                      style={{
-                        background: rowIndex === 0 ? 'var(--bg-surface-alt)' : 'var(--bg-surface)',
-                      }}
-                    >
-                      {cells.map((cell, cellIndex) => (
-                        <td
-                          key={`${rowIndex}-${cellIndex}`}
-                          style={{
-                            padding: '7px 9px',
-                            borderBottom: '1px solid var(--border-subtle)',
-                            borderRight: '1px solid var(--border-subtle)',
-                            fontFamily: 'var(--font-mono)',
-                            fontSize: 11,
-                            color: rowIndex === 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
-                          }}
-                        >
-                          {cell}
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+        {/* Previewing spinner */}
+        {previewing ? (
+          <div style={{ ...MONO, fontSize: 12, color: 'var(--text-muted)', marginBottom: 12 }}>
+            Validating symbols…
           </div>
         ) : null}
 
+        {/* Enriched preview table */}
+        {!previewing && preview ? (
+          <div style={{ marginBottom: 16 }}>
+            <div
+              style={{
+                ...MONO,
+                fontSize: 11,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                marginBottom: 8,
+                display: 'flex',
+                gap: 16,
+              }}
+            >
+              <span>Preview</span>
+              <span style={{ color: 'var(--color-gain)' }}>{preview.readyCount} ready</span>
+              {preview.skipCount > 0 && (
+                <span style={{ color: 'var(--color-loss)' }}>{preview.skipCount} will skip</span>
+              )}
+            </div>
+            <PreviewTable rows={preview.rows} />
+          </div>
+        ) : null}
+
+        {/* Import result */}
         {result ? (
           <div>
             <div
@@ -292,53 +402,36 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
             </div>
             {result.skipped.length > 0 ? (
               <div style={{ border: '1px solid var(--border-primary)', overflowX: 'auto' }}>
-                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
                   <thead>
                     <tr style={{ background: 'var(--bg-surface-alt)' }}>
-                      <th style={{ padding: '8px 10px', textAlign: 'left', fontSize: 11 }}>Row</th>
-                      <th style={{ padding: '8px 10px', textAlign: 'left', fontSize: 11 }}>
-                        Symbol
-                      </th>
-                      <th style={{ padding: '8px 10px', textAlign: 'left', fontSize: 11 }}>
-                        Reason
-                      </th>
+                      {['Row', 'Symbol', 'Reason'].map((h) => (
+                        <th
+                          key={h}
+                          style={{
+                            ...TD,
+                            ...MONO,
+                            textAlign: 'left',
+                            color: 'var(--text-muted)',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.06em',
+                            fontWeight: 400,
+                          }}
+                        >
+                          {h}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
                     {result.skipped.map((item) => (
-                      <tr key={`${item.row}-${item.symbol}-${item.reason}`}>
-                        <td
-                          style={{
-                            padding: '7px 10px',
-                            borderTop: '1px solid var(--border-subtle)',
-                            fontFamily: 'var(--font-mono)',
-                            fontSize: 11,
-                            color: 'var(--text-secondary)',
-                          }}
-                        >
-                          {item.row}
-                        </td>
-                        <td
-                          style={{
-                            padding: '7px 10px',
-                            borderTop: '1px solid var(--border-subtle)',
-                            fontFamily: 'var(--font-mono)',
-                            fontSize: 11,
-                            color: 'var(--text-primary)',
-                          }}
-                        >
+                      <tr key={`${item.row}-${item.symbol}`}>
+                        <td style={{ ...TD, ...MONO, color: 'var(--text-muted)' }}>{item.row}</td>
+                        <td style={{ ...TD, ...MONO, color: 'var(--text-primary)' }}>
                           {item.symbol || '—'}
                         </td>
-                        <td
-                          style={{
-                            padding: '7px 10px',
-                            borderTop: '1px solid var(--border-subtle)',
-                            fontFamily: 'var(--font-mono)',
-                            fontSize: 11,
-                            color: 'var(--color-loss)',
-                          }}
-                        >
-                          {item.reason}
+                        <td style={{ ...TD, ...MONO, color: 'var(--color-loss)' }}>
+                          {STATUS_LABEL[item.reason]?.label ?? item.reason}
                         </td>
                       </tr>
                     ))}
@@ -346,14 +439,8 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport }: Props) {
                 </table>
               </div>
             ) : (
-              <div
-                style={{
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 12,
-                  color: 'var(--color-gain)',
-                }}
-              >
-                No rows were skipped.
+              <div style={{ ...MONO, fontSize: 12, color: 'var(--color-gain)' }}>
+                All rows imported successfully.
               </div>
             )}
           </div>

--- a/src/hooks/usePortfolio.ts
+++ b/src/hooks/usePortfolio.ts
@@ -5,6 +5,7 @@ import type {
   HoldingInput,
   ImportResult,
   PortfolioSnapshot,
+  PreviewImportResult,
 } from '../types/portfolio';
 import { MOCK_SNAPSHOT, MOCK_HOLDINGS } from '../lib/mockData';
 
@@ -27,6 +28,7 @@ export interface UsePortfolioReturn {
   updateHolding: (holding: Holding) => Promise<Holding>;
   deleteHolding: (id: string) => Promise<void>;
   importHoldingsCsv: (csvContent: string) => Promise<ImportResult>;
+  previewImportCsv: (csvContent: string) => Promise<PreviewImportResult>;
   exportHoldingsCsv: () => Promise<string>;
 }
 
@@ -179,6 +181,30 @@ export function usePortfolio(): UsePortfolioReturn {
     [loadPortfolio]
   );
 
+  const previewImportCsv = useCallback(async (csvContent: string): Promise<PreviewImportResult> => {
+    if (isTauri()) {
+      return tauriInvoke<PreviewImportResult>('preview_import_csv', { csvContent });
+    }
+    // Browser mock: parse the CSV and return a basic preview
+    const imported = parseMockCsv(csvContent);
+    return {
+      rows: imported.map((input, index) => ({
+        row: index + 2,
+        originalSymbol: input.symbol,
+        resolvedSymbol: input.symbol,
+        name: input.name,
+        assetType: input.assetType,
+        currency: input.currency,
+        exchange: '',
+        quantity: input.quantity,
+        costBasis: input.costBasis,
+        status: 'ready',
+      })),
+      readyCount: imported.length,
+      skipCount: 0,
+    };
+  }, []);
+
   const exportHoldingsCsv = useCallback(async (): Promise<string> => {
     if (isTauri()) {
       return tauriInvoke<string>('export_holdings_csv');
@@ -209,6 +235,7 @@ export function usePortfolio(): UsePortfolioReturn {
     updateHolding,
     deleteHolding,
     importHoldingsCsv,
+    previewImportCsv,
     exportHoldingsCsv,
   };
 }

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -105,6 +105,26 @@ export interface SymbolResult {
   exchange: string;
   currency: string;
 }
+
+export interface PreviewRow {
+  row: number;
+  originalSymbol: string;
+  resolvedSymbol: string;
+  name: string;
+  assetType: string;
+  currency: string;
+  exchange: string;
+  quantity: number;
+  costBasis: number;
+  /** "ready" | "cash" | "duplicate" | "invalid_symbol" | "validation_failed" */
+  status: string;
+}
+
+export interface PreviewImportResult {
+  rows: PreviewRow[];
+  readyCount: number;
+  skipCount: number;
+}
 // ── Tauri Command Signatures ──
 
 // invoke('get_portfolio')           → PortfolioSnapshot


### PR DESCRIPTION
## Summary
- **`SYMBOL:COUNTRY` parsing**: `BMO:CA` → `BMO.TO`, `AAPL:US` → `AAPL`, `BARC:GB` → `BARC.L`, etc. Supported country codes: CA, GB, AU, DE, FR, JP, HK (US/unknown → no suffix). Plain symbols (`AAPL`, `BMO.TO`) pass through unchanged.
- **`preview_import_csv` command**: validates each row via symbol cache / Yahoo Finance before inserting — returns resolved symbol, detected name/type/currency/exchange, and per-row status (`ready`, `cash`, `duplicate`, `invalid_symbol`, `validation_failed`)
- **Enriched preview UI**: file selection immediately triggers async validation and shows a rich table (original symbol → resolved, type badge, exchange, CCY, qty, cost, status). Import button shows `"Import N rows"` and stays disabled until at least one row is ready.
- **Human-readable error labels**: "Invalid symbol", "Duplicate", "Check failed" instead of raw codes in both preview and result tables.
- **Updated template**: includes `BMO:CA` example and a cash row.

## Test Plan
- [ ] `cargo test` — 30 tests pass (includes 3 new normalize/parse tests)
- [ ] `npm test` — 9 tests pass
- [ ] Upload a CSV with `BMO:CA` — preview shows `BMO.TO` in Resolved column
- [ ] Upload a CSV with `AAPL:US` — preview shows `AAPL` (no suffix)
- [ ] Upload a CSV with a plain `AAPL` — preview shows `AAPL` unchanged
- [ ] Upload a CSV with a cash row (type=cash, no symbol) — preview shows status "Cash" (green)
- [ ] Upload a CSV with a symbol already in portfolio — preview shows "Duplicate" (amber)
- [ ] Upload a CSV with a made-up symbol — preview shows "Invalid symbol" (red, dimmed row)
- [ ] Click Import — only ready rows are inserted; result table shows human-readable skip reasons

Closes #55