### PR TITLE
fix: return Err instead of silent 1:1 fallback when FX rate missing (#92)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -390,13 +390,27 @@ fn build_portfolio_snapshot(
             holding.currency.to_uppercase(),
             base_currency.to_uppercase()
         );
-        let fx_rate = if holding.currency.eq_ignore_ascii_case(base_currency) {
-            1.0
+        let fx_rate_result = if holding.currency.eq_ignore_ascii_case(base_currency) {
+            Ok(1.0f64)
         } else {
-            fx_map.get(&fx_pair).map(|r| r.rate).unwrap_or_else(|| {
-                convert_to_base(1.0, &holding.currency, base_currency, cached_fx)
-            })
+            fx_map
+                .get(&fx_pair)
+                .map(|r| Ok(r.rate))
+                .unwrap_or_else(|| convert_to_base(1.0, &holding.currency, base_currency, cached_fx))
         };
+
+        let fx_rate = match fx_rate_result {
+            Ok(rate) => rate,
+            Err(ref e) => {
+                eprintln!(
+                    "FX conversion error for holding {} ({}): {}; setting market/cost values to 0",
+                    holding.symbol, holding.currency, e
+                );
+                0.0
+            }
+        };
+
+        let fx_available = fx_rate_result.is_ok();
 
         let current_price_cad = current_price * fx_rate;
         let market_value_cad = holding.quantity * current_price_cad;
@@ -408,9 +422,11 @@ fn build_portfolio_snapshot(
             0.0
         };
 
-        total_value += market_value_cad;
-        total_cost += cost_value_cad;
-        daily_pnl += market_value_cad * (change_percent / 100.0);
+        if fx_available {
+            total_value += market_value_cad;
+            total_cost += cost_value_cad;
+            daily_pnl += market_value_cad * (change_percent / 100.0);
+        }
 
         holdings_with_price.push(HoldingWithPrice {
             id: holding.id.clone(),
@@ -1174,5 +1190,54 @@ mod tests {
         assert!((snapshot.holdings[0].target_delta_value + 180.0).abs() < 0.001);
         assert!((snapshot.holdings[1].target_delta_value + 330.0).abs() < 0.001);
         assert!((snapshot.target_cash_delta - 330.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_zeroes_holding_when_fx_rate_missing() {
+        // One CAD holding (base), one USD holding with NO fx rate provided.
+        let holdings = vec![
+            make_holding("SHOP.TO", AssetType::Stock, 10.0, 100.0, "CAD"),
+            make_holding("AAPL", AssetType::Stock, 5.0, 100.0, "USD"),
+        ];
+        let prices = vec![
+            PriceData {
+                symbol: "SHOP.TO".to_string(),
+                price: 110.0,
+                currency: "CAD".to_string(),
+                change: 0.0,
+                change_percent: 0.0,
+                updated_at: Utc::now().to_rfc3339(),
+            },
+            PriceData {
+                symbol: "AAPL".to_string(),
+                price: 150.0,
+                currency: "USD".to_string(),
+                change: 0.0,
+                change_percent: 0.0,
+                updated_at: Utc::now().to_rfc3339(),
+            },
+        ];
+
+        // No FX rates — USDCAD is missing
+        let snapshot = build_portfolio_snapshot(
+            &holdings,
+            &prices,
+            &[],
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+        );
+
+        // CAD holding is unaffected
+        assert!((snapshot.holdings[0].market_value_cad - 1100.0).abs() < 0.001);
+        assert!((snapshot.holdings[0].cost_value_cad - 1000.0).abs() < 0.001);
+
+        // USD holding with missing FX rate gets zeroed out — NOT a 1:1 conversion
+        assert_eq!(snapshot.holdings[1].market_value_cad, 0.0);
+        assert_eq!(snapshot.holdings[1].cost_value_cad, 0.0);
+        assert_eq!(snapshot.holdings[1].gain_loss, 0.0);
+
+        // Portfolio totals exclude the holding with missing FX
+        assert!((snapshot.total_value - 1100.0).abs() < 0.001);
+        assert!((snapshot.total_cost - 1000.0).abs() < 0.001);
     }
 }

--- a/src-tauri/src/fx.rs
+++ b/src-tauri/src/fx.rs
@@ -46,23 +46,25 @@ pub async fn fetch_all_fx_rates(
         .collect()
 }
 
-pub fn convert_to_base(amount: f64, from_currency: &str, base: &str, rates: &[FxRate]) -> f64 {
+pub fn convert_to_base(
+    amount: f64,
+    from_currency: &str,
+    base: &str,
+    rates: &[FxRate],
+) -> Result<f64, String> {
     let from_upper = from_currency.to_uppercase();
     let base_upper = base.to_uppercase();
     if from_upper == base_upper {
-        return amount;
+        return Ok(amount);
     }
 
     let pair = format!("{}{}", from_upper, base_upper);
     match rates.iter().find(|r| r.pair == pair) {
-        Some(rate) => amount * rate.rate,
-        None => {
-            eprintln!(
-                "FX rate not found for {} → {}, returning unconverted amount",
-                from_currency, base
-            );
-            amount
-        }
+        Some(rate) => Ok(amount * rate.rate),
+        None => Err(format!(
+            "FX rate not found for {} → {}",
+            from_currency, base
+        )),
     }
 }
 
@@ -81,29 +83,44 @@ mod tests {
     #[test]
     fn base_passthrough_returns_amount_unchanged() {
         let rates = vec![make_rate("USDCAD", 1.36)];
-        assert_eq!(convert_to_base(100.0, "CAD", "CAD", &rates), 100.0);
-        assert_eq!(convert_to_base(100.0, "cad", "CAD", &rates), 100.0);
-        assert_eq!(convert_to_base(100.0, "USD", "USD", &rates), 100.0);
+        assert_eq!(convert_to_base(100.0, "CAD", "CAD", &rates), Ok(100.0));
+        assert_eq!(convert_to_base(100.0, "cad", "CAD", &rates), Ok(100.0));
+        assert_eq!(convert_to_base(100.0, "USD", "USD", &rates), Ok(100.0));
     }
 
     #[test]
     fn usd_converts_to_cad_correctly() {
         let rates = vec![make_rate("USDCAD", 1.36)];
-        let result = convert_to_base(100.0, "USD", "CAD", &rates);
+        let result = convert_to_base(100.0, "USD", "CAD", &rates).expect("rate should be found");
         assert!((result - 136.0).abs() < 0.001);
     }
 
     #[test]
     fn cad_converts_to_usd_correctly() {
         let rates = vec![make_rate("CADUSD", 0.735)];
-        let result = convert_to_base(100.0, "CAD", "USD", &rates);
+        let result = convert_to_base(100.0, "CAD", "USD", &rates).expect("rate should be found");
         assert!((result - 73.5).abs() < 0.001);
     }
 
     #[test]
-    fn missing_rate_returns_amount_unchanged() {
+    fn missing_rate_returns_err() {
         let result = convert_to_base(200.0, "EUR", "CAD", &[]);
-        assert_eq!(result, 200.0);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("EUR") && err.contains("CAD"),
+            "error message should name the currencies, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn present_rate_returns_ok_with_converted_value() {
+        let rates = vec![make_rate("EURCAD", 1.45)];
+        let result = convert_to_base(100.0, "EUR", "CAD", &rates);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert!((value - 145.0).abs() < 0.001);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **#92** — `convert_to_base` in `fx.rs` now returns `Result<f64, String>`. When a required FX rate is missing, it returns `Err(...)` instead of silently treating the amount as 1:1.
- Holdings with missing FX rates are excluded from portfolio totals entirely (set to `0.0`) rather than contributing wrong values
- Error is logged via `eprintln!` with the holding symbol and reason

## Test plan
- [x] `missing_rate_returns_err` test verifies the new behaviour
- [x] `present_rate_returns_ok_with_converted_value` verifies normal path unchanged
- [x] 40 total Rust tests pass
- [ ] Add a holding in EUR when EURCAD rate isn't cached → verify portfolio total excludes it rather than using wrong value

Closes #92