### PR TITLE
fix: replace HashMap cache clear-all with LRU eviction (#103)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1585,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2171,6 +2179,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2860,6 +2877,7 @@ dependencies = [
  "chrono",
  "csv",
  "futures",
+ "lru",
  "reqwest",
  "rusqlite",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ rusqlite = { version = "0.38", features = ["bundled"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 futures = "0.3"
 csv = "1.3"
+lru = "0.12"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -52,15 +53,17 @@ pub(crate) struct SearchCacheEntry {
     cached_at: Instant,
 }
 
-pub struct SearchCacheState(pub Mutex<HashMap<String, SearchCacheEntry>>);
+pub struct SearchCacheState(pub Mutex<lru::LruCache<String, SearchCacheEntry>>);
 
 impl SearchCacheState {
     pub fn new() -> Self {
-        SearchCacheState(Mutex::new(HashMap::new()))
+        let capacity =
+            NonZeroUsize::new(crate::config::SEARCH_CACHE_MAX_ENTRIES).unwrap_or(NonZeroUsize::new(200).unwrap());
+        SearchCacheState(Mutex::new(lru::LruCache::new(capacity)))
     }
 
     fn get(&self, key: &str) -> Option<Vec<SymbolResult>> {
-        let cache = self.0.lock().ok()?;
+        let mut cache = self.0.lock().ok()?;
         let entry = cache.get(key)?;
         if entry.cached_at.elapsed()
             > Duration::from_secs(crate::config::SEARCH_CACHE_TTL_SECS as u64)
@@ -72,10 +75,7 @@ impl SearchCacheState {
 
     fn set(&self, key: String, results: Vec<SymbolResult>) {
         if let Ok(mut cache) = self.0.lock() {
-            if cache.len() >= crate::config::SEARCH_CACHE_MAX_ENTRIES {
-                cache.clear();
-            }
-            cache.insert(
+            cache.put(
                 key,
                 SearchCacheEntry {
                     results,
@@ -1140,6 +1140,43 @@ mod tests {
         assert!((snapshot.holdings[1].market_value_cad - 220.0).abs() < 0.001);
         assert!((snapshot.total_value - 396.0).abs() < 0.001);
         assert!((snapshot.total_cost - 360.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn search_cache_lru_evicts_oldest_not_all() {
+        // Build a cache with capacity 200 (matches SEARCH_CACHE_MAX_ENTRIES).
+        let capacity = NonZeroUsize::new(200).unwrap();
+        let mut cache: lru::LruCache<String, ()> = lru::LruCache::new(capacity);
+
+        // Fill all 200 slots with keys "key-0" … "key-199".
+        for i in 0..200 {
+            cache.put(format!("key-{}", i), ());
+        }
+        assert_eq!(cache.len(), 200);
+
+        // Insert the 201st entry — LRU should evict "key-0" (least-recently used).
+        cache.put("key-200".to_string(), ());
+
+        // Cache is still 200 entries (not 0).
+        assert_eq!(cache.len(), 200, "cache should hold 200 entries after LRU eviction, not be cleared");
+
+        // The oldest entry ("key-0") was evicted.
+        assert!(
+            cache.peek("key-0").is_none(),
+            "key-0 (oldest) should have been evicted"
+        );
+
+        // The most-recently inserted entry is present.
+        assert!(
+            cache.peek("key-200").is_some(),
+            "key-200 (newest) should still be in cache"
+        );
+
+        // Entry 199 (inserted just before 200) is still present.
+        assert!(
+            cache.peek("key-199").is_some(),
+            "key-199 should still be in cache"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **#103** — Symbol validation cache replaced from `HashMap` with `lru::LruCache`. When the 201st symbol is validated, the **least-recently-used** entry is evicted instead of clearing all 200 entries at once.
- Added `lru = "0.12"` to `Cargo.toml`

## Test plan
- [x] `search_cache_lru_evicts_oldest_not_all` test: fills to 200, inserts 201st, verifies oldest evicted and newest retained
- [x] 39 total Rust tests pass
- [ ] Validate 200+ unique symbols → confirm earlier symbols not re-fetched unnecessarily

Closes #103