### PR TITLE
fix: keep portfolio views in sync after holdings changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { Performance } from './components/Performance';
 import { StressTest } from './components/StressTest';
 import { ToastProvider } from './components/ui/Toast';
 import { useToast } from './components/ui/Toast';
-import { usePortfolio } from './hooks/usePortfolio';
+import { PortfolioProvider, usePortfolio } from './hooks/usePortfolio';
 import { useConfig } from './hooks/useConfig';
 import { CurrencyContext } from './lib/currencyContext';
 import { formatCompact } from './lib/format';
@@ -90,9 +90,11 @@ function AppRoutes() {
 export default function App() {
   return (
     <ToastProvider>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
+      <PortfolioProvider>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </PortfolioProvider>
     </ToastProvider>
   );
 }

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -4,6 +4,7 @@ import App from '../App';
 
 // Mock Tauri — not available in jsdom
 vi.mock('../hooks/usePortfolio', () => ({
+  PortfolioProvider: ({ children }: { children: React.ReactNode }) => children,
   usePortfolio: () => ({
     portfolio: null,
     holdings: [],
@@ -13,6 +14,9 @@ vi.mock('../hooks/usePortfolio', () => ({
     addHolding: vi.fn(),
     updateHolding: vi.fn(),
     deleteHolding: vi.fn(),
+    importHoldingsCsv: vi.fn(),
+    previewImportCsv: vi.fn(),
+    exportHoldingsCsv: vi.fn(),
   }),
 }));
 

--- a/src/hooks/usePortfolio.ts
+++ b/src/hooks/usePortfolio.ts
@@ -1,4 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import {
+  createContext,
+  createElement,
+  useState,
+  useEffect,
+  useCallback,
+  useContext,
+  type ReactNode,
+} from 'react';
 import type {
   AccountType,
   Holding,
@@ -32,6 +40,8 @@ export interface UsePortfolioReturn {
   exportHoldingsCsv: () => Promise<string>;
 }
 
+const PortfolioContext = createContext<UsePortfolioReturn | null>(null);
+
 function parseMockCsv(csvContent: string): HoldingInput[] {
   const lines = csvContent
     .trim()
@@ -63,7 +73,7 @@ function parseMockCsv(csvContent: string): HoldingInput[] {
   });
 }
 
-export function usePortfolio(): UsePortfolioReturn {
+function usePortfolioState(): UsePortfolioReturn {
   const [portfolio, setPortfolio] = useState<PortfolioSnapshot | null>(null);
   const [holdings, setHoldings] = useState<Holding[]>([]);
   const [loading, setLoading] = useState(true);
@@ -238,4 +248,17 @@ export function usePortfolio(): UsePortfolioReturn {
     previewImportCsv,
     exportHoldingsCsv,
   };
+}
+
+export function PortfolioProvider({ children }: { children: ReactNode }) {
+  const value = usePortfolioState();
+  return createElement(PortfolioContext.Provider, { value }, children);
+}
+
+export function usePortfolio(): UsePortfolioReturn {
+  const context = useContext(PortfolioContext);
+  if (!context) {
+    throw new Error('usePortfolio must be used within a PortfolioProvider');
+  }
+  return context;
 }


### PR DESCRIPTION
## Summary
- move portfolio state into a shared provider so all routes consume the same live snapshot
- keep holdings mutations and refresh actions updating dashboard, performance, and stress views immediately
- extend the app test mock to support the provider-backed hook

Closes #43

## Verification
- npm run typecheck
- npm run test
- npm run build
- cargo test