### PR TITLE
ci: add cross-platform release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: '22'
+
+jobs:
+  release:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS (Apple Silicon)
+            platform: macos-latest
+            target: aarch64-apple-darwin
+            args: --target aarch64-apple-darwin
+          - name: macOS (Intel)
+            platform: macos-latest
+            target: x86_64-apple-darwin
+            args: --target x86_64-apple-darwin
+          - name: Windows
+            platform: windows-latest
+            target: ''
+            args: ''
+          - name: Linux
+            platform: ubuntu-22.04
+            target: ''
+            args: ''
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install frontend deps
+        run: npm ci
+
+      - name: Verify version files match tag
+        shell: bash
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          TAURI_VERSION="$(node -p "require('./src-tauri/tauri.conf.json').version")"
+          CARGO_VERSION="$(grep '^version = ' src-tauri/Cargo.toml | head -n1 | sed 's/version = \"\(.*\)\"/\1/')"
+
+          test "$TAG_VERSION" = "$PACKAGE_VERSION"
+          test "$TAG_VERSION" = "$TAURI_VERSION"
+          test "$TAG_VERSION" = "$CARGO_VERSION"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust target
+        if: matrix.target != ''
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: 'src-tauri -> target'
+
+      - name: Install Linux system deps
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev
+
+      - name: Build and publish draft release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional macOS signing and notarization secrets:
+          # APPLE_CERTIFICATE
+          # APPLE_CERTIFICATE_PASSWORD
+          # APPLE_SIGNING_IDENTITY
+          # APPLE_ID
+          # APPLE_PASSWORD
+          # APPLE_TEAM_ID
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: Portfolio Tracker ${{ github.ref_name }}
+          releaseBody: |
+            See the [changelog](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for release details.
+
+            ## Downloads
+            | Platform | Installer |
+            | --- | --- |
+            | macOS (Apple Silicon) | `.dmg` |
+            | macOS (Intel) | `.dmg` |
+            | Windows | `.exe` / `.msi` |
+            | Linux | `.AppImage` / `.deb` |
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Shared portfolio state across views so holdings changes refresh dashboard, performance, and stress views automatically
+- Target allocation support with rebalance deltas and deployable cash guidance
+- CSV import with symbol validation and preview
+- Account metadata for holdings, filters, and exports
+- Configurable base currency across portfolio views
+
+## [0.1.0] - 2026-03-14
+
+### Added
+- Dashboard with portfolio value, allocation charts, and top movers
+- Holdings CRUD for stocks, ETFs, crypto, and cash
+- Historical performance charts and portfolio stats
+- Stress testing with preset and custom scenarios
+- Live Yahoo Finance pricing and FX conversion
+- Local SQLite persistence via Tauri and Rust

--- a/README.md
+++ b/README.md
@@ -10,13 +10,24 @@ A macOS desktop portfolio tracker built with Tauri v2. Tracks stocks, ETFs, cryp
 
 The app runs as a native macOS window with a Bloomberg-inspired dark terminal UI. Holdings are stored locally in SQLite — no cloud account required.
 
-**Docs:** [Feature Guide](docs/features.md) · [Roadmap](docs/roadmap.md)
+**Docs:** [Feature Guide](docs/features.md) · [Roadmap](docs/roadmap.md) · [Release Guide](docs/releases.md)
 
 ---
 
 ## Screenshot
 
 ![Portfolio Tracker dashboard showing portfolio value, allocation, and holdings](docs/screenshot-dashboard.png)
+
+---
+
+## Download
+
+- Latest release: https://github.com/GitError/portfolio-tracker/releases/latest
+- All releases: https://github.com/GitError/portfolio-tracker/releases
+
+Release builds are published from tags matching `v*.*.*` and first appear as draft GitHub Releases for review.
+
+> **Signing note:** macOS and Windows installers may show platform security warnings until signing certificates are configured. See [docs/releases.md](docs/releases.md) for the signing secrets and release flow.
 
 ---
 
@@ -132,6 +143,17 @@ cargo test                # Unit tests (db, stress engine, fx)
 cargo clippy              # Linter
 cargo fmt                 # Formatter
 ```
+
+### Releases
+
+```bash
+./scripts/bump-version.sh 0.1.1
+git commit -am "chore: bump version to 0.1.1"
+git tag v0.1.1
+git push && git push --tags
+```
+
+Pushing a `v*.*.*` tag triggers `.github/workflows/release.yml`, which builds cross-platform Tauri installers and creates a draft GitHub Release with attached artifacts.
 
 ### Git hooks
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,57 @@
+# Releases
+
+## Download
+
+Published installers are attached to GitHub Releases:
+
+- Latest release: https://github.com/GitError/portfolio-tracker/releases/latest
+- All releases: https://github.com/GitError/portfolio-tracker/releases
+
+Draft releases are created automatically from tags that match `v*.*.*`.
+
+## Versioning
+
+Keep these three files in sync for every release:
+
+- `package.json`
+- `src-tauri/tauri.conf.json`
+- `src-tauri/Cargo.toml`
+
+Use `./scripts/bump-version.sh X.Y.Z` to update them together.
+
+## Release flow
+
+1. Update `CHANGELOG.md`
+2. Run `./scripts/bump-version.sh X.Y.Z`
+3. Commit the version bump
+4. Tag the release with `vX.Y.Z`
+5. Push the branch and tag
+6. GitHub Actions builds installers and creates a draft release
+7. Review the draft release and publish it manually
+
+## Code signing
+
+### macOS
+
+Unsigned macOS builds work for testing, but users will see Gatekeeper warnings.
+To enable Developer ID signing and notarization, configure these repository secrets:
+
+- `APPLE_CERTIFICATE`
+- `APPLE_CERTIFICATE_PASSWORD`
+- `APPLE_SIGNING_IDENTITY`
+- `APPLE_ID`
+- `APPLE_PASSWORD`
+- `APPLE_TEAM_ID`
+
+The release workflow is already wired to use those environment variables when they are present.
+
+### Windows
+
+Windows signing is optional for now. Without a signing certificate, SmartScreen may warn on first launch.
+
+## Expected artifacts
+
+- macOS Apple Silicon: `.dmg`
+- macOS Intel: `.dmg`
+- Windows: `.exe`, `.msi`
+- Linux: `.AppImage`, `.deb`

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: ./scripts/bump-version.sh <version>"
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be in semver format: X.Y.Z"
+  exit 1
+fi
+
+echo "Bumping project version to $VERSION..."
+
+npm version "$VERSION" --no-git-tag-version
+
+node -e '
+  const fs = require("fs");
+  const path = "src-tauri/tauri.conf.json";
+  const json = JSON.parse(fs.readFileSync(path, "utf8"));
+  json.version = process.argv[1];
+  fs.writeFileSync(path, JSON.stringify(json, null, 2) + "\n");
+' "$VERSION"
+
+perl -0pi -e 's/^version = ".*?"$/version = "'"$VERSION"'"/m' src-tauri/Cargo.toml
+
+echo "Updated:"
+echo "  - package.json"
+echo "  - src-tauri/tauri.conf.json"
+echo "  - src-tauri/Cargo.toml"
+echo
+echo "Next steps:"
+echo "  git add package.json package-lock.json src-tauri/tauri.conf.json src-tauri/Cargo.toml CHANGELOG.md"
+echo "  git commit -m \"chore: bump version to $VERSION\""
+echo "  git tag v$VERSION"
+echo "  git push && git push --tags"


### PR DESCRIPTION
## Summary
- add a tag-triggered GitHub Actions release workflow that builds Tauri installers for macOS, Windows, and Linux and publishes a draft GitHub Release
- add a version bump script, changelog, and release guide documenting version sync and code signing secrets
- update the README with release download links and the tag-based release flow

Closes #40

## Verification
- zsh -n scripts/bump-version.sh
- git diff --check
- npm run test
- cargo test