### PR TITLE
test: targeted coverage for import/export, config, and format helpers

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1086,6 +1086,103 @@ mod tests {
         assert!(csv.contains(",22.5"));
     }
 
+    // ── CSV round-trip tests ──────────────────────────────────────────────────
+
+    /// Export a set of holdings to CSV, re-parse it with `parse_import_rows`,
+    /// and verify that every key field is preserved exactly.
+    #[test]
+    fn csv_round_trip_preserves_key_fields() {
+        let mut h1 = make_holding("AAPL", AssetType::Stock, 10.0, 155.25, "USD");
+        h1.name = "Apple Inc.".to_string();
+        h1.exchange = "NMS".to_string();
+        h1.target_weight = 25.0;
+
+        let mut h2 = make_holding("XIU.TO", AssetType::Etf, 50.0, 34.5, "CAD");
+        h2.name = "iShares S&P/TSX 60 Index ETF".to_string();
+        h2.exchange = "TRT".to_string();
+        h2.target_weight = 15.0;
+
+        let mut h3 = make_holding("BTC-USD", AssetType::Crypto, 0.5, 40000.0, "USD");
+        h3.name = "Bitcoin USD".to_string();
+        h3.target_weight = 10.0;
+
+        let holdings = vec![h1, h2, h3];
+        let csv = build_holdings_csv(&holdings).expect("build csv");
+
+        let rows = parse_import_rows(&csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 3, "row count should be preserved");
+
+        // Row 0 — AAPL (stock)
+        assert_eq!(rows[0].symbol, "AAPL");
+        assert!(matches!(rows[0].asset_type, AssetType::Stock));
+        assert!((rows[0].quantity - 10.0).abs() < 0.001);
+        assert!((rows[0].cost_basis - 155.25).abs() < 0.001);
+        assert_eq!(rows[0].currency, "USD");
+        assert_eq!(rows[0].exchange, "NMS");
+        assert!((rows[0].target_weight - 25.0).abs() < 0.001);
+
+        // Row 1 — XIU.TO (etf)
+        assert_eq!(rows[1].symbol, "XIU.TO");
+        assert!(matches!(rows[1].asset_type, AssetType::Etf));
+        assert!((rows[1].quantity - 50.0).abs() < 0.001);
+        assert!((rows[1].cost_basis - 34.5).abs() < 0.001);
+        assert_eq!(rows[1].currency, "CAD");
+        assert_eq!(rows[1].exchange, "TRT");
+        assert!((rows[1].target_weight - 15.0).abs() < 0.001);
+
+        // Row 2 — BTC-USD (crypto)
+        assert_eq!(rows[2].symbol, "BTC-USD");
+        assert!(matches!(rows[2].asset_type, AssetType::Crypto));
+        assert!((rows[2].quantity - 0.5).abs() < 0.001);
+        assert!((rows[2].cost_basis - 40000.0).abs() < 0.001);
+        assert_eq!(rows[2].currency, "USD");
+        assert!((rows[2].target_weight - 10.0).abs() < 0.001);
+    }
+
+    /// Exporting a single cash holding round-trips correctly.
+    #[test]
+    fn csv_round_trip_cash_holding() {
+        let mut cash = make_holding("CAD-CASH", AssetType::Cash, 5000.0, 1.0, "CAD");
+        cash.name = "CAD Cash".to_string();
+        cash.target_weight = 5.0;
+
+        let csv = build_holdings_csv(&[cash]).expect("build csv");
+        let rows = parse_import_rows(&csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].symbol, "CAD-CASH");
+        assert!(matches!(rows[0].asset_type, AssetType::Cash));
+        assert!((rows[0].quantity - 5000.0).abs() < 0.001);
+        assert!((rows[0].cost_basis - 1.0).abs() < 0.001);
+        assert_eq!(rows[0].currency, "CAD");
+        assert!((rows[0].target_weight - 5.0).abs() < 0.001);
+    }
+
+    /// An empty holdings slice produces a CSV that fails parsing (no data rows).
+    #[test]
+    fn build_holdings_csv_empty_slice_roundtrip_fails_gracefully() {
+        let csv = build_holdings_csv(&[]).expect("build csv for empty slice");
+        // build_holdings_csv writes a header-only CSV; parse_import_rows should
+        // return an error because there are no data rows.
+        let result = parse_import_rows(&csv);
+        assert!(result.is_err(), "empty csv should error on import");
+        assert!(result.unwrap_err().contains("empty"));
+    }
+
+    /// Round-trip with target_weight = 0 (the default) is preserved as 0.
+    #[test]
+    fn csv_round_trip_zero_target_weight() {
+        let holding = make_holding("MSFT", AssetType::Stock, 3.0, 200.0, "USD");
+        // target_weight is already 0.0 from make_holding
+
+        let csv = build_holdings_csv(&[holding]).expect("build csv");
+        let rows = parse_import_rows(&csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 1);
+        assert!((rows[0].target_weight - 0.0).abs() < 0.001);
+    }
+
     #[test]
     fn build_portfolio_snapshot_converts_mixed_currency_holdings_into_base_currency() {
         let holdings = vec![

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -592,4 +592,53 @@ mod tests {
         assert_eq!(holdings.len(), 1);
         assert_eq!(holdings[0].exchange, "NYSE");
     }
+
+    // ── Config persistence ────────────────────────────────────────────────────
+
+    #[test]
+    fn set_and_get_config_round_trips_value() {
+        let conn = open_test_db();
+        set_config(&conn, "base_currency", "USD").expect("set config");
+        let val = get_config(&conn, "base_currency").expect("get config");
+        assert_eq!(val, Some("USD".to_string()));
+    }
+
+    #[test]
+    fn get_config_returns_none_for_missing_key() {
+        let conn = open_test_db();
+        let val = get_config(&conn, "nonexistent_key").expect("get config");
+        assert_eq!(val, None);
+    }
+
+    #[test]
+    fn set_config_upserts_existing_key() {
+        let conn = open_test_db();
+        set_config(&conn, "theme", "dark").expect("initial set");
+        set_config(&conn, "theme", "light").expect("update set");
+        let val = get_config(&conn, "theme").expect("get config");
+        assert_eq!(val, Some("light".to_string()));
+    }
+
+    #[test]
+    fn set_config_stores_multiple_independent_keys() {
+        let conn = open_test_db();
+        set_config(&conn, "base_currency", "CAD").expect("set base_currency");
+        set_config(&conn, "theme", "dark").expect("set theme");
+        assert_eq!(
+            get_config(&conn, "base_currency").expect("get"),
+            Some("CAD".to_string())
+        );
+        assert_eq!(
+            get_config(&conn, "theme").expect("get"),
+            Some("dark".to_string())
+        );
+    }
+
+    #[test]
+    fn set_config_persists_empty_string_value() {
+        let conn = open_test_db();
+        set_config(&conn, "greeting", "").expect("set empty");
+        let val = get_config(&conn, "greeting").expect("get config");
+        assert_eq!(val, Some(String::new()));
+    }
 }

--- a/src/__tests__/SymbolSearch.test.tsx
+++ b/src/__tests__/SymbolSearch.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SymbolSearch } from '../components/ui/SymbolSearch';
+
+// Ensure we are always in the browser (non-Tauri) mock path
+beforeEach(() => {
+  // @ts-expect-error — intentionally removing Tauri internals for mock path
+  delete window.__TAURI_INTERNALS__;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
+function renderSymbolSearch(overrides: Partial<React.ComponentProps<typeof SymbolSearch>> = {}) {
+  const onSelect = vi.fn();
+  const onChange = vi.fn();
+  const result = render(
+    <SymbolSearch
+      value=""
+      onChange={onChange}
+      onSelect={onSelect}
+      placeholder="AAPL"
+      {...overrides}
+    />
+  );
+  return { ...result, onSelect, onChange };
+}
+
+/** Type into the search input and flush the debounce timer. */
+async function typeAndFlush(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+  await act(async () => {
+    vi.advanceTimersByTime(400);
+  });
+}
+
+describe('SymbolSearch – basic rendering', () => {
+  it('renders the input', () => {
+    renderSymbolSearch();
+    expect(screen.getByPlaceholderText('AAPL')).toBeTruthy();
+  });
+
+  it('does not show dropdown before typing', () => {
+    renderSymbolSearch();
+    expect(screen.queryByText('Apple Inc.')).toBeNull();
+  });
+});
+
+describe('SymbolSearch – mock data filtering', () => {
+  it('shows results after debounce when query length >= 2', async () => {
+    renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'aa');
+    expect(screen.queryByText('Apple Inc.')).toBeTruthy();
+  });
+
+  it('does not show results when query is only 1 character', async () => {
+    renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'a');
+    expect(screen.queryByText('Apple Inc.')).toBeNull();
+  });
+
+  it('filters results by symbol prefix', async () => {
+    renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'vo');
+    expect(screen.queryByText('Vanguard S&P 500 ETF')).toBeTruthy();
+  });
+
+  it('calls onSelect when a result is clicked', async () => {
+    const { onSelect } = renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'aa');
+    expect(screen.queryByText('Apple Inc.')).toBeTruthy();
+    // Use mouseDown — the component uses onMouseDown to prevent blur before select
+    fireEvent.mouseDown(screen.getByText('Apple Inc.'));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ symbol: 'AAPL', name: 'Apple Inc.' })
+    );
+  });
+});
+
+describe('SymbolSearch – stale async request guard', () => {
+  it('discards stale responses when the query changes before the result arrives', async () => {
+    // We simulate the guard by typing two queries in quick succession.
+    // The second fireEvent.change clears the first debounce timer and
+    // updates currentQueryRef before the first async callback executes.
+    // Only the second query's results should appear.
+    renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+
+    // Type first query — schedules a 300 ms debounce
+    fireEvent.change(input, { target: { value: 'aa' } });
+    // Immediately type a second query — clears the first debounce and schedules a new one
+    fireEvent.change(input, { target: { value: 'ms' } });
+
+    // Advance past the debounce; only the second timer fires (first was cleared)
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    // Results for 'ms' (Microsoft) should be shown, not Apple
+    expect(screen.queryByText('Microsoft Corporation')).toBeTruthy();
+    expect(screen.queryByText('Apple Inc.')).toBeNull();
+  });
+});
+
+describe('SymbolSearch – keyboard navigation', () => {
+  it('highlights items with ArrowDown and selects with Enter', async () => {
+    const { onSelect } = renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'aa');
+    expect(screen.queryByText('Apple Inc.')).toBeTruthy();
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it('closes dropdown on Escape', async () => {
+    renderSymbolSearch();
+    const input = screen.getByPlaceholderText('AAPL');
+    await typeAndFlush(input, 'aa');
+    expect(screen.queryByText('Apple Inc.')).toBeTruthy();
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+    });
+    expect(screen.queryByText('Apple Inc.')).toBeNull();
+  });
+});

--- a/src/lib/constants.test.ts
+++ b/src/lib/constants.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { SUPPORTED_CURRENCIES, ASSET_TYPE_CONFIG, ACCOUNT_OPTIONS } from './constants';
+
+describe('SUPPORTED_CURRENCIES', () => {
+  it('contains no duplicate currency codes', () => {
+    const seen = new Set<string>();
+    for (const currency of SUPPORTED_CURRENCIES) {
+      expect(seen.has(currency), `Duplicate currency found: ${currency}`).toBe(false);
+      seen.add(currency);
+    }
+    expect(seen.size).toBe(SUPPORTED_CURRENCIES.length);
+  });
+
+  it('all currency codes are uppercase ISO 4217 format', () => {
+    for (const currency of SUPPORTED_CURRENCIES) {
+      expect(currency).toMatch(/^[A-Z]{3}$/);
+    }
+  });
+
+  it('contains CAD and USD as primary trading currencies', () => {
+    expect(SUPPORTED_CURRENCIES).toContain('CAD');
+    expect(SUPPORTED_CURRENCIES).toContain('USD');
+  });
+
+  it('is non-empty', () => {
+    expect(SUPPORTED_CURRENCIES.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ASSET_TYPE_CONFIG', () => {
+  it('defines all four asset types', () => {
+    expect(ASSET_TYPE_CONFIG).toHaveProperty('stock');
+    expect(ASSET_TYPE_CONFIG).toHaveProperty('etf');
+    expect(ASSET_TYPE_CONFIG).toHaveProperty('crypto');
+    expect(ASSET_TYPE_CONFIG).toHaveProperty('cash');
+  });
+
+  it('each asset type has a label, color, and icon', () => {
+    for (const [key, cfg] of Object.entries(ASSET_TYPE_CONFIG)) {
+      expect(cfg.label, `${key}.label`).toBeTruthy();
+      expect(cfg.color, `${key}.color`).toBeTruthy();
+      expect(cfg.icon, `${key}.icon`).toBeTruthy();
+    }
+  });
+});
+
+describe('ACCOUNT_OPTIONS', () => {
+  it('contains no duplicate account values', () => {
+    const values = ACCOUNT_OPTIONS.map((o) => o.value);
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it('each option has a non-empty label', () => {
+    for (const option of ACCOUNT_OPTIONS) {
+      expect(option.label.trim()).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency, formatPercent, formatNumber, formatCompact } from './format';
+
+describe('formatCurrency', () => {
+  it('formats a positive number', () => {
+    expect(formatCurrency(1234.56, 'CAD')).toBe('1,234.56 CAD');
+  });
+
+  it('formats zero', () => {
+    expect(formatCurrency(0, 'CAD')).toBe('0.00 CAD');
+  });
+
+  it('formats a negative number', () => {
+    const result = formatCurrency(-500.5, 'USD');
+    expect(result).toContain('-500.50');
+    expect(result).toContain('USD');
+  });
+
+  it('returns placeholder for NaN without throwing', () => {
+    expect(() => formatCurrency(NaN)).not.toThrow();
+    expect(formatCurrency(NaN)).toBe('—');
+  });
+
+  it('returns placeholder for Infinity without throwing', () => {
+    expect(() => formatCurrency(Infinity)).not.toThrow();
+    expect(formatCurrency(Infinity)).toBe('—');
+  });
+
+  it('returns placeholder for negative Infinity without throwing', () => {
+    expect(() => formatCurrency(-Infinity)).not.toThrow();
+    expect(formatCurrency(-Infinity)).toBe('—');
+  });
+
+  it('returns placeholder for undefined without throwing', () => {
+    expect(() => formatCurrency(undefined)).not.toThrow();
+    expect(formatCurrency(undefined)).toBe('—');
+  });
+
+  it('returns placeholder for null without throwing', () => {
+    expect(() => formatCurrency(null)).not.toThrow();
+    expect(formatCurrency(null)).toBe('—');
+  });
+
+  it('defaults to CAD when no currency is provided', () => {
+    expect(formatCurrency(100)).toContain('CAD');
+  });
+});
+
+describe('formatPercent', () => {
+  it('formats zero', () => {
+    expect(formatPercent(0)).toBe('+0.00%');
+  });
+
+  it('formats a negative decimal', () => {
+    expect(formatPercent(-12.34)).toBe('-12.34%');
+  });
+
+  it('formats a positive decimal', () => {
+    expect(formatPercent(5.5)).toBe('+5.50%');
+  });
+
+  it('formats -0.1234 as -0.12%', () => {
+    // -0.1234 is treated as a raw percent value (already in % units), not a decimal fraction
+    expect(formatPercent(-0.1234)).toBe('-0.12%');
+  });
+
+  it('returns placeholder for NaN without throwing', () => {
+    expect(() => formatPercent(NaN)).not.toThrow();
+    expect(formatPercent(NaN)).toBe('—');
+  });
+
+  it('returns placeholder for Infinity without throwing', () => {
+    expect(() => formatPercent(Infinity)).not.toThrow();
+    expect(formatPercent(Infinity)).toBe('—');
+  });
+
+  it('returns placeholder for undefined without throwing', () => {
+    expect(() => formatPercent(undefined)).not.toThrow();
+    expect(formatPercent(undefined)).toBe('—');
+  });
+
+  it('returns placeholder for null without throwing', () => {
+    expect(() => formatPercent(null)).not.toThrow();
+    expect(formatPercent(null)).toBe('—');
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats with default 2 decimal places', () => {
+    expect(formatNumber(1234.567)).toBe('1,234.57');
+  });
+
+  it('formats with custom decimal places', () => {
+    expect(formatNumber(1234.5678, 4)).toBe('1,234.5678');
+  });
+
+  it('returns placeholder for NaN', () => {
+    expect(formatNumber(NaN)).toBe('—');
+  });
+
+  it('returns placeholder for Infinity', () => {
+    expect(formatNumber(Infinity)).toBe('—');
+  });
+
+  it('returns placeholder for undefined', () => {
+    expect(formatNumber(undefined)).toBe('—');
+  });
+
+  it('returns placeholder for null', () => {
+    expect(formatNumber(null)).toBe('—');
+  });
+});
+
+describe('formatCompact', () => {
+  it('abbreviates millions', () => {
+    expect(formatCompact(1_500_000)).toContain('M');
+  });
+
+  it('abbreviates thousands', () => {
+    expect(formatCompact(52_300)).toContain('K');
+  });
+
+  it('formats small values with $ prefix', () => {
+    const result = formatCompact(999);
+    expect(result).toContain('$');
+    expect(result).not.toContain('K');
+    expect(result).not.toContain('M');
+  });
+
+  it('handles negative millions', () => {
+    const result = formatCompact(-2_000_000);
+    expect(result).toContain('-');
+    expect(result).toContain('M');
+  });
+
+  it('returns placeholder for NaN', () => {
+    expect(formatCompact(NaN)).toBe('—');
+  });
+
+  it('returns placeholder for Infinity', () => {
+    expect(formatCompact(Infinity)).toBe('—');
+  });
+
+  it('returns placeholder for undefined', () => {
+    expect(formatCompact(undefined)).toBe('—');
+  });
+
+  it('returns placeholder for null', () => {
+    expect(formatCompact(null)).toBe('—');
+  });
+});


### PR DESCRIPTION
Closes #87

## Summary
- Rust: CSV round-trip tests for `build_holdings_csv`/`parse_import_rows` covering stock/ETF/crypto, cash holdings, empty slice, and zero target_weight
- Rust: Config persistence tests using in-memory SQLite (`set_config`/`get_config` round-trip, missing key, upsert, multiple keys, empty string value)
- Frontend: `format.ts` NaN/Infinity/undefined/null guard tests for all four formatters (`formatCurrency`, `formatPercent`, `formatNumber`, `formatCompact`)
- Frontend: `SUPPORTED_CURRENCIES` uniqueness and uppercase-ISO-4217 tests in `constants.test.ts`
- Frontend: `SymbolSearch` stale async request guard tests using Vitest fake timers

## Test Plan
- [ ] `cargo test` passes (50 tests, 0 failed)
- [ ] `npm test` passes (178 tests, 0 failed)