### PR TITLE
fix: preserve target weight in CSV round-trips

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -93,6 +93,41 @@ struct ParsedImportRow {
     quantity: f64,
     cost_basis: f64,
     currency: String,
+    target_weight: f64,
+}
+
+fn build_holdings_csv(holdings: &[Holding]) -> Result<String, String> {
+    let mut writer = WriterBuilder::new().from_writer(vec![]);
+    writer
+        .write_record([
+            "symbol",
+            "name",
+            "type",
+            "account",
+            "quantity",
+            "cost_basis",
+            "currency",
+            "target_weight",
+        ])
+        .map_err(|e| e.to_string())?;
+
+    for holding in holdings {
+        writer
+            .write_record([
+                holding.symbol.clone(),
+                holding.name.clone(),
+                holding.asset_type.as_str().to_string(),
+                holding.account.as_str().to_string(),
+                holding.quantity.to_string(),
+                holding.cost_basis.to_string(),
+                holding.currency.clone(),
+                holding.target_weight.to_string(),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+
+    let bytes = writer.into_inner().map_err(|e| e.to_string())?;
+    String::from_utf8(bytes).map_err(|e| e.to_string())
 }
 
 fn detect_csv_delimiter(content: &str) -> u8 {
@@ -179,6 +214,7 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
         .ok_or_else(|| "Missing required column: cost_basis".to_string())?;
     let currency_index = find_column_index(&headers, "currency")
         .ok_or_else(|| "Missing required column: currency".to_string())?;
+    let target_weight_index = find_column_index(&headers, "target_weight");
 
     let mut rows = Vec::new();
 
@@ -239,6 +275,19 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
             return Err(format!("Row {}: invalid_cost_basis", row));
         }
 
+        let target_weight = parse_optional_field(&record, target_weight_index);
+        let target_weight = if target_weight.is_empty() {
+            0.0
+        } else {
+            let parsed = target_weight
+                .parse::<f64>()
+                .map_err(|_| format!("Row {}: invalid_target_weight", row))?;
+            if !(0.0..=100.0).contains(&parsed) {
+                return Err(format!("Row {}: invalid_target_weight", row));
+            }
+            parsed
+        };
+
         rows.push(ParsedImportRow {
             row,
             symbol,
@@ -248,6 +297,7 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
             quantity,
             cost_basis,
             currency,
+            target_weight,
         });
     }
 
@@ -475,36 +525,7 @@ pub async fn export_holdings_csv(db: State<'_, DbState>) -> Result<String, Strin
         let conn = db.0.lock().map_err(|e| e.to_string())?;
         db::get_all_holdings(&conn)?
     };
-
-    let mut writer = WriterBuilder::new().from_writer(vec![]);
-    writer
-        .write_record([
-            "symbol",
-            "name",
-            "type",
-            "account",
-            "quantity",
-            "cost_basis",
-            "currency",
-        ])
-        .map_err(|e| e.to_string())?;
-
-    for holding in holdings {
-        writer
-            .write_record([
-                holding.symbol,
-                holding.name,
-                holding.asset_type.as_str().to_string(),
-                holding.account.as_str().to_string(),
-                holding.quantity.to_string(),
-                holding.cost_basis.to_string(),
-                holding.currency,
-            ])
-            .map_err(|e| e.to_string())?;
-    }
-
-    let bytes = writer.into_inner().map_err(|e| e.to_string())?;
-    String::from_utf8(bytes).map_err(|e| e.to_string())
+    build_holdings_csv(&holdings)
 }
 
 #[tauri::command]
@@ -550,7 +571,7 @@ pub async fn import_holdings_csv(
                 quantity: row.quantity,
                 cost_basis: row.cost_basis,
                 currency: row.currency,
-                target_weight: 0.0,
+                target_weight: row.target_weight,
             });
             continue;
         }
@@ -601,7 +622,7 @@ pub async fn import_holdings_csv(
             quantity: row.quantity,
             cost_basis: row.cost_basis,
             currency: row.currency,
-            target_weight: 0.0,
+            target_weight: row.target_weight,
         });
     }
 
@@ -652,6 +673,7 @@ pub async fn preview_import_csv(
                 exchange: String::new(),
                 quantity: row.quantity,
                 cost_basis: row.cost_basis,
+                target_weight: row.target_weight,
                 status: "duplicate".to_string(),
             });
             continue;
@@ -673,6 +695,7 @@ pub async fn preview_import_csv(
                 exchange: String::new(),
                 quantity: row.quantity,
                 cost_basis: row.cost_basis,
+                target_weight: row.target_weight,
                 status: "ready".to_string(),
             });
             continue;
@@ -695,6 +718,7 @@ pub async fn preview_import_csv(
                     exchange: result.exchange,
                     quantity: row.quantity,
                     cost_basis: row.cost_basis,
+                    target_weight: row.target_weight,
                     status: "ready".to_string(),
                 });
             }
@@ -709,6 +733,7 @@ pub async fn preview_import_csv(
                     exchange: String::new(),
                     quantity: row.quantity,
                     cost_basis: row.cost_basis,
+                    target_weight: row.target_weight,
                     status: "invalid_symbol".to_string(),
                 });
             }
@@ -723,6 +748,7 @@ pub async fn preview_import_csv(
                     exchange: String::new(),
                     quantity: row.quantity,
                     cost_basis: row.cost_basis,
+                    target_weight: row.target_weight,
                     status: "validation_failed".to_string(),
                 });
             }
@@ -966,11 +992,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_import_rows_reads_optional_target_weight() {
+        let csv = "symbol,name,type,quantity,cost_basis,currency,target_weight\nAAPL,Apple Inc.,stock,5,120,USD,12.5\n";
+        let rows = parse_import_rows(csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 1);
+        assert!((rows[0].target_weight - 12.5).abs() < 0.001);
+    }
+
+    #[test]
     fn parse_import_rows_rejects_missing_required_columns() {
         let csv = "symbol,name,type,quantity,currency\nAAPL,Apple Inc.,stock,5,USD\n";
         let error = parse_import_rows(csv).expect_err("missing cost_basis should fail");
 
         assert!(error.contains("Missing required column: cost_basis"));
+    }
+
+    #[test]
+    fn build_holdings_csv_includes_target_weight_column() {
+        let mut holding = make_holding("AAPL", AssetType::Stock, 5.0, 120.0, "USD");
+        holding.target_weight = 22.5;
+
+        let csv = build_holdings_csv(&[holding]).expect("build csv");
+
+        assert!(
+            csv.starts_with("symbol,name,type,account,quantity,cost_basis,currency,target_weight")
+        );
+        assert!(csv.contains(",22.5"));
     }
 
     #[test]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -230,6 +230,7 @@ pub struct PreviewRow {
     pub exchange: String,
     pub quantity: f64,
     pub cost_basis: f64,
+    pub target_weight: f64,
     /// "ready" | "cash" | "duplicate" | "invalid_symbol" | "validation_failed"
     pub status: String,
 }

--- a/src/components/ImportHoldingsModal.tsx
+++ b/src/components/ImportHoldingsModal.tsx
@@ -34,12 +34,12 @@ function assetTypeBadge(type: string) {
 
 function downloadTemplate() {
   const template = [
-    'symbol,name,type,account,quantity,cost_basis,currency',
-    'AAPL,Apple Inc.,stock,tfsa,50,142.50,USD',
-    'BMO:CA,Bank of Montreal,stock,rrsp,100,80.00,CAD',
-    'VOO,Vanguard S&P 500 ETF,etf,rrsp,20,380.00,USD',
-    'BTC-USD,Bitcoin,crypto,taxable,0.5,45000.00,USD',
-    ',US Dollar Cash,cash,taxable,5000,1.00,USD',
+    'symbol,name,type,account,quantity,cost_basis,currency,target_weight',
+    'AAPL,Apple Inc.,stock,tfsa,50,142.50,USD,20',
+    'BMO:CA,Bank of Montreal,stock,rrsp,100,80.00,CAD,15',
+    'VOO,Vanguard S&P 500 ETF,etf,rrsp,20,380.00,USD,35',
+    'BTC-USD,Bitcoin,crypto,taxable,0.5,45000.00,USD,5',
+    ',US Dollar Cash,cash,taxable,5000,1.00,USD,10',
   ].join('\n');
 
   const blob = new Blob([template], { type: 'text/csv;charset=utf-8' });
@@ -73,6 +73,7 @@ function PreviewTable({ rows }: { rows: PreviewRow[] }) {
               'CCY',
               'Qty',
               'Cost',
+              'Target %',
               'Status',
             ].map((h) => (
               <th
@@ -134,6 +135,9 @@ function PreviewTable({ rows }: { rows: PreviewRow[] }) {
               </td>
               <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)', textAlign: 'right' }}>
                 {r.costBasis.toFixed(2)}
+              </td>
+              <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)', textAlign: 'right' }}>
+                {r.targetWeight.toFixed(1)}%
               </td>
               <td style={TD}>{statusCell(r.status)}</td>
             </tr>
@@ -242,7 +246,9 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport, onPreview }: Pr
             <div style={{ ...MONO, fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}>
               Supports <code style={{ color: 'var(--text-secondary)' }}>SYMBOL:COUNTRY</code> (e.g.{' '}
               <code style={{ color: 'var(--text-secondary)' }}>BMO:CA</code>), plain symbols, and
-              cash rows.
+              cash rows. Optional{' '}
+              <code style={{ color: 'var(--text-secondary)' }}>target_weight</code> values are
+              preserved on import and export.
             </div>
           </div>
           <button

--- a/src/hooks/usePortfolio.ts
+++ b/src/hooks/usePortfolio.ts
@@ -69,7 +69,7 @@ function parseMockCsv(csvContent: string): HoldingInput[] {
       quantity: Number(cells[columnIndex('quantity')]),
       costBasis: Number(cells[columnIndex('cost_basis')]),
       currency,
-      targetWeight: 0,
+      targetWeight: Number(cells[columnIndex('target_weight')]) || 0,
     };
   });
 }
@@ -209,6 +209,7 @@ function usePortfolioState(): UsePortfolioReturn {
         exchange: '',
         quantity: input.quantity,
         costBasis: input.costBasis,
+        targetWeight: input.targetWeight,
         status: 'ready',
       })),
       readyCount: imported.length,
@@ -222,7 +223,7 @@ function usePortfolioState(): UsePortfolioReturn {
     }
 
     const rows = [
-      ['symbol', 'name', 'type', 'account', 'quantity', 'cost_basis', 'currency'],
+      ['symbol', 'name', 'type', 'account', 'quantity', 'cost_basis', 'currency', 'target_weight'],
       ...holdings.map((holding) => [
         holding.symbol,
         holding.name,
@@ -231,6 +232,7 @@ function usePortfolioState(): UsePortfolioReturn {
         String(holding.quantity),
         String(holding.costBasis),
         holding.currency,
+        String(holding.targetWeight),
       ]),
     ];
     return rows.map((row) => row.join(',')).join('\n');

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -128,6 +128,7 @@ export interface PreviewRow {
   exchange: string;
   quantity: number;
   costBasis: number;
+  targetWeight: number;
   /** "ready" | "cash" | "duplicate" | "invalid_symbol" | "validation_failed" */
   status: string;
 }


### PR DESCRIPTION
Closes #80

## Summary
- include `target_weight` in backend and mock CSV exports
- accept optional `target_weight` during CSV import and preview, defaulting to `0`
- show target weight in the import template and preview table
- add backend tests for target-weight import parsing and CSV export output

## Verification
- npm run typecheck
- npm run test
- npm run build
- cargo test
