### PR TITLE
ci: add staged pre-push build verification (#47)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,27 +1,24 @@
-#!/bin/sh
-# pre-commit: run lint + typecheck + format check on staged TS/TSX files
-
+#!/bin/zsh
 set -e
 
 echo "🔍 Running pre-commit checks..."
 
 # Frontend checks
 echo "  → ESLint..."
-npm run lint
+npm run lint || { echo "❌ ESLint failed"; exit 1; }
 
 echo "  → TypeScript..."
-npm run typecheck
+npm run typecheck || { echo "❌ TypeScript check failed"; exit 1; }
 
 echo "  → Prettier..."
-npm run format:check
+npm run format:check || { echo "❌ Prettier check failed — run 'npm run format' to fix"; exit 1; }
 
-# Rust format check (if src-tauri changes are staged)
+# Rust format check (only if src-tauri files are staged)
 if git diff --cached --name-only | grep -q '^src-tauri/'; then
   echo "  → cargo fmt..."
   CARGO="${HOME}/.cargo/bin/cargo"
   if [ -x "$CARGO" ]; then
-    cd src-tauri
-    "$CARGO" fmt --check
+    cd src-tauri && "$CARGO" fmt --check || { echo "❌ cargo fmt check failed — run 'cargo fmt' in src-tauri/ to fix"; exit 1; }
     cd ..
   else
     echo "  (cargo not found, skipping Rust fmt check)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,21 +1,91 @@
-#!/bin/sh
-# pre-push: run full test suite before push
-
+#!/bin/zsh
 set -e
 
-echo "🧪 Running full test suite before push..."
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CARGO="${HOME}/.cargo/bin/cargo"
+echo "🚀 Pre-push verification for branch: $BRANCH"
+
+# ── Stage 1: Lint + format (< 10s) ───────────────────────────────────────────
+echo ""
+echo "Stage 1: Lint + format..."
+npm run lint --silent
+npm run format:check --silent
+if [ -x "$CARGO" ]; then
+  cd src-tauri && "$CARGO" fmt --check 2>/dev/null && cd ..
+fi
+echo "  ✓ Lint + format passed"
+
+# ── Stage 2: Build verification (< 2 min) ────────────────────────────────────
+echo ""
+echo "Stage 2: Build verification..."
+
+echo "  → Frontend build (tsc + vite)..."
+npm run build --silent
+
+echo "  → Backend build (cargo)..."
+if [ -x "$CARGO" ]; then
+  cd src-tauri && "$CARGO" build --quiet 2>/dev/null && cd ..
+else
+  echo "  (cargo not found, skipping backend build)"
+fi
+echo "  ✓ Builds passed"
+
+# ── Stage 3: Tests (< 1 min) ─────────────────────────────────────────────────
+echo ""
+echo "Stage 3: Tests..."
 
 echo "  → Frontend tests..."
-npm test
+npm run test --silent
 
-echo "  → Rust tests..."
-CARGO="${HOME}/.cargo/bin/cargo"
+echo "  → Backend tests..."
 if [ -x "$CARGO" ]; then
-  cd src-tauri
-  "$CARGO" test
-  cd ..
+  cd src-tauri && "$CARGO" test --quiet 2>/dev/null && cd ..
 else
-  echo "  (cargo not found, skipping Rust tests)"
+  echo "  (cargo not found, skipping backend tests)"
+fi
+echo "  ✓ Tests passed"
+
+# ── Stage 4: Clippy (< 30s) ──────────────────────────────────────────────────
+echo ""
+echo "Stage 4: Clippy..."
+if [ -x "$CARGO" ]; then
+  cd src-tauri && "$CARGO" clippy --quiet -- -D warnings 2>/dev/null && cd ..
+  echo "  ✓ Clippy passed"
+else
+  echo "  (cargo not found, skipping clippy)"
 fi
 
-echo "✅ All tests passed. Proceeding with push."
+# ── Stage 5: Claude review (only on main/dev) ────────────────────────────────
+if [[ "$BRANCH" == "main" || "$BRANCH" == "dev" ]]; then
+  DIFF=$(git log --oneline --no-merges origin/$BRANCH..HEAD 2>/dev/null)
+  if [ -n "$DIFF" ]; then
+    echo ""
+    echo "🔍 Stage 5: Claude Code review..."
+    claude -p "You are reviewing code about to be pushed to the '$BRANCH' branch of a Tauri v2 portfolio tracker (Rust + React/TypeScript).
+
+Review the following changes for:
+1. Bugs or logic errors
+2. Type alignment issues between Rust (serde camelCase) and TypeScript interfaces
+3. Security issues (SQL injection, hardcoded secrets, unvalidated input)
+4. Missing error handling
+5. Style consistency with the dark terminal/Bloomberg design system
+
+Only flag real issues. Be concise. If everything looks good, say so.
+
+Changes being pushed:
+$(git diff origin/$BRANCH..HEAD)
+
+Files changed:
+$(git diff --name-only origin/$BRANCH..HEAD)"
+
+    echo ""
+    read "REPLY?Claude review complete. Continue pushing? [y/N] "
+    if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+      echo "Push aborted."
+      exit 1
+    fi
+  fi
+fi
+
+echo ""
+echo "✅ All pre-push checks passed!"

--- a/README.md
+++ b/README.md
@@ -139,9 +139,25 @@ Located in `.githooks/`, activated by `git config core.hooksPath .githooks` duri
 
 | Hook | Runs |
 |------|------|
-| pre-commit | ESLint, TypeScript check, Prettier check, `cargo fmt --check` |
-| pre-push | Full test suite — Vitest + `cargo test` |
+| pre-commit | ESLint, TypeScript check, Prettier check, `cargo fmt --check` (fast, ~5s) |
+| pre-push | Staged: lint → build (`npm run build` + `cargo build`) → tests → clippy → Claude review on main/dev |
 | post-merge | Reinstalls deps if `package-lock.json` or `Cargo.lock` changed |
+
+The pre-push hook runs in stages so failures surface early:
+
+1. **Lint + format** (~5s) — ESLint, Prettier, `cargo fmt`
+2. **Build** (~30–60s warm) — `npm run build` (tsc strict + Vite) and `cargo build` (full compilation)
+3. **Tests** (~15–30s) — Vitest and `cargo test`
+4. **Clippy** (~10–20s) — `cargo clippy -D warnings`
+5. **Claude review** (main/dev only) — AI review of the diff with a proceed/abort prompt
+
+**Escape hatch:** if you need to push urgently (e.g. a docs fix) and don't want to wait, use:
+
+```bash
+git push --no-verify
+```
+
+CI will still catch any issues — `--no-verify` only skips local hooks.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replaces the minimal pre-push hook (tests only) with a 4-stage pipeline: lint → build → tests → clippy
- Adds `npm run build` (tsc strict + Vite) and `cargo build` to catch compilation errors before CI
- Stages run fastest-first so failures surface quickly; quiet/silent flags suppress noise
- Adds optional Claude Code diff review on `main`/`dev` pushes with a proceed/abort prompt
- Tightens pre-commit error messages to name the failing check and the fix command
- Documents `git push --no-verify` escape hatch in README

## Test Plan
- [x] New pre-push hook ran successfully during this PR's own push (all 4 stages passed)
- [x] Pre-commit hook committed cleanly with updated error messages
- [ ] Verify `npm run build` failure blocks the push (introduce a TS error, attempt push)
- [ ] Verify `cargo build` failure blocks the push (introduce a Rust error, attempt push)
- [ ] Verify `git push --no-verify` skips the hook as documented

Closes #47