### PR TITLE
feat: add keyboard shortcuts and help overlay (#119)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { Dashboard } from './components/Dashboard';
@@ -9,21 +9,17 @@ import { ToastProvider } from './components/ui/Toast';
 import { useToast } from './components/ui/Toast';
 import { PortfolioProvider, usePortfolio } from './hooks/usePortfolio';
 import { useConfig } from './hooks/useConfig';
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { KeyboardShortcutsOverlay } from './components/KeyboardShortcutsOverlay';
 import { CurrencyContext } from './lib/currencyContext';
 import { formatCompact } from './lib/format';
-
-const ROUTE_KEYS: Record<string, string> = {
-  '1': '/',
-  '2': '/holdings',
-  '3': '/performance',
-  '4': '/stress',
-};
 
 function AppRoutes() {
   const { portfolio, loading, error, refreshPrices } = usePortfolio();
   const navigate = useNavigate();
   const { showToast } = useToast();
   const { value: baseCurrency, setValue: setBaseCurrency } = useConfig('base_currency', 'CAD');
+  const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
 
   // Dynamic document title
   useEffect(() => {
@@ -34,29 +30,21 @@ function AppRoutes() {
     }
   }, [portfolio]);
 
-  // Keyboard shortcuts
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      const isMeta = e.metaKey || e.ctrlKey;
-      const tag = (e.target as HTMLElement).tagName;
-      const isInput = tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA';
+  const handleAddHolding = useCallback(() => {
+    navigate('/holdings?add=1');
+  }, [navigate]);
 
-      // Cmd/Ctrl+R \u2014 refresh prices
-      if (isMeta && e.key === 'r' && !isInput) {
-        e.preventDefault();
-        refreshPrices();
-        return;
-      }
+  const handleToggleHelp = useCallback(() => {
+    setShowShortcutsHelp((prev) => !prev);
+  }, []);
 
-      // 1\u20134 \u2014 navigate views (when not in an input)
-      if (!isMeta && !isInput && ROUTE_KEYS[e.key]) {
-        navigate(ROUTE_KEYS[e.key]);
-      }
-    }
-
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [navigate, refreshPrices]);
+  // Keyboard shortcuts via dedicated hook
+  useKeyboardShortcuts({
+    onRefresh: refreshPrices,
+    onAddHolding: handleAddHolding,
+    onNavigate: navigate,
+    onToggleHelp: handleToggleHelp,
+  });
 
   // Wire errors to toast
   useEffect(() => {
@@ -83,6 +71,10 @@ function AppRoutes() {
           <Route path="/stress" element={<StressTest />} />
         </Route>
       </Routes>
+      <KeyboardShortcutsOverlay
+        isOpen={showShortcutsHelp}
+        onClose={() => setShowShortcutsHelp(false)}
+      />
     </CurrencyContext.Provider>
   );
 }

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Upload, Download } from 'lucide-react';
 import { usePortfolio } from '../hooks/usePortfolio';
@@ -137,6 +137,21 @@ export function Holdings() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkDeletePending, setBulkDeletePending] = useState(false);
+
+  // Auto-open the add-holding modal when navigated here via keyboard shortcut (?add=1)
+  useEffect(() => {
+    if (searchParams.get('add') === '1') {
+      setModalOpen(true);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('add');
+          return next;
+        },
+        { replace: true }
+      );
+    }
+  }, [searchParams, setSearchParams]);
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const baseCurrency = portfolio?.baseCurrency ?? 'CAD';
   const columns: { key: SortKey; label: string; align: 'left' | 'right' }[] = useMemo(

--- a/src/components/KeyboardShortcutsOverlay.tsx
+++ b/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,219 @@
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+
+interface ShortcutRow {
+  keys: string[];
+  action: string;
+}
+
+const SHORTCUTS: ShortcutRow[] = [
+  { keys: ['⌘', 'R'], action: 'Refresh prices' },
+  { keys: ['⌘', 'N'], action: 'Add holding' },
+  { keys: ['⌘', '1'], action: 'Go to Dashboard' },
+  { keys: ['⌘', '2'], action: 'Go to Holdings' },
+  { keys: ['⌘', '3'], action: 'Go to Performance' },
+  { keys: ['⌘', '4'], action: 'Go to Stress Test' },
+  { keys: ['?'], action: 'Toggle this help panel' },
+  { keys: ['Esc'], action: 'Close overlays / modals' },
+];
+
+interface KeyboardShortcutsOverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function KeyboardShortcutsOverlay({ isOpen, onClose }: KeyboardShortcutsOverlayProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 100,
+        background: 'rgba(0, 0, 0, 0.6)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border-primary)',
+          borderRadius: '2px',
+          width: '100%',
+          maxWidth: 480,
+          padding: '24px',
+          position: 'relative',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 20,
+          }}
+        >
+          <h2
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontWeight: 600,
+              fontSize: 15,
+              color: 'var(--text-primary)',
+              letterSpacing: '-0.01em',
+              margin: 0,
+            }}
+          >
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'transparent',
+              border: '1px solid var(--border-primary)',
+              color: 'var(--text-secondary)',
+              borderRadius: '2px',
+              cursor: 'pointer',
+              padding: 4,
+            }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Shortcuts table */}
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <thead>
+            <tr>
+              <th
+                style={{
+                  textAlign: 'left',
+                  fontSize: 10,
+                  fontFamily: 'var(--font-mono)',
+                  color: 'var(--text-secondary)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                  fontWeight: 600,
+                  padding: '4px 0 8px 0',
+                  borderBottom: '1px solid var(--border-primary)',
+                  width: '40%',
+                }}
+              >
+                Keys
+              </th>
+              <th
+                style={{
+                  textAlign: 'left',
+                  fontSize: 10,
+                  fontFamily: 'var(--font-mono)',
+                  color: 'var(--text-secondary)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.08em',
+                  fontWeight: 600,
+                  padding: '4px 0 8px 12px',
+                  borderBottom: '1px solid var(--border-primary)',
+                }}
+              >
+                Action
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {SHORTCUTS.map((row, index) => (
+              <tr
+                key={index}
+                style={{
+                  background: index % 2 === 0 ? 'transparent' : 'var(--bg-surface-alt)',
+                }}
+              >
+                <td
+                  style={{
+                    padding: '8px 0',
+                    borderBottom: '1px solid var(--border-subtle)',
+                    verticalAlign: 'middle',
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+                    {row.keys.map((key, ki) => (
+                      <kbd
+                        key={ki}
+                        style={{
+                          display: 'inline-block',
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 11,
+                          fontWeight: 500,
+                          color: 'var(--text-primary)',
+                          background: 'var(--bg-surface-hover)',
+                          border: '1px solid var(--border-primary)',
+                          borderRadius: '2px',
+                          padding: '2px 6px',
+                          lineHeight: '1.4',
+                        }}
+                      >
+                        {key}
+                      </kbd>
+                    ))}
+                  </span>
+                </td>
+                <td
+                  style={{
+                    padding: '8px 0 8px 12px',
+                    fontSize: 13,
+                    color: 'var(--text-secondary)',
+                    borderBottom: '1px solid var(--border-subtle)',
+                    verticalAlign: 'middle',
+                  }}
+                >
+                  {row.action}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Footer hint */}
+        <p
+          style={{
+            marginTop: 16,
+            fontSize: 11,
+            color: 'var(--text-muted)',
+            fontFamily: 'var(--font-mono)',
+            textAlign: 'center',
+          }}
+        >
+          Shortcuts are disabled when focus is inside an input field.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,174 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useKeyboardShortcuts } from '../useKeyboardShortcuts';
+
+function fireKeydown(overrides: Partial<KeyboardEventInit> & { target?: EventTarget }): void {
+  const { target, ...init } = overrides;
+  const event = new KeyboardEvent('keydown', { bubbles: true, ...init });
+  if (target) {
+    Object.defineProperty(event, 'target', { value: target, configurable: true });
+  }
+  window.dispatchEvent(event);
+}
+
+describe('useKeyboardShortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls onRefresh when metaKey+r is pressed', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    fireKeydown({ key: 'r', metaKey: true });
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it('calls onRefresh when ctrlKey+r is pressed', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    fireKeydown({ key: 'r', ctrlKey: true });
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call onRefresh when target is an INPUT element', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    const inputEl = document.createElement('input');
+    fireKeydown({ key: 'r', metaKey: true, target: inputEl });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRefresh when target is a TEXTAREA element', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    const textarea = document.createElement('textarea');
+    fireKeydown({ key: 'r', metaKey: true, target: textarea });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRefresh when target is a SELECT element', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    const select = document.createElement('select');
+    fireKeydown({ key: 'r', metaKey: true, target: select });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRefresh when target is contenteditable', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onRefresh }));
+
+    const div = document.createElement('div');
+    div.contentEditable = 'true';
+    fireKeydown({ key: 'r', metaKey: true, target: div });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('calls onNavigate("/") when metaKey+1 is pressed', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate }));
+
+    fireKeydown({ key: '1', metaKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('calls onNavigate("/holdings") when metaKey+2 is pressed', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate }));
+
+    fireKeydown({ key: '2', metaKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith('/holdings');
+  });
+
+  it('calls onNavigate("/performance") when metaKey+3 is pressed', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate }));
+
+    fireKeydown({ key: '3', metaKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith('/performance');
+  });
+
+  it('calls onNavigate("/stress") when metaKey+4 is pressed', () => {
+    const onNavigate = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNavigate }));
+
+    fireKeydown({ key: '4', metaKey: true });
+
+    expect(onNavigate).toHaveBeenCalledWith('/stress');
+  });
+
+  it('calls onToggleHelp when ? key is pressed without modifier', () => {
+    const onToggleHelp = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onToggleHelp }));
+
+    fireKeydown({ key: '?' });
+
+    expect(onToggleHelp).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call onToggleHelp when ? is pressed with metaKey', () => {
+    const onToggleHelp = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onToggleHelp }));
+
+    // ? with metaKey should not trigger help
+    fireKeydown({ key: '?', metaKey: true });
+
+    expect(onToggleHelp).not.toHaveBeenCalled();
+  });
+
+  it('calls onAddHolding when metaKey+n is pressed', () => {
+    const onAddHolding = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAddHolding }));
+
+    fireKeydown({ key: 'n', metaKey: true });
+
+    expect(onAddHolding).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call onAddHolding when target is an INPUT element', () => {
+    const onAddHolding = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onAddHolding }));
+
+    const inputEl = document.createElement('input');
+    fireKeydown({ key: 'n', metaKey: true, target: inputEl });
+
+    expect(onAddHolding).not.toHaveBeenCalled();
+  });
+
+  it('removes the event listener on unmount', () => {
+    const onRefresh = vi.fn();
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() => useKeyboardShortcuts({ onRefresh }));
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+  });
+
+  it('does not throw when callbacks are undefined', () => {
+    expect(() => {
+      renderHook(() => useKeyboardShortcuts({}));
+      fireKeydown({ key: 'r', metaKey: true });
+      fireKeydown({ key: '?' });
+      fireKeydown({ key: '1', metaKey: true });
+    }).not.toThrow();
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+
+export interface KeyboardShortcutCallbacks {
+  onRefresh?: () => void;
+  onAddHolding?: () => void;
+  onNavigate?: (path: string) => void;
+  onToggleHelp?: () => void;
+}
+
+const NAVIGATE_KEYS: Record<string, string> = {
+  '1': '/',
+  '2': '/holdings',
+  '3': '/performance',
+  '4': '/stress',
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target) return false;
+  const el = target as HTMLElement;
+  const tag = el.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (el.isContentEditable) return true;
+  return false;
+}
+
+export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks): void {
+  const { onRefresh, onAddHolding, onNavigate, onToggleHelp } = callbacks;
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent): void {
+      const isMeta = e.metaKey || e.ctrlKey;
+
+      if (isEditableTarget(e.target)) return;
+
+      // Cmd/Ctrl+R — refresh prices
+      if (isMeta && e.key === 'r') {
+        e.preventDefault();
+        onRefresh?.();
+        return;
+      }
+
+      // Cmd/Ctrl+N — add holding
+      if (isMeta && e.key === 'n') {
+        e.preventDefault();
+        onAddHolding?.();
+        return;
+      }
+
+      // Cmd/Ctrl+1..4 — navigate
+      if (isMeta && NAVIGATE_KEYS[e.key]) {
+        onNavigate?.(NAVIGATE_KEYS[e.key]);
+        return;
+      }
+
+      // ? (no modifier) — toggle help
+      if (!isMeta && e.key === '?') {
+        onToggleHelp?.();
+        return;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onRefresh, onAddHolding, onNavigate, onToggleHelp]);
+}


### PR DESCRIPTION
## Summary
- **#119** — Global keyboard shortcuts for power users
  - `⌘R` / `Ctrl+R` → refresh prices
  - `⌘N` / `Ctrl+N` → open Add Holding modal
  - `⌘1–4` → navigate to Dashboard / Holdings / Performance / Stress Test
  - `?` → toggle keyboard shortcuts help overlay
- Shortcuts are suppressed when focus is inside any form input/textarea/select
- Help overlay lists all shortcuts in a clean modal with `<kbd>` styling

## Files
- New: `src/hooks/useKeyboardShortcuts.ts`
- New: `src/components/KeyboardShortcutsOverlay.tsx`
- Modified: `src/App.tsx` — registers hook, renders overlay
- Modified: `src/components/Holdings.tsx` — handles `?add=1` URL param to open modal

## Test plan
- [x] 16 new unit tests for `useKeyboardShortcuts` — all pass (25 total)
- [ ] Press `⌘R` → prices refresh
- [ ] Press `?` → overlay appears with shortcut list
- [ ] Focus a text input → `⌘R` does not trigger refresh
- [ ] Press `⌘1`–`⌘4` → correct routes loaded

Closes #119