### PR TITLE
feat: add target allocation and rebalance deltas

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -300,6 +300,8 @@ fn build_portfolio_snapshot(
             daily_pnl: 0.0,
             last_updated,
             base_currency: base_currency.to_string(),
+            total_target_weight: 0.0,
+            target_cash_delta: 0.0,
         };
     }
 
@@ -362,6 +364,7 @@ fn build_portfolio_snapshot(
             quantity: holding.quantity,
             cost_basis: holding.cost_basis,
             currency: holding.currency.clone(),
+            target_weight: holding.target_weight,
             created_at: holding.created_at.clone(),
             updated_at: holding.updated_at.clone(),
             current_price,
@@ -371,9 +374,15 @@ fn build_portfolio_snapshot(
             gain_loss,
             gain_loss_percent,
             weight: 0.0,
+            target_value: 0.0,
+            target_delta_value: 0.0,
+            target_delta_percent: 0.0,
             daily_change_percent: change_percent,
         });
     }
+
+    let total_target_weight: f64 = holdings.iter().map(|holding| holding.target_weight).sum();
+    let mut target_cash_delta = 0.0f64;
 
     for holding in &mut holdings_with_price {
         holding.weight = if total_value != 0.0 {
@@ -381,6 +390,13 @@ fn build_portfolio_snapshot(
         } else {
             0.0
         };
+        holding.target_value = total_value * (holding.target_weight / 100.0);
+        holding.target_delta_value = holding.target_value - holding.market_value_cad;
+        holding.target_delta_percent = holding.target_weight - holding.weight;
+
+        if holding.asset_type.as_str() == "cash" {
+            target_cash_delta += holding.market_value_cad - holding.target_value;
+        }
     }
 
     let total_gain_loss = total_value - total_cost;
@@ -399,6 +415,8 @@ fn build_portfolio_snapshot(
         daily_pnl,
         last_updated,
         base_currency: base_currency.to_string(),
+        total_target_weight,
+        target_cash_delta,
     }
 }
 #[tauri::command]
@@ -532,6 +550,7 @@ pub async fn import_holdings_csv(
                 quantity: row.quantity,
                 cost_basis: row.cost_basis,
                 currency: row.currency,
+                target_weight: 0.0,
             });
             continue;
         }
@@ -582,6 +601,7 @@ pub async fn import_holdings_csv(
             quantity: row.quantity,
             cost_basis: row.cost_basis,
             currency: row.currency,
+            target_weight: 0.0,
         });
     }
 
@@ -887,6 +907,7 @@ mod tests {
             quantity,
             cost_basis,
             currency: currency.to_string(),
+            target_weight: 0.0,
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
         }
@@ -997,6 +1018,7 @@ mod tests {
         assert!((snapshot.total_value - 1887.5).abs() < 0.001);
         assert!((snapshot.total_cost - 1625.0).abs() < 0.001);
         assert!((snapshot.daily_pnl - 92.75).abs() < 0.001);
+        assert_eq!(snapshot.total_target_weight, 0.0);
     }
 
     #[test]
@@ -1043,5 +1065,39 @@ mod tests {
         assert!((snapshot.holdings[1].market_value_cad - 220.0).abs() < 0.001);
         assert!((snapshot.total_value - 396.0).abs() < 0.001);
         assert!((snapshot.total_cost - 360.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_computes_target_deltas() {
+        let mut holdings = vec![
+            make_holding("AAPL", AssetType::Stock, 10.0, 100.0, "CAD"),
+            make_holding("CAD-CASH", AssetType::Cash, 500.0, 1.0, "CAD"),
+        ];
+        holdings[0].target_weight = 60.0;
+        holdings[1].target_weight = 10.0;
+
+        let prices = vec![PriceData {
+            symbol: "AAPL".to_string(),
+            price: 120.0,
+            currency: "CAD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &holdings,
+            &prices,
+            &[],
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+        );
+
+        assert!((snapshot.total_value - 1700.0).abs() < 0.001);
+        assert!((snapshot.total_target_weight - 70.0).abs() < 0.001);
+        assert!((snapshot.holdings[0].target_value - 1020.0).abs() < 0.001);
+        assert!((snapshot.holdings[0].target_delta_value + 180.0).abs() < 0.001);
+        assert!((snapshot.holdings[1].target_delta_value + 330.0).abs() < 0.001);
+        assert!((snapshot.target_cash_delta - 330.0).abs() < 0.001);
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -36,6 +36,7 @@ pub fn init_db(conn: &Connection) -> Result<(), String> {
             quantity    REAL NOT NULL,
             cost_basis  REAL NOT NULL,
             currency    TEXT NOT NULL,
+            target_weight REAL NOT NULL DEFAULT 0,
             created_at  TEXT NOT NULL,
             updated_at  TEXT NOT NULL
         );
@@ -80,6 +81,14 @@ pub fn init_db(conn: &Connection) -> Result<(), String> {
         .map_err(|e| e.to_string())?;
     }
 
+    if !table_has_column(conn, "holdings", "target_weight")? {
+        conn.execute(
+            "ALTER TABLE holdings ADD COLUMN target_weight REAL NOT NULL DEFAULT 0",
+            [],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
     conn.execute(
         "UPDATE holdings SET account='cash' WHERE asset_type='cash' AND account='taxable'",
         [],
@@ -117,8 +126,8 @@ pub fn insert_holding(conn: &Connection, input: HoldingInput) -> Result<Holding,
     let asset_type_str = input.asset_type.as_str();
 
     conn.execute(
-        "INSERT INTO holdings (id, symbol, name, asset_type, account, quantity, cost_basis, currency, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        "INSERT INTO holdings (id, symbol, name, asset_type, account, quantity, cost_basis, currency, target_weight, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
         params![
             id,
             input.symbol,
@@ -128,6 +137,7 @@ pub fn insert_holding(conn: &Connection, input: HoldingInput) -> Result<Holding,
             input.quantity,
             input.cost_basis,
             input.currency,
+            input.target_weight,
             now,
             now
         ],
@@ -143,6 +153,7 @@ pub fn insert_holding(conn: &Connection, input: HoldingInput) -> Result<Holding,
         quantity: input.quantity,
         cost_basis: input.cost_basis,
         currency: input.currency,
+        target_weight: input.target_weight,
         created_at: now.clone(),
         updated_at: now,
     })
@@ -154,8 +165,8 @@ pub fn update_holding(conn: &Connection, holding: Holding) -> Result<Holding, St
 
     let rows = conn
         .execute(
-            "UPDATE holdings SET symbol=?1, name=?2, asset_type=?3, account=?4, quantity=?5, cost_basis=?6, currency=?7, updated_at=?8
-             WHERE id=?9",
+            "UPDATE holdings SET symbol=?1, name=?2, asset_type=?3, account=?4, quantity=?5, cost_basis=?6, currency=?7, target_weight=?8, updated_at=?9
+             WHERE id=?10",
             params![
                 holding.symbol,
                 holding.name,
@@ -164,6 +175,7 @@ pub fn update_holding(conn: &Connection, holding: Holding) -> Result<Holding, St
                 holding.quantity,
                 holding.cost_basis,
                 holding.currency,
+                holding.target_weight,
                 now,
                 holding.id
             ],
@@ -190,7 +202,7 @@ pub fn delete_holding(conn: &Connection, id: &str) -> Result<bool, String> {
 pub fn get_all_holdings(conn: &Connection) -> Result<Vec<Holding>, String> {
     let mut stmt = conn
         .prepare(
-            "SELECT id, symbol, name, asset_type, account, quantity, cost_basis, currency, created_at, updated_at
+            "SELECT id, symbol, name, asset_type, account, quantity, cost_basis, currency, target_weight, created_at, updated_at
              FROM holdings ORDER BY created_at ASC",
         )
         .map_err(|e| e.to_string())?;
@@ -207,8 +219,9 @@ pub fn get_all_holdings(conn: &Connection) -> Result<Vec<Holding>, String> {
                 row.get::<_, f64>(5)?,
                 row.get::<_, f64>(6)?,
                 row.get::<_, String>(7)?,
-                row.get::<_, String>(8)?,
+                row.get::<_, f64>(8)?,
                 row.get::<_, String>(9)?,
+                row.get::<_, String>(10)?,
             ))
         })
         .map_err(|e| e.to_string())?
@@ -223,6 +236,7 @@ pub fn get_all_holdings(conn: &Connection) -> Result<Vec<Holding>, String> {
                 quantity,
                 cost_basis,
                 currency,
+                target_weight,
                 created_at,
                 updated_at,
             )| {
@@ -237,6 +251,7 @@ pub fn get_all_holdings(conn: &Connection) -> Result<Vec<Holding>, String> {
                     quantity,
                     cost_basis,
                     currency,
+                    target_weight,
                     created_at,
                     updated_at,
                 }
@@ -442,6 +457,7 @@ mod tests {
             quantity: 10.0,
             cost_basis: 100.0,
             currency: "CAD".to_string(),
+            target_weight: 0.0,
         }
     }
 
@@ -474,11 +490,13 @@ mod tests {
         let updated_holding = Holding {
             quantity: 20.0,
             cost_basis: 150.0,
+            target_weight: 12.5,
             ..inserted
         };
         let updated = update_holding(&conn, updated_holding).expect("update");
         assert!((updated.quantity - 20.0).abs() < 0.001);
         assert!((updated.cost_basis - 150.0).abs() < 0.001);
+        assert!((updated.target_weight - 12.5).abs() < 0.001);
     }
 
     #[test]

--- a/src-tauri/src/stress.rs
+++ b/src-tauri/src/stress.rs
@@ -98,6 +98,7 @@ mod tests {
             quantity: 1.0,
             cost_basis: value,
             currency: currency.to_string(),
+            target_weight: 0.0,
             created_at: "2024-01-01T00:00:00Z".to_string(),
             updated_at: "2024-01-01T00:00:00Z".to_string(),
             current_price: value,
@@ -107,6 +108,9 @@ mod tests {
             gain_loss: 0.0,
             gain_loss_percent: 0.0,
             weight: 1.0,
+            target_value: 0.0,
+            target_delta_value: 0.0,
+            target_delta_percent: 0.0,
             daily_change_percent: 0.0,
         }
     }
@@ -122,6 +126,8 @@ mod tests {
             daily_pnl: 0.0,
             last_updated: "2024-01-01T00:00:00Z".to_string(),
             base_currency: "CAD".to_string(),
+            total_target_weight: 0.0,
+            target_cash_delta: 0.0,
         }
     }
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -80,6 +80,7 @@ pub struct Holding {
     pub quantity: f64,
     pub cost_basis: f64,
     pub currency: String,
+    pub target_weight: f64,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -94,6 +95,7 @@ pub struct HoldingInput {
     pub quantity: f64,
     pub cost_basis: f64,
     pub currency: String,
+    pub target_weight: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +128,7 @@ pub struct HoldingWithPrice {
     pub quantity: f64,
     pub cost_basis: f64,
     pub currency: String,
+    pub target_weight: f64,
     pub created_at: String,
     pub updated_at: String,
     pub current_price: f64,
@@ -135,6 +138,9 @@ pub struct HoldingWithPrice {
     pub gain_loss: f64,
     pub gain_loss_percent: f64,
     pub weight: f64,
+    pub target_value: f64,
+    pub target_delta_value: f64,
+    pub target_delta_percent: f64,
     pub daily_change_percent: f64,
 }
 
@@ -150,6 +156,8 @@ pub struct PortfolioSnapshot {
     pub last_updated: String,
     /// The currency all values are expressed in (user-configurable, default "CAD").
     pub base_currency: String,
+    pub total_target_weight: f64,
+    pub target_cash_delta: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/AddHoldingModal.tsx
+++ b/src/components/AddHoldingModal.tsx
@@ -52,6 +52,7 @@ interface FormState {
   quantity: string;
   costBasis: string;
   currency: string;
+  targetWeight: string;
 }
 
 interface FormErrors {
@@ -59,6 +60,7 @@ interface FormErrors {
   name?: string;
   quantity?: string;
   costBasis?: string;
+  targetWeight?: string;
 }
 
 const EMPTY_FORM: FormState = {
@@ -69,6 +71,7 @@ const EMPTY_FORM: FormState = {
   quantity: '',
   costBasis: '',
   currency: 'USD',
+  targetWeight: '0',
 };
 
 const INPUT_STYLE: React.CSSProperties = {
@@ -136,6 +139,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
           quantity: String(editingHolding.quantity),
           costBasis: String(editingHolding.costBasis),
           currency: editingHolding.currency,
+          targetWeight: String(editingHolding.targetWeight ?? 0),
         });
       } else {
         setForm(EMPTY_FORM);
@@ -189,6 +193,10 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
     if (isNaN(qty) || qty <= 0) next.quantity = 'Quantity must be > 0';
     const cost = parseFloat(form.costBasis);
     if (isNaN(cost) || cost <= 0) next.costBasis = 'Cost basis must be > 0';
+    const targetWeight = parseFloat(form.targetWeight);
+    if (isNaN(targetWeight) || targetWeight < 0 || targetWeight > 100) {
+      next.targetWeight = 'Target weight must be between 0 and 100';
+    }
     setErrors(next);
     return Object.keys(next).length === 0;
   }
@@ -205,6 +213,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
         quantity: parseFloat(form.quantity),
         costBasis: parseFloat(form.costBasis),
         currency: form.currency,
+        targetWeight: parseFloat(form.targetWeight),
       };
       await onSave(input);
       onClose();
@@ -243,7 +252,9 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
     (isCash || form.symbol.trim()) &&
     form.name.trim() &&
     parseFloat(form.quantity) > 0 &&
-    parseFloat(form.costBasis) > 0;
+    parseFloat(form.costBasis) > 0 &&
+    parseFloat(form.targetWeight) >= 0 &&
+    parseFloat(form.targetWeight) <= 100;
 
   return (
     <div
@@ -348,7 +359,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
           </Field>
 
           {/* Qty + Cost row */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
             <Field label={isCash ? 'Amount' : 'Quantity'} error={errors.quantity}>
               <input
                 type="number"
@@ -395,6 +406,20 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
                 />
               </Field>
             )}
+            <Field label="Target Weight %" error={errors.targetWeight}>
+              <input
+                type="number"
+                value={form.targetWeight}
+                onChange={set('targetWeight')}
+                placeholder="0.0"
+                min="0"
+                max="100"
+                step="0.1"
+                style={INPUT_STYLE}
+                onFocus={(e) => (e.target.style.borderColor = 'var(--color-accent)')}
+                onBlur={(e) => (e.target.style.borderColor = 'var(--border-primary)')}
+              />
+            </Field>
           </div>
         </div>
 

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -24,6 +24,9 @@ type SortKey = keyof Pick<
   | 'gainLoss'
   | 'gainLossPercent'
   | 'weight'
+  | 'targetWeight'
+  | 'targetDeltaPercent'
+  | 'targetDeltaValue'
 >;
 
 interface SortState {
@@ -85,9 +88,12 @@ export function Holdings() {
       { key: 'costBasis', label: 'Cost Basis', align: 'right' },
       { key: 'currentPrice', label: 'Price', align: 'right' },
       { key: 'marketValueCad', label: `Mkt Value (${baseCurrency})`, align: 'right' },
+      { key: 'weight', label: 'Current %', align: 'right' },
+      { key: 'targetWeight', label: 'Target %', align: 'right' },
+      { key: 'targetDeltaPercent', label: 'Delta %', align: 'right' },
+      { key: 'targetDeltaValue', label: `Rebalance (${baseCurrency})`, align: 'right' },
       { key: 'gainLoss', label: `Gain/Loss (${baseCurrency})`, align: 'right' },
       { key: 'gainLossPercent', label: 'G/L %', align: 'right' },
-      { key: 'weight', label: 'Weight', align: 'right' },
     ],
     [baseCurrency]
   );
@@ -181,6 +187,8 @@ export function Holdings() {
     () => ({
       marketValueCad: rows.reduce((s, r) => s + r.marketValueCad, 0),
       gainLoss: rows.reduce((s, r) => s + r.gainLoss, 0),
+      targetWeight: rows.reduce((s, r) => s + r.targetWeight, 0),
+      targetDeltaValue: rows.reduce((s, r) => s + r.targetDeltaValue, 0),
       gainLossPercent: portfolio
         ? (rows.reduce((s, r) => s + r.gainLoss, 0) /
             Math.max(
@@ -192,6 +200,28 @@ export function Holdings() {
     }),
     [rows, portfolio]
   );
+
+  const rebalanceSummary = useMemo(() => {
+    if (!portfolio) return null;
+    const buys = rows
+      .filter((row) => row.targetDeltaValue > 0.01)
+      .reduce((sum, row) => sum + row.targetDeltaValue, 0);
+    const sells = rows
+      .filter((row) => row.targetDeltaValue < -0.01)
+      .reduce((sum, row) => sum + Math.abs(row.targetDeltaValue), 0);
+    return {
+      totalTargetWeight: rows.reduce((sum, row) => sum + row.targetWeight, 0),
+      unassignedTargetWeight: Math.max(
+        0,
+        100 - rows.reduce((sum, row) => sum + row.targetWeight, 0)
+      ),
+      deployableCash: rows
+        .filter((row) => row.assetType === 'cash')
+        .reduce((sum, row) => sum + Math.max(0, -row.targetDeltaValue), 0),
+      suggestedBuys: buys,
+      suggestedSells: sells,
+    };
+  }, [portfolio, rows]);
 
   const isEmpty = holdings.length === 0;
 
@@ -339,320 +369,477 @@ export function Holdings() {
           action={{ label: '+ Add Holding', onClick: () => setModalOpen(true) }}
         />
       ) : (
-        <div
-          style={{
-            border: '1px solid var(--border-primary)',
-            overflow: 'auto',
-            maxHeight: 'calc(100vh - 200px)',
-          }}
-        >
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
-            <thead style={{ position: 'sticky', top: 0, zIndex: 2 }}>
-              <tr>
-                {columns.map(({ key, label, align }) => (
-                  <th key={key} onClick={() => toggleSort(key)} style={{ ...TH, textAlign: align }}>
-                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-                      {label}
-                      {sort.key === key ? (
-                        sort.dir === 'asc' ? (
-                          <ChevronUp size={10} />
-                        ) : (
-                          <ChevronDown size={10} />
-                        )
-                      ) : null}
-                    </span>
-                  </th>
-                ))}
-                <th style={{ ...TH, textAlign: 'center' }}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((h, i) => {
-                const isDeleting = deletingId === h.id;
-                const isPending = pendingDelete === h.id;
-                const bg = i % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
-                return (
-                  <tr
-                    key={h.id}
+        <>
+          {rebalanceSummary && (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+                gap: 1,
+                background: 'var(--border-primary)',
+                border: '1px solid var(--border-primary)',
+                marginBottom: 12,
+              }}
+            >
+              {[
+                {
+                  label: 'Assigned Target',
+                  value: `${rebalanceSummary.totalTargetWeight.toFixed(1)}%`,
+                  tone: 'var(--text-primary)',
+                },
+                {
+                  label: 'Unassigned Target',
+                  value: `${rebalanceSummary.unassignedTargetWeight.toFixed(1)}%`,
+                  tone: 'var(--text-secondary)',
+                },
+                {
+                  label: 'Deployable Cash',
+                  value: formatCurrency(rebalanceSummary.deployableCash, baseCurrency),
+                  tone: 'var(--color-accent)',
+                },
+                {
+                  label: 'Suggested Net Buys',
+                  value: formatCurrency(rebalanceSummary.suggestedBuys, baseCurrency),
+                  tone: 'var(--color-gain)',
+                },
+              ].map((item) => (
+                <div
+                  key={item.label}
+                  style={{
+                    background: 'var(--bg-surface)',
+                    padding: '12px 14px',
+                  }}
+                >
+                  <div
                     style={{
-                      background: isPending
-                        ? 'rgba(255,71,87,0.08)'
-                        : isDeleting
-                          ? 'rgba(255,71,87,0.15)'
-                          : bg,
-                      transition: 'background 200ms',
-                    }}
-                    onMouseEnter={(e) => {
-                      if (!isPending && !isDeleting)
-                        (e.currentTarget as HTMLElement).style.background =
-                          'var(--bg-surface-hover)';
-                    }}
-                    onMouseLeave={(e) => {
-                      if (!isPending && !isDeleting)
-                        (e.currentTarget as HTMLElement).style.background = bg;
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 10,
+                      color: 'var(--text-muted)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.08em',
+                      marginBottom: 6,
                     }}
                   >
-                    <td
+                    {item.label}
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 15,
+                      fontWeight: 700,
+                      color: item.tone,
+                    }}
+                  >
+                    {item.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div
+            style={{
+              border: '1px solid var(--border-primary)',
+              overflow: 'auto',
+              maxHeight: 'calc(100vh - 260px)',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+              <thead style={{ position: 'sticky', top: 0, zIndex: 2 }}>
+                <tr>
+                  {columns.map(({ key, label, align }) => (
+                    <th
+                      key={key}
+                      onClick={() => toggleSort(key)}
+                      style={{ ...TH, textAlign: align }}
+                    >
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                        {label}
+                        {sort.key === key ? (
+                          sort.dir === 'asc' ? (
+                            <ChevronUp size={10} />
+                          ) : (
+                            <ChevronDown size={10} />
+                          )
+                        ) : null}
+                      </span>
+                    </th>
+                  ))}
+                  <th style={{ ...TH, textAlign: 'center' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((h, i) => {
+                  const isDeleting = deletingId === h.id;
+                  const isPending = pendingDelete === h.id;
+                  const bg = i % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
+                  return (
+                    <tr
+                      key={h.id}
                       style={{
-                        ...TD,
-                        fontFamily: 'var(--font-mono)',
-                        fontWeight: 700,
-                        color: 'var(--text-primary)',
+                        background: isPending
+                          ? 'rgba(255,71,87,0.08)'
+                          : isDeleting
+                            ? 'rgba(255,71,87,0.15)'
+                            : bg,
+                        transition: 'background 200ms',
+                      }}
+                      onMouseEnter={(e) => {
+                        if (!isPending && !isDeleting)
+                          (e.currentTarget as HTMLElement).style.background =
+                            'var(--bg-surface-hover)';
+                      }}
+                      onMouseLeave={(e) => {
+                        if (!isPending && !isDeleting)
+                          (e.currentTarget as HTMLElement).style.background = bg;
                       }}
                     >
-                      {h.symbol}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        color: 'var(--text-secondary)',
-                        maxWidth: 160,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      }}
-                    >
-                      {h.name}
-                    </td>
-                    <td style={TD}>
-                      <Badge type={h.assetType} />
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        color: 'var(--text-secondary)',
-                        fontFamily: 'var(--font-mono)',
-                        textTransform: 'uppercase',
-                      }}
-                    >
-                      {ACCOUNT_OPTIONS.find((option) => option.value === h.account)?.label ??
-                        h.account}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-secondary)',
-                      }}
-                    >
-                      {formatNumber(h.quantity, h.assetType === 'crypto' ? 4 : 2)}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-secondary)',
-                      }}
-                    >
-                      {formatNumber(h.costBasis, 2)} {h.currency}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-primary)',
-                      }}
-                    >
-                      {h.assetType === 'cash'
-                        ? '—'
-                        : `${formatNumber(h.currentPrice, 2)} ${h.currency}`}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-primary)',
-                        fontWeight: 600,
-                      }}
-                    >
-                      {formatCurrency(h.marketValueCad, baseCurrency)}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: h.assetType === 'cash' ? 'var(--text-muted)' : pnlColor(h.gainLoss),
-                      }}
-                    >
-                      {h.assetType === 'cash'
-                        ? '—'
-                        : `${h.gainLoss >= 0 ? '+' : ''}${formatCurrency(h.gainLoss, baseCurrency)}`}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color:
-                          h.assetType === 'cash'
-                            ? 'var(--text-muted)'
-                            : pnlColor(h.gainLossPercent),
-                      }}
-                    >
-                      {h.assetType === 'cash' ? '—' : formatPercent(h.gainLossPercent)}
-                    </td>
-                    <td
-                      style={{
-                        ...TD,
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-secondary)',
-                      }}
-                    >
-                      {h.weight.toFixed(1)}%
-                    </td>
-                    <td style={{ ...TD, textAlign: 'center', borderRight: 'none' }}>
-                      {isPending ? (
-                        <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
-                          <span
-                            style={{
-                              fontSize: 11,
-                              color: 'var(--color-loss)',
-                              fontFamily: 'var(--font-mono)',
-                            }}
-                          >
-                            Delete?
+                      <td
+                        style={{
+                          ...TD,
+                          fontFamily: 'var(--font-mono)',
+                          fontWeight: 700,
+                          color: 'var(--text-primary)',
+                        }}
+                      >
+                        {h.symbol}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          color: 'var(--text-secondary)',
+                          maxWidth: 160,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {h.name}
+                      </td>
+                      <td style={TD}>
+                        <Badge type={h.assetType} />
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          color: 'var(--text-secondary)',
+                          fontFamily: 'var(--font-mono)',
+                          textTransform: 'uppercase',
+                        }}
+                      >
+                        {ACCOUNT_OPTIONS.find((option) => option.value === h.account)?.label ??
+                          h.account}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {formatNumber(h.quantity, h.assetType === 'crypto' ? 4 : 2)}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {formatNumber(h.costBasis, 2)} {h.currency}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-primary)',
+                        }}
+                      >
+                        {h.assetType === 'cash'
+                          ? '—'
+                          : `${formatNumber(h.currentPrice, 2)} ${h.currency}`}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-primary)',
+                          fontWeight: 600,
+                        }}
+                      >
+                        {formatCurrency(h.marketValueCad, baseCurrency)}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-secondary)',
+                        }}
+                      >
+                        {h.weight.toFixed(1)}%
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: h.targetWeight > 0 ? 'var(--text-primary)' : 'var(--text-muted)',
+                        }}
+                      >
+                        {h.targetWeight > 0 ? `${h.targetWeight.toFixed(1)}%` : '—'}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: pnlColor(h.targetDeltaPercent),
+                        }}
+                      >
+                        {h.targetWeight > 0 || h.assetType === 'cash'
+                          ? formatPercent(h.targetDeltaPercent)
+                          : '—'}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: pnlColor(h.targetDeltaValue),
+                          fontWeight: 600,
+                        }}
+                      >
+                        {h.targetWeight > 0 || h.assetType === 'cash'
+                          ? `${h.targetDeltaValue >= 0 ? '+' : ''}${formatCurrency(h.targetDeltaValue, baseCurrency)}`
+                          : '—'}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color:
+                            h.assetType === 'cash' ? 'var(--text-muted)' : pnlColor(h.gainLoss),
+                        }}
+                      >
+                        {h.assetType === 'cash'
+                          ? '—'
+                          : `${h.gainLoss >= 0 ? '+' : ''}${formatCurrency(h.gainLoss, baseCurrency)}`}
+                      </td>
+                      <td
+                        style={{
+                          ...TD,
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color:
+                            h.assetType === 'cash'
+                              ? 'var(--text-muted)'
+                              : pnlColor(h.gainLossPercent),
+                        }}
+                      >
+                        {h.assetType === 'cash' ? '—' : formatPercent(h.gainLossPercent)}
+                      </td>
+                      <td style={{ ...TD, textAlign: 'center', borderRight: 'none' }}>
+                        {isPending ? (
+                          <span style={{ display: 'inline-flex', gap: 6, alignItems: 'center' }}>
+                            <span
+                              style={{
+                                fontSize: 11,
+                                color: 'var(--color-loss)',
+                                fontFamily: 'var(--font-mono)',
+                              }}
+                            >
+                              Delete?
+                            </span>
+                            <button
+                              onClick={() => handleDelete(h.id)}
+                              style={{
+                                fontSize: 11,
+                                color: 'var(--color-loss)',
+                                background: 'none',
+                                border: '1px solid var(--color-loss)',
+                                padding: '2px 6px',
+                                borderRadius: '2px',
+                                cursor: 'pointer',
+                                fontFamily: 'var(--font-mono)',
+                              }}
+                            >
+                              Confirm
+                            </button>
+                            <button
+                              onClick={() => setPendingDelete(null)}
+                              style={{
+                                fontSize: 11,
+                                color: 'var(--text-secondary)',
+                                background: 'none',
+                                border: '1px solid var(--border-primary)',
+                                padding: '2px 6px',
+                                borderRadius: '2px',
+                                cursor: 'pointer',
+                                fontFamily: 'var(--font-mono)',
+                              }}
+                            >
+                              Cancel
+                            </button>
                           </span>
-                          <button
-                            onClick={() => handleDelete(h.id)}
-                            style={{
-                              fontSize: 11,
-                              color: 'var(--color-loss)',
-                              background: 'none',
-                              border: '1px solid var(--color-loss)',
-                              padding: '2px 6px',
-                              borderRadius: '2px',
-                              cursor: 'pointer',
-                              fontFamily: 'var(--font-mono)',
-                            }}
-                          >
-                            Confirm
-                          </button>
-                          <button
-                            onClick={() => setPendingDelete(null)}
-                            style={{
-                              fontSize: 11,
-                              color: 'var(--text-secondary)',
-                              background: 'none',
-                              border: '1px solid var(--border-primary)',
-                              padding: '2px 6px',
-                              borderRadius: '2px',
-                              cursor: 'pointer',
-                              fontFamily: 'var(--font-mono)',
-                            }}
-                          >
-                            Cancel
-                          </button>
-                        </span>
-                      ) : (
-                        <span style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
-                          <button
-                            onClick={() => {
-                              setEditing(h);
-                              setModalOpen(true);
-                            }}
-                            title="Edit"
-                            style={{
-                              background: 'none',
-                              border: 'none',
-                              color: 'var(--text-muted)',
-                              cursor: 'pointer',
-                              padding: 3,
-                              display: 'flex',
-                              alignItems: 'center',
-                            }}
-                          >
-                            <Pencil size={13} />
-                          </button>
-                          <button
-                            onClick={() => setPendingDelete(h.id)}
-                            title="Delete"
-                            style={{
-                              background: 'none',
-                              border: 'none',
-                              color: 'var(--text-muted)',
-                              cursor: 'pointer',
-                              padding: 3,
-                              display: 'flex',
-                              alignItems: 'center',
-                            }}
-                          >
-                            <Trash2 size={13} />
-                          </button>
-                        </span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-            <tfoot style={{ position: 'sticky', bottom: 0 }}>
-              <tr
-                style={{
-                  background: 'var(--bg-surface-alt)',
-                  borderTop: '2px solid var(--border-primary)',
-                }}
-              >
-                <td
-                  colSpan={7}
+                        ) : (
+                          <span style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+                            <button
+                              onClick={() => {
+                                setEditing(h);
+                                setModalOpen(true);
+                              }}
+                              title="Edit"
+                              style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'var(--text-muted)',
+                                cursor: 'pointer',
+                                padding: 3,
+                                display: 'flex',
+                                alignItems: 'center',
+                              }}
+                            >
+                              <Pencil size={13} />
+                            </button>
+                            <button
+                              onClick={() => setPendingDelete(h.id)}
+                              title="Delete"
+                              style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'var(--text-muted)',
+                                cursor: 'pointer',
+                                padding: 3,
+                                display: 'flex',
+                                alignItems: 'center',
+                              }}
+                            >
+                              <Trash2 size={13} />
+                            </button>
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot style={{ position: 'sticky', bottom: 0 }}>
+                <tr
                   style={{
-                    ...TD,
-                    fontFamily: 'var(--font-mono)',
-                    fontWeight: 700,
-                    color: 'var(--text-secondary)',
-                    fontSize: 10,
-                    textTransform: 'uppercase',
-                    letterSpacing: '0.06em',
+                    background: 'var(--bg-surface-alt)',
+                    borderTop: '2px solid var(--border-primary)',
                   }}
                 >
-                  Total ({rows.length} positions)
-                </td>
-                <td
-                  style={{
-                    ...TD,
-                    textAlign: 'right',
-                    fontFamily: 'var(--font-mono)',
-                    fontWeight: 700,
-                    color: 'var(--text-primary)',
-                    fontSize: 13,
-                  }}
-                >
-                  {formatCurrency(totals.marketValueCad, baseCurrency)}
-                </td>
-                <td
-                  style={{
-                    ...TD,
-                    textAlign: 'right',
-                    fontFamily: 'var(--font-mono)',
-                    fontWeight: 700,
-                    color: pnlColor(totals.gainLoss),
-                    fontSize: 13,
-                  }}
-                >
-                  {totals.gainLoss >= 0 ? '+' : ''}
-                  {formatCurrency(totals.gainLoss, baseCurrency)}
-                </td>
-                <td
-                  style={{
-                    ...TD,
-                    textAlign: 'right',
-                    fontFamily: 'var(--font-mono)',
-                    fontWeight: 700,
-                    color: pnlColor(totals.gainLossPercent),
-                    fontSize: 13,
-                  }}
-                >
-                  {formatPercent(totals.gainLossPercent)}
-                </td>
-                <td colSpan={2} style={TD} />
-              </tr>
-            </tfoot>
-          </table>
-        </div>
+                  <td
+                    colSpan={7}
+                    style={{
+                      ...TD,
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: 'var(--text-secondary)',
+                      fontSize: 10,
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                    }}
+                  >
+                    Total ({rows.length} positions)
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: 'var(--text-primary)',
+                      fontSize: 13,
+                    }}
+                  >
+                    {formatCurrency(totals.marketValueCad, baseCurrency)}
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: 'var(--text-secondary)',
+                      fontSize: 13,
+                    }}
+                  >
+                    100.0%
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: totals.targetWeight > 0 ? 'var(--text-primary)' : 'var(--text-muted)',
+                      fontSize: 13,
+                    }}
+                  >
+                    {totals.targetWeight > 0 ? `${totals.targetWeight.toFixed(1)}%` : '—'}
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: pnlColor(100 - totals.targetWeight),
+                      fontSize: 13,
+                    }}
+                  >
+                    {formatPercent(totals.targetWeight - 100)}
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: pnlColor(totals.targetDeltaValue),
+                      fontSize: 13,
+                    }}
+                  >
+                    {totals.targetDeltaValue >= 0 ? '+' : ''}
+                    {formatCurrency(totals.targetDeltaValue, baseCurrency)}
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: pnlColor(totals.gainLoss),
+                      fontSize: 13,
+                    }}
+                  >
+                    {totals.gainLoss >= 0 ? '+' : ''}
+                    {formatCurrency(totals.gainLoss, baseCurrency)}
+                  </td>
+                  <td
+                    style={{
+                      ...TD,
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 700,
+                      color: pnlColor(totals.gainLossPercent),
+                      fontSize: 13,
+                    }}
+                  >
+                    {formatPercent(totals.gainLossPercent)}
+                  </td>
+                  <td colSpan={2} style={TD} />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </>
       )}
 
       <AddHoldingModal

--- a/src/hooks/usePortfolio.ts
+++ b/src/hooks/usePortfolio.ts
@@ -69,6 +69,7 @@ function parseMockCsv(csvContent: string): HoldingInput[] {
       quantity: Number(cells[columnIndex('quantity')]),
       costBasis: Number(cells[columnIndex('cost_basis')]),
       currency,
+      targetWeight: 0,
     };
   });
 }

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -3,7 +3,12 @@ import type { Holding, HoldingWithPrice, PortfolioSnapshot } from '../types/port
 const USD_CAD = 1.36;
 const EUR_CAD = 1.47;
 
-const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }> = [
+type MockHolding = Omit<
+  HoldingWithPrice,
+  'weight' | 'targetValue' | 'targetDeltaValue' | 'targetDeltaPercent'
+>;
+
+const RAW_HOLDINGS: MockHolding[] = [
   // Stocks
   {
     id: '1',
@@ -21,7 +26,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 50 * (189.84 - 155.0) * USD_CAD,
     gainLossPercent: ((189.84 - 155.0) / 155.0) * 100,
     dailyChangePercent: 1.24,
-    weight: 0,
+    targetWeight: 12,
     createdAt: '2023-01-15T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -41,7 +46,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 30 * (415.52 - 310.0) * USD_CAD,
     gainLossPercent: ((415.52 - 310.0) / 310.0) * 100,
     dailyChangePercent: -0.83,
-    weight: 0,
+    targetWeight: 10,
     createdAt: '2023-02-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -61,7 +66,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 25 * (875.4 - 420.0) * USD_CAD,
     gainLossPercent: ((875.4 - 420.0) / 420.0) * 100,
     dailyChangePercent: 3.47,
-    weight: 0,
+    targetWeight: 8,
     createdAt: '2023-03-10T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -81,7 +86,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 150 * (81.24 - 85.0),
     gainLossPercent: ((81.24 - 85.0) / 85.0) * 100,
     dailyChangePercent: -0.42,
-    weight: 0,
+    targetWeight: 8,
     createdAt: '2022-11-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -101,7 +106,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 80 * (135.88 - 120.0),
     gainLossPercent: ((135.88 - 120.0) / 120.0) * 100,
     dailyChangePercent: 0.61,
-    weight: 0,
+    targetWeight: 8,
     createdAt: '2022-12-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -122,7 +127,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 40 * (481.55 - 380.0) * USD_CAD,
     gainLossPercent: ((481.55 - 380.0) / 380.0) * 100,
     dailyChangePercent: 0.95,
-    weight: 0,
+    targetWeight: 14,
     createdAt: '2022-06-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -142,7 +147,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 200 * (112.4 - 88.0),
     gainLossPercent: ((112.4 - 88.0) / 88.0) * 100,
     dailyChangePercent: 1.02,
-    weight: 0,
+    targetWeight: 12,
     createdAt: '2022-07-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -163,7 +168,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 0.85 * (87450.0 - 42000.0),
     gainLossPercent: ((87450.0 - 42000.0) / 42000.0) * 100,
     dailyChangePercent: 4.82,
-    weight: 0,
+    targetWeight: 6,
     createdAt: '2023-01-20T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -183,7 +188,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 5.0 * (4380.0 - 2200.0),
     gainLossPercent: ((4380.0 - 2200.0) / 2200.0) * 100,
     dailyChangePercent: -2.14,
-    weight: 0,
+    targetWeight: 4,
     createdAt: '2023-02-10T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -204,7 +209,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 0,
     gainLossPercent: 0,
     dailyChangePercent: 0,
-    weight: 0,
+    targetWeight: 6,
     createdAt: '2023-06-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -224,7 +229,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 0,
     gainLossPercent: 0,
     dailyChangePercent: 0,
-    weight: 0,
+    targetWeight: 2,
     createdAt: '2023-06-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -244,7 +249,7 @@ const RAW_HOLDINGS: Array<Omit<HoldingWithPrice, 'weight'> & { weight: number }>
     gainLoss: 0,
     gainLossPercent: 0,
     dailyChangePercent: 0,
-    weight: 0,
+    targetWeight: 10,
     createdAt: '2023-06-01T10:00:00Z',
     updatedAt: '2024-01-15T10:00:00Z',
   },
@@ -257,6 +262,9 @@ function buildSnapshot(): PortfolioSnapshot {
   const holdings: HoldingWithPrice[] = RAW_HOLDINGS.map((h) => ({
     ...h,
     weight: (h.marketValueCad / totalValue) * 100,
+    targetValue: totalValue * (h.targetWeight / 100),
+    targetDeltaValue: totalValue * (h.targetWeight / 100) - h.marketValueCad,
+    targetDeltaPercent: h.targetWeight - (h.marketValueCad / totalValue) * 100,
   }));
 
   const totalGainLoss = totalValue - totalCost;
@@ -276,6 +284,10 @@ function buildSnapshot(): PortfolioSnapshot {
     dailyPnl,
     lastUpdated: new Date().toISOString(),
     baseCurrency: 'CAD',
+    totalTargetWeight: holdings.reduce((sum, h) => sum + h.targetWeight, 0),
+    targetCashDelta: holdings
+      .filter((holding) => holding.assetType === 'cash')
+      .reduce((sum, holding) => sum + (holding.marketValueCad - holding.targetValue), 0),
   };
 }
 
@@ -289,8 +301,7 @@ export const MOCK_HOLDINGS: Holding[] = RAW_HOLDINGS.map(
     costValueCad: _4,
     gainLoss: _5,
     gainLossPercent: _6,
-    weight: _7,
-    dailyChangePercent: _8,
+    dailyChangePercent: _7,
     ...h
   }) => h
 );

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -9,6 +9,7 @@ export interface HoldingInput {
   quantity: number;
   costBasis: number;
   currency: string;
+  targetWeight: number;
 }
 
 export interface Holding {
@@ -20,6 +21,7 @@ export interface Holding {
   quantity: number;
   costBasis: number; // per unit, in original currency
   currency: string; // ISO currency code
+  targetWeight: number; // desired % of total portfolio value
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
 }
@@ -32,6 +34,9 @@ export interface HoldingWithPrice extends Holding {
   gainLoss: number; // marketValueCad - costValueCad
   gainLossPercent: number; // gainLoss / costValueCad
   weight: number; // marketValueCad / totalPortfolioValue
+  targetValue: number; // desired value in base currency
+  targetDeltaValue: number; // targetValue - marketValueCad
+  targetDeltaPercent: number; // targetWeight - weight
   dailyChangePercent: number;
 }
 
@@ -45,6 +50,8 @@ export interface PortfolioSnapshot {
   lastUpdated: string; // ISO 8601
   /** The currency all values are expressed in. Defaults to "CAD". */
   baseCurrency: string;
+  totalTargetWeight: number;
+  targetCashDelta: number;
 }
 
 export interface PriceData {


### PR DESCRIPTION
## Summary
- add per-holding target allocation storage to the portfolio model and SQLite schema
- compute target value, delta percent, and rebalance amount in the portfolio snapshot
- expose target weights in the holding form and show rebalance guidance in the holdings view

Closes #65

## Verification
- npm run typecheck
- npm run test
- npm run build
- cargo test
- cargo build