### PR TITLE
feat: add portfolio rebalancing tool with drift analysis (#106)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,7 +14,8 @@ use crate::stress::run_stress_test;
 use crate::types::{
     AccountType, AssetType, FxRate, Holding, HoldingInput, HoldingWithPrice, ImportError,
     ImportResult, PerformancePoint, PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceAlert,
-    PriceAlertInput, PriceData, RefreshResult, StressResult, StressScenario, SymbolResult,
+    PriceAlertInput, PriceData, RebalanceSuggestion, RefreshResult, StressResult, StressScenario,
+    SymbolResult,
 };
 
 const MAX_IMPORT_ROWS: usize = 500;
@@ -1073,6 +1074,80 @@ pub async fn import_data(state: State<'_, DbState>, json: String) -> Result<usiz
         db::insert_holding_with_id(&conn, holding).map_err(|e| e.to_string())?;
     }
     Ok(count)
+}
+
+#[tauri::command]
+pub async fn get_rebalance_suggestions(
+    db: State<'_, DbState>,
+    drift_threshold: f64,
+) -> Result<Vec<RebalanceSuggestion>, String> {
+    let base_currency = get_base_currency(&db);
+
+    let holdings = {
+        let conn = db.0.lock().map_err(|e| e.to_string())?;
+        db::get_all_holdings(&conn)?
+    };
+
+    let (cached_prices, cached_fx) = {
+        let conn = db.0.lock().map_err(|e| e.to_string())?;
+        (db::get_cached_prices(&conn)?, db::get_fx_rates(&conn)?)
+    };
+
+    let snapshot = build_portfolio_snapshot(
+        &holdings,
+        &cached_prices,
+        &cached_fx,
+        &base_currency,
+        Utc::now().to_rfc3339(),
+    );
+
+    let total_value = snapshot.total_value;
+
+    let mut suggestions: Vec<RebalanceSuggestion> = snapshot
+        .holdings
+        .into_iter()
+        .filter(|h| {
+            // Exclude cash holdings and holdings with no target weight
+            h.asset_type.as_str() != "cash" && h.target_weight > 0.0
+        })
+        .filter_map(|h| {
+            let target_value_cad = total_value * (h.target_weight / 100.0);
+            let drift = h.weight - h.target_weight;
+            if drift.abs() < drift_threshold {
+                return None;
+            }
+            // positive = sell (over-weight), negative = buy (under-weight)
+            let suggested_trade_cad = h.market_value_cad - target_value_cad;
+            let suggested_units = if h.current_price_cad != 0.0 {
+                suggested_trade_cad / h.current_price_cad
+            } else {
+                0.0
+            };
+            Some(RebalanceSuggestion {
+                holding_id: h.id,
+                symbol: h.symbol,
+                name: h.name,
+                current_value_cad: h.market_value_cad,
+                target_value_cad,
+                current_weight: h.weight,
+                target_weight: h.target_weight,
+                drift,
+                suggested_trade_cad,
+                suggested_units,
+                current_price_cad: h.current_price_cad,
+            })
+        })
+        .collect();
+
+    // Sort by |drift| descending — biggest drifters first
+    suggestions.sort_by(|a, b| {
+        b.drift
+            .abs()
+            .partial_cmp(&a.drift.abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(suggestions)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub fn run() {
             commands::add_alert,
             commands::delete_alert,
             commands::reset_alert,
+            commands::get_rebalance_suggestions,
         ])
         .run(tauri::generate_context!());
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -312,3 +312,19 @@ pub struct RefreshResult {
     /// Symbols for which the price fetch failed (network error, HTTP error, parse failure).
     pub failed_symbols: Vec<String>,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebalanceSuggestion {
+    pub holding_id: String,
+    pub symbol: String,
+    pub name: String,
+    pub current_value_cad: f64,
+    pub target_value_cad: f64,
+    pub current_weight: f64,   // actual % of portfolio
+    pub target_weight: f64,    // user-set target %
+    pub drift: f64,            // current_weight - target_weight (percentage points)
+    pub suggested_trade_cad: f64,  // positive = sell, negative = buy
+    pub suggested_units: f64,      // positive = sell, negative = buy
+    pub current_price_cad: f64,
+}

--- a/src/components/Rebalance.tsx
+++ b/src/components/Rebalance.tsx
@@ -1,0 +1,545 @@
+import { useState, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Download, RefreshCw } from 'lucide-react';
+import { Spinner } from './ui/Spinner';
+import { formatCurrency, formatNumber, formatPercent } from '../lib/format';
+import type { RebalanceSuggestion } from '../types/portfolio';
+
+const DEFAULT_DRIFT_THRESHOLD = 5;
+
+function DriftBadge({ drift }: { drift: number }) {
+  const isOver = drift > 0;
+  const color = isOver ? 'var(--color-loss)' : 'var(--color-accent)';
+  const label = isOver ? `+${drift.toFixed(2)}pp` : `${drift.toFixed(2)}pp`;
+  return (
+    <span
+      style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 13,
+        color,
+        fontWeight: 600,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function TradeCell({ suggestion }: { suggestion: RebalanceSuggestion }) {
+  const isSell = suggestion.suggestedTradeCad > 0;
+  const color = isSell ? 'var(--color-loss)' : 'var(--color-gain)';
+  const action = isSell ? 'Sell' : 'Buy';
+  const units = Math.abs(suggestion.suggestedUnits);
+  return (
+    <span
+      style={{
+        fontFamily: 'var(--font-mono)',
+        fontSize: 13,
+        color,
+        fontWeight: 600,
+      }}
+    >
+      {action} {formatNumber(units, 4)} units
+    </span>
+  );
+}
+
+function buildCsvContent(suggestions: RebalanceSuggestion[]): string {
+  const header = [
+    'symbol',
+    'name',
+    'current_weight_%',
+    'target_weight_%',
+    'drift_pp',
+    'action',
+    'units',
+    'amount_cad',
+    'current_price_cad',
+  ].join(',');
+
+  const rows = suggestions.map((s) => {
+    const action = s.suggestedTradeCad > 0 ? 'sell' : 'buy';
+    const units = Math.abs(s.suggestedUnits).toFixed(4);
+    const amount = Math.abs(s.suggestedTradeCad).toFixed(2);
+    return [
+      s.symbol,
+      `"${s.name.replace(/"/g, '""')}"`,
+      s.currentWeight.toFixed(2),
+      s.targetWeight.toFixed(2),
+      s.drift.toFixed(2),
+      action,
+      units,
+      amount,
+      s.currentPriceCad.toFixed(4),
+    ].join(',');
+  });
+
+  return [header, ...rows].join('\n');
+}
+
+export function Rebalance() {
+  const [driftThreshold, setDriftThreshold] = useState(DEFAULT_DRIFT_THRESHOLD);
+  const [suggestions, setSuggestions] = useState<RebalanceSuggestion[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchSuggestions = useCallback(async (threshold: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await invoke<RebalanceSuggestion[]>('get_rebalance_suggestions', {
+        driftThreshold: threshold,
+      });
+      setSuggestions(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSuggestions(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleThresholdChange = useCallback(
+    (value: number) => {
+      setDriftThreshold(value);
+      void fetchSuggestions(value);
+    },
+    [fetchSuggestions]
+  );
+
+  const handleRefresh = useCallback(() => {
+    void fetchSuggestions(driftThreshold);
+  }, [fetchSuggestions, driftThreshold]);
+
+  const handleExport = useCallback(async () => {
+    if (!suggestions || suggestions.length === 0) return;
+    const csv = buildCsvContent(suggestions);
+    try {
+      await navigator.clipboard.writeText(csv);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: create a temporary textarea
+      const textarea = document.createElement('textarea');
+      textarea.value = csv;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [suggestions]);
+
+  // Load on first render
+  const [initialized, setInitialized] = useState(false);
+  if (!initialized) {
+    setInitialized(true);
+    void fetchSuggestions(driftThreshold);
+  }
+
+  return (
+    <div
+      style={{
+        padding: '24px 32px',
+        height: '100%',
+        overflowY: 'auto',
+        boxSizing: 'border-box',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 24,
+          flexWrap: 'wrap',
+          gap: 12,
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              margin: 0,
+              fontSize: 20,
+              fontWeight: 600,
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            Rebalance
+          </h1>
+          <p
+            style={{
+              margin: '4px 0 0',
+              fontSize: 13,
+              color: 'var(--text-secondary)',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            Holdings that have drifted from their target allocation
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          {/* Drift threshold control */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border-primary)',
+              borderRadius: 2,
+              padding: '6px 12px',
+            }}
+          >
+            <label
+              htmlFor="drift-threshold"
+              style={{
+                fontSize: 12,
+                color: 'var(--text-secondary)',
+                fontFamily: 'var(--font-sans)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Show drift &gt;
+            </label>
+            <input
+              id="drift-threshold"
+              type="number"
+              min={0}
+              max={50}
+              step={1}
+              value={driftThreshold}
+              onChange={(e) => {
+                const val = Math.max(0, Math.min(50, Number(e.target.value)));
+                handleThresholdChange(val);
+              }}
+              style={{
+                width: 52,
+                background: 'var(--bg-surface-hover)',
+                border: '1px solid var(--border-primary)',
+                borderRadius: 2,
+                color: 'var(--text-primary)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 13,
+                padding: '2px 6px',
+                outline: 'none',
+                textAlign: 'right',
+              }}
+            />
+            <span
+              style={{
+                fontSize: 12,
+                color: 'var(--text-secondary)',
+                fontFamily: 'var(--font-sans)',
+              }}
+            >
+              %
+            </span>
+          </div>
+
+          {/* Refresh */}
+          <button
+            onClick={handleRefresh}
+            disabled={loading}
+            title="Refresh rebalance suggestions"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 14px',
+              background: 'transparent',
+              border: '1px solid var(--border-primary)',
+              borderRadius: 2,
+              color: 'var(--text-secondary)',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              fontSize: 13,
+              fontFamily: 'var(--font-sans)',
+              transition: 'color 150ms, border-color 150ms',
+              opacity: loading ? 0.5 : 1,
+            }}
+          >
+            <RefreshCw size={14} />
+            Refresh
+          </button>
+
+          {/* Export CSV */}
+          <button
+            onClick={() => void handleExport()}
+            disabled={!suggestions || suggestions.length === 0}
+            title="Copy trade list as CSV"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 14px',
+              background: 'var(--color-accent)',
+              border: 'none',
+              borderRadius: 2,
+              color: '#fff',
+              cursor: !suggestions || suggestions.length === 0 ? 'not-allowed' : 'pointer',
+              fontSize: 13,
+              fontFamily: 'var(--font-sans)',
+              fontWeight: 500,
+              opacity: !suggestions || suggestions.length === 0 ? 0.4 : 1,
+              transition: 'opacity 150ms',
+            }}
+          >
+            <Download size={14} />
+            {copied ? 'Copied!' : 'Export CSV'}
+          </button>
+        </div>
+      </div>
+
+      {/* Loading state */}
+      {loading && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 64,
+          }}
+        >
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {/* Error state */}
+      {!loading && error && (
+        <div
+          style={{
+            padding: '16px 20px',
+            background: 'rgba(255,71,87,0.08)',
+            border: '1px solid rgba(255,71,87,0.3)',
+            borderRadius: 2,
+            color: 'var(--color-loss)',
+            fontSize: 13,
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Empty state — no holdings have target weights */}
+      {!loading && !error && suggestions !== null && suggestions.length === 0 && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '80px 32px',
+            textAlign: 'center',
+            color: 'var(--text-secondary)',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 40,
+              marginBottom: 16,
+              opacity: 0.4,
+            }}
+          >
+            ⚖
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 15,
+              fontWeight: 500,
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            No rebalancing needed
+          </p>
+          <p
+            style={{
+              margin: '8px 0 0',
+              fontSize: 13,
+              fontFamily: 'var(--font-sans)',
+              maxWidth: 400,
+            }}
+          >
+            Set target weights on your holdings to see rebalancing suggestions, or lower the drift
+            threshold above.
+          </p>
+        </div>
+      )}
+
+      {/* Results table */}
+      {!loading && !error && suggestions !== null && suggestions.length > 0 && (
+        <div
+          style={{
+            border: '1px solid var(--border-primary)',
+            overflow: 'hidden',
+          }}
+        >
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              tableLayout: 'fixed',
+            }}
+          >
+            <thead>
+              <tr
+                style={{
+                  background: 'var(--bg-surface-alt)',
+                  borderBottom: '1px solid var(--border-primary)',
+                }}
+              >
+                {[
+                  { label: 'Symbol', width: '14%', align: 'left' as const },
+                  { label: 'Name', width: '20%', align: 'left' as const },
+                  { label: 'Current %', width: '11%', align: 'right' as const },
+                  { label: 'Target %', width: '11%', align: 'right' as const },
+                  { label: 'Drift', width: '11%', align: 'right' as const },
+                  { label: 'Suggested Trade', width: '20%', align: 'right' as const },
+                  { label: 'Amount (CAD)', width: '13%', align: 'right' as const },
+                ].map(({ label, width, align }) => (
+                  <th
+                    key={label}
+                    style={{
+                      width,
+                      padding: '8px 12px',
+                      textAlign: align,
+                      fontSize: 11,
+                      fontWeight: 600,
+                      color: 'var(--text-muted)',
+                      fontFamily: 'var(--font-sans)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.05em',
+                      userSelect: 'none',
+                    }}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {suggestions.map((s, idx) => (
+                <tr
+                  key={s.holdingId}
+                  style={{
+                    background: idx % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)',
+                    borderBottom: '1px solid var(--border-subtle)',
+                    transition: 'background 100ms',
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLTableRowElement).style.background =
+                      'var(--bg-surface-hover)';
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLTableRowElement).style.background =
+                      idx % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
+                  }}
+                >
+                  {/* Symbol */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    {s.symbol}
+                  </td>
+
+                  {/* Name */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      fontSize: 13,
+                      color: 'var(--text-secondary)',
+                      fontFamily: 'var(--font-sans)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={s.name}
+                  >
+                    {s.name}
+                  </td>
+
+                  {/* Current % */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 13,
+                      color: 'var(--text-primary)',
+                    }}
+                  >
+                    {formatPercent(s.currentWeight)}
+                  </td>
+
+                  {/* Target % */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 13,
+                      color: 'var(--text-secondary)',
+                    }}
+                  >
+                    {formatPercent(s.targetWeight)}
+                  </td>
+
+                  {/* Drift */}
+                  <td style={{ padding: '10px 12px', textAlign: 'right' }}>
+                    <DriftBadge drift={s.drift} />
+                  </td>
+
+                  {/* Suggested Trade */}
+                  <td style={{ padding: '10px 12px', textAlign: 'right' }}>
+                    <TradeCell suggestion={s} />
+                  </td>
+
+                  {/* Amount CAD */}
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      textAlign: 'right',
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 13,
+                      color: s.suggestedTradeCad > 0 ? 'var(--color-loss)' : 'var(--color-gain)',
+                    }}
+                  >
+                    {formatCurrency(Math.abs(s.suggestedTradeCad))}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Summary row */}
+      {!loading && !error && suggestions !== null && suggestions.length > 0 && (
+        <div
+          style={{
+            marginTop: 12,
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          {suggestions.length} holding{suggestions.length !== 1 ? 's' : ''} with drift &gt;{' '}
+          {driftThreshold}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -165,6 +165,20 @@ export interface PreviewImportResult {
   readyCount: number;
   skipCount: number;
 }
+export interface RebalanceSuggestion {
+  holdingId: string;
+  symbol: string;
+  name: string;
+  currentValueCad: number;
+  targetValueCad: number;
+  currentWeight: number;
+  targetWeight: number;
+  drift: number;
+  suggestedTradeCad: number;
+  suggestedUnits: number;
+  currentPriceCad: number;
+}
+
 // ── Tauri Command Signatures ──
 
 // invoke('get_portfolio')           → PortfolioSnapshot
@@ -177,3 +191,4 @@ export interface PreviewImportResult {
 // invoke('run_stress_test_cmd', { scenario }) → StressResult
 // invoke('search_symbols', { query }) → SymbolResult[]
 // invoke('get_symbol_price', { symbol }) → PriceData
+// invoke('get_rebalance_suggestions', { driftThreshold }) → RebalanceSuggestion[]


### PR DESCRIPTION
## Summary
- **#106** — New `/rebalance` route with `Rebalance.tsx` component
- Backend: `get_rebalance_suggestions` command computes drift from target weights, suggests buy/sell trades, filters by configurable drift threshold
- Frontend: table showing Symbol | Current % | Target % | Drift | Suggested Trade | Amount (CAD), drift threshold slider, clipboard CSV export
- Nav item added to Sidebar (Scale icon)
- Cash holdings excluded from rebalancing

## Test plan
- [x] 50 Rust tests pass, TypeScript clean
- [ ] Set target weights → /rebalance shows drift table
- [ ] Drift threshold slider filters results
- [ ] Export copies trade list to clipboard

Closes #106