### PR TITLE
feat: add stress scenario explanation modal

### DIFF
--- a/src/components/StressTest.tsx
+++ b/src/components/StressTest.tsx
@@ -10,13 +10,20 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+import { HelpCircle } from 'lucide-react';
 import { usePortfolio } from '../hooks/usePortfolio';
 import { useStressTest } from '../hooks/useStressTest';
-import { createPresetScenarios, fxShockKey, ASSET_TYPE_CONFIG } from '../lib/constants';
+import {
+  createPresetScenarioInfo,
+  createPresetScenarios,
+  fxShockKey,
+  ASSET_TYPE_CONFIG,
+} from '../lib/constants';
 import { formatCurrency, formatPercent, formatCompact } from '../lib/format';
 import { pnlColor } from '../lib/colors';
 import { EmptyState } from './ui/EmptyState';
 import { Select } from './ui/Select';
+import { StressTestInfo } from './StressTestInfo';
 import type { StressScenario } from '../types/portfolio';
 
 // ─── Shock state keyed as the scenario.shocks keys ───────────────────────────
@@ -193,6 +200,7 @@ export function StressTest() {
   const { portfolio, holdings } = usePortfolio();
   const { result, loading, runTest } = useStressTest();
   const baseCurrency = portfolio?.baseCurrency ?? 'CAD';
+  const presetScenarioInfo = useMemo(() => createPresetScenarioInfo(baseCurrency), [baseCurrency]);
   const presetScenarios = useMemo(() => createPresetScenarios(baseCurrency), [baseCurrency]);
   const presetNames = useMemo(
     () => [...presetScenarios.map((s) => s.name), 'Custom'],
@@ -201,7 +209,12 @@ export function StressTest() {
   const [presetName, setPresetName] = useState<string>('Mild Correction');
   const [shocks, setShocks] = useState<ShockMap>(ZERO_SHOCKS);
   const [showComparison, setShowComparison] = useState(false);
+  const [infoOpen, setInfoOpen] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activePresetInfo = useMemo(
+    () => presetScenarioInfo.find((scenario) => scenario.name === presetName) ?? null,
+    [presetName, presetScenarioInfo]
+  );
 
   // Detect which FX sliders are relevant to held currencies
   const activeFxSliders = useMemo(() => {
@@ -320,7 +333,39 @@ export function StressTest() {
         >
           {/* Preset selector */}
           <div style={{ marginBottom: 20 }}>
-            <div style={SECTION_TITLE}>Preset Scenario</div>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                marginBottom: 10,
+              }}
+            >
+              <div style={{ ...SECTION_TITLE, flex: 1, marginBottom: 0 }}>Preset Scenario</div>
+              {activePresetInfo && (
+                <button
+                  onClick={() => setInfoOpen(true)}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    background: 'transparent',
+                    border: '1px solid var(--border-primary)',
+                    color: 'var(--text-secondary)',
+                    padding: '5px 10px',
+                    cursor: 'pointer',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                  }}
+                >
+                  <HelpCircle size={12} />
+                  Info
+                </button>
+              )}
+            </div>
             <Select
               value={presetName}
               onChange={handlePresetChange}
@@ -353,7 +398,8 @@ export function StressTest() {
                   marginBottom: 10,
                 }}
               >
-                Positive = {baseCurrency} weakens (foreign assets worth more in {baseCurrency})
+                Positive = {baseCurrency} weakens. Foreign holdings convert into more {baseCurrency}
+                . Negative = {baseCurrency} strengthens.
               </div>
               {activeFxSliders.map(({ key, label }) => (
                 <ShockSlider
@@ -728,6 +774,12 @@ export function StressTest() {
           )}
         </div>
       </div>
+
+      <StressTestInfo
+        isOpen={infoOpen}
+        scenario={activePresetInfo}
+        onClose={() => setInfoOpen(false)}
+      />
 
       {/* Slider thumb global style injection */}
       <style>{`

--- a/src/components/StressTestInfo.tsx
+++ b/src/components/StressTestInfo.tsx
@@ -1,0 +1,190 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { formatPercent } from '../lib/format';
+import type { StressScenarioInfo } from '../types/portfolio';
+
+interface Props {
+  scenario: StressScenarioInfo | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const OVERLAY: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  backdropFilter: 'blur(4px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+  padding: 20,
+};
+
+const PANEL: React.CSSProperties = {
+  width: '100%',
+  maxWidth: 560,
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-primary)',
+  padding: 24,
+};
+
+export function StressTestInfo({ scenario, isOpen, onClose }: Props) {
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !scenario) return null;
+
+  return (
+    <div style={OVERLAY} onClick={(event) => event.target === event.currentTarget && onClose()}>
+      <div style={PANEL}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 16,
+            marginBottom: 18,
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                marginBottom: 6,
+              }}
+            >
+              Scenario Info
+            </div>
+            <h2
+              style={{
+                margin: 0,
+                fontFamily: 'var(--font-sans)',
+                fontSize: 18,
+                color: 'var(--text-primary)',
+              }}
+            >
+              {scenario.name}
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'transparent',
+              border: '1px solid var(--border-primary)',
+              color: 'var(--text-secondary)',
+              width: 32,
+              height: 32,
+              display: 'grid',
+              placeItems: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <p
+          style={{
+            margin: 0,
+            color: 'var(--text-secondary)',
+            fontSize: 14,
+            lineHeight: 1.6,
+          }}
+        >
+          {scenario.description}
+        </p>
+
+        <div style={{ marginTop: 18 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              marginBottom: 8,
+            }}
+          >
+            Shock Breakdown
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+              gap: 8,
+            }}
+          >
+            {Object.entries(scenario.shocks).map(([key, value]) => (
+              <div
+                key={key}
+                style={{
+                  border: '1px solid var(--border-subtle)',
+                  padding: '10px 12px',
+                  background: 'var(--bg-surface-alt)',
+                }}
+              >
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--text-muted)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    marginBottom: 4,
+                  }}
+                >
+                  {key.replace(/_/g, '/')}
+                </div>
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 14,
+                    color: value >= 0 ? 'var(--color-gain)' : 'var(--color-loss)',
+                    fontWeight: 700,
+                  }}
+                >
+                  {formatPercent(value * 100)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ marginTop: 18 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              marginBottom: 6,
+            }}
+          >
+            Historical Parallel
+          </div>
+          <div
+            style={{
+              color: 'var(--text-primary)',
+              fontSize: 13,
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            {scenario.historicalParallel}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,10 +1,10 @@
-import type { AccountType, StressScenario } from '../types/portfolio';
+import type { AccountType, StressScenario, StressScenarioInfo } from '../types/portfolio';
 
 export function fxShockKey(currency: string, baseCurrency: string): string {
   return `fx_${currency.toLowerCase()}_${baseCurrency.toLowerCase()}`;
 }
 
-export function createPresetScenarios(baseCurrency: string): StressScenario[] {
+export function createPresetScenarioInfo(baseCurrency: string): StressScenarioInfo[] {
   const addFxShock = (shocks: Record<string, number>, currency: string, value: number) => {
     if (currency.toUpperCase() !== baseCurrency.toUpperCase()) {
       shocks[fxShockKey(currency, baseCurrency)] = value;
@@ -26,24 +26,42 @@ export function createPresetScenarios(baseCurrency: string): StressScenario[] {
     {
       name: 'Mild Correction',
       shocks: { stock: -0.05, etf: -0.05, crypto: -0.1 },
+      description:
+        'Models a routine pullback where equities fall modestly and crypto drops harder because of higher volatility.',
+      historicalParallel: 'Q4 2018, Sep 2020',
     },
     {
       name: 'Bear Market',
       shocks: bearMarket,
+      description:
+        'Models a prolonged risk-off drawdown with large equity losses and a flight toward safety assets.',
+      historicalParallel: '2008 GFC, 2022 rate hiking cycle',
     },
     {
       name: 'Crypto Winter',
       shocks: { crypto: -0.5 },
+      description:
+        'Models a crypto-specific collapse where digital assets reprice sharply while traditional assets stay relatively stable.',
+      historicalParallel: '2018 crypto winter, May 2022 Terra/Luna collapse',
     },
     {
       name: 'Base Currency Drop',
       shocks: baseCurrencyDrop,
+      description: `Models a sharp drop in ${baseCurrency} versus major currencies, increasing the local value of foreign holdings.`,
+      historicalParallel: '2015 oil shock and CAD weakness',
     },
     {
       name: 'Stagflation',
       shocks: stagflation,
+      description:
+        'Models inflation staying high while growth weakens, pulling down risk assets while the local currency also softens.',
+      historicalParallel: '1970s stagflation, partial parallel in 2022',
     },
   ];
+}
+
+export function createPresetScenarios(baseCurrency: string): StressScenario[] {
+  return createPresetScenarioInfo(baseCurrency).map(({ name, shocks }) => ({ name, shocks }));
 }
 
 export const ASSET_TYPE_CONFIG = {

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -74,6 +74,11 @@ export interface StressScenario {
   shocks: Record<string, number>; // keys: "stock"|"etf"|"crypto"|"fx_usd_cad"|"fx_cad_usd" etc, values: decimal (-0.10 = -10%)
 }
 
+export interface StressScenarioInfo extends StressScenario {
+  description: string;
+  historicalParallel: string;
+}
+
 export interface StressHoldingResult {
   holdingId: string;
   symbol: string;


### PR DESCRIPTION
## Summary
- add scenario metadata for preset stress tests including descriptions and historical parallels
- add an info button and modal on the stress test screen for the selected preset scenario
- clarify FX shock direction directly in the stress test controls

Closes #44

## Verification
- npm run typecheck
- npm run test
- npm run build
- cargo test