### PR TITLE
feat: add price alerts with event-driven notifications (#105)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,9 +12,9 @@ use crate::price::{fetch_all_prices, fetch_price, FetchAllPricesResult};
 use crate::search::search_symbols_yahoo;
 use crate::stress::run_stress_test;
 use crate::types::{
-    AccountType, AssetType, FxRate, Holding, HoldingInput, HoldingWithPrice, ImportError,
-    ImportResult, PerformancePoint, PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceData,
-    RefreshResult, StressResult, StressScenario, SymbolResult,
+    AccountType, AssetType, CreateAlertRequest, FxRate, Holding, HoldingInput, HoldingWithPrice,
+    ImportError, ImportResult, PerformancePoint, PortfolioSnapshot, PreviewImportResult,
+    PreviewRow, PriceAlert, PriceData, RefreshResult, StressResult, StressScenario, SymbolResult,
 };
 
 const MAX_IMPORT_ROWS: usize = 500;
@@ -844,6 +844,7 @@ pub async fn preview_import_csv(
 
 #[tauri::command]
 pub async fn refresh_prices(
+    app: tauri::AppHandle,
     db: State<'_, DbState>,
     client: State<'_, HttpClient>,
 ) -> Result<RefreshResult, String> {
@@ -927,6 +928,9 @@ pub async fn refresh_prices(
             eprintln!("Failed to prune portfolio snapshots: {}", e);
         }
     }
+
+    // Check active price alerts against freshly cached prices
+    check_price_alerts(&app, &db).await;
 
     Ok(RefreshResult {
         prices,
@@ -1017,6 +1021,167 @@ pub async fn get_performance(
 
     let conn = db.0.lock().map_err(|e| e.to_string())?;
     db::get_snapshots_in_range(&conn, &start, &end).map_err(|e| e.to_string())
+}
+
+/// Emitted to the frontend when a price alert is triggered.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PriceAlertTriggeredPayload {
+    alert_id: i64,
+    holding_id: String,
+    symbol: String,
+    alert_type: String,
+    target_price: f64,
+    current_price: f64,
+    currency: String,
+}
+
+/// Check all active (non-triggered) alerts against the current price cache.
+/// Triggers and emits events for any alerts that have crossed their threshold.
+/// Errors are logged but never propagated — price refresh must not fail due to alert issues.
+async fn check_price_alerts(app: &tauri::AppHandle, db: &State<'_, DbState>) {
+    use tauri::Emitter;
+
+    let (alerts, holdings, cached_prices) = {
+        let conn = match db.0.lock() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("Alert check: failed to lock DB: {}", e);
+                return;
+            }
+        };
+        let alerts = match db::get_alerts(&conn, false) {
+            Ok(a) => a,
+            Err(e) => {
+                eprintln!("Alert check: failed to load alerts: {}", e);
+                return;
+            }
+        };
+        let holdings = match db::get_all_holdings(&conn) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("Alert check: failed to load holdings: {}", e);
+                return;
+            }
+        };
+        let prices = match db::get_cached_prices(&conn) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("Alert check: failed to load prices: {}", e);
+                return;
+            }
+        };
+        (alerts, holdings, prices)
+    };
+
+    // Build lookup maps
+    let holding_map: HashMap<String, &crate::types::Holding> =
+        holdings.iter().map(|h| (h.id.clone(), h)).collect();
+    let price_map: HashMap<String, f64> =
+        cached_prices.iter().map(|p| (p.symbol.clone(), p.price)).collect();
+
+    for alert in &alerts {
+        let holding = match holding_map.get(&alert.holding_id) {
+            Some(h) => h,
+            None => continue,
+        };
+
+        let current_price = match price_map.get(&holding.symbol) {
+            Some(&p) => p,
+            None => continue,
+        };
+
+        let triggered = match alert.alert_type.as_str() {
+            "above" => current_price >= alert.target_price,
+            "below" => current_price <= alert.target_price,
+            _ => false,
+        };
+
+        if triggered {
+            {
+                let conn = match db.0.lock() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("Alert check: failed to lock DB for update: {}", e);
+                        continue;
+                    }
+                };
+                if let Err(e) = db::mark_alert_triggered(&conn, alert.id) {
+                    eprintln!("Alert check: failed to mark alert {} triggered: {}", alert.id, e);
+                    continue;
+                }
+            }
+
+            let payload = PriceAlertTriggeredPayload {
+                alert_id: alert.id,
+                holding_id: alert.holding_id.clone(),
+                symbol: holding.symbol.clone(),
+                alert_type: alert.alert_type.clone(),
+                target_price: alert.target_price,
+                current_price,
+                currency: alert.currency.clone(),
+            };
+
+            if let Err(e) = app.emit("price-alert-triggered", &payload) {
+                eprintln!("Alert check: failed to emit event for alert {}: {}", alert.id, e);
+            }
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn add_price_alert(
+    state: tauri::State<'_, DbState>,
+    alert: CreateAlertRequest,
+) -> Result<PriceAlert, String> {
+    if alert.target_price <= 0.0 {
+        return Err("Target price must be greater than 0".to_string());
+    }
+    if alert.alert_type != "above" && alert.alert_type != "below" {
+        return Err("Alert type must be 'above' or 'below'".to_string());
+    }
+    if alert.holding_id.is_empty() {
+        return Err("Holding ID is required".to_string());
+    }
+
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    let id = db::insert_alert(
+        &conn,
+        &alert.holding_id,
+        &alert.alert_type,
+        alert.target_price,
+        &alert.currency,
+    )
+    .map_err(|e| e.to_string())?;
+
+    let created_at = chrono::Utc::now().to_rfc3339();
+    Ok(PriceAlert {
+        id,
+        holding_id: alert.holding_id,
+        alert_type: alert.alert_type,
+        target_price: alert.target_price,
+        currency: alert.currency,
+        triggered: false,
+        created_at,
+    })
+}
+
+#[tauri::command]
+pub async fn get_price_alerts(
+    state: tauri::State<'_, DbState>,
+    include_triggered: bool,
+) -> Result<Vec<PriceAlert>, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    db::get_alerts(&conn, include_triggered).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_price_alert(
+    state: tauri::State<'_, DbState>,
+    id: i64,
+) -> Result<bool, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    db::delete_alert(&conn, id).map_err(|e| e.to_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::types::{
-    AccountType, AssetType, FxRate, Holding, HoldingInput, PerformancePoint, PriceData,
+    AccountType, AssetType, FxRate, Holding, HoldingInput, PerformancePoint, PriceAlert, PriceData,
     SymbolResult,
 };
 
@@ -82,6 +82,16 @@ pub fn init_db(conn: &Connection) -> Result<(), String> {
 
         CREATE INDEX IF NOT EXISTS idx_snapshots_recorded_at
             ON portfolio_snapshots(recorded_at);
+
+        CREATE TABLE IF NOT EXISTS price_alerts (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            holding_id   TEXT    NOT NULL REFERENCES holdings(id) ON DELETE CASCADE,
+            alert_type   TEXT    NOT NULL CHECK(alert_type IN ('above','below')),
+            target_price REAL    NOT NULL,
+            currency     TEXT    NOT NULL,
+            triggered    INTEGER NOT NULL DEFAULT 0,
+            created_at   TEXT    NOT NULL
+        );
         ",
     )
     .map_err(|e| e.to_string())?;
@@ -543,6 +553,66 @@ pub fn sum_target_weights(conn: &Connection, exclude_id: Option<&str>) -> Result
     Ok(sum)
 }
 
+pub fn insert_alert(
+    conn: &Connection,
+    holding_id: &str,
+    alert_type: &str,
+    target_price: f64,
+    currency: &str,
+) -> Result<i64, rusqlite::Error> {
+    let created_at = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO price_alerts (holding_id, alert_type, target_price, currency, triggered, created_at)
+         VALUES (?1, ?2, ?3, ?4, 0, ?5)",
+        params![holding_id, alert_type, target_price, currency, created_at],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn get_alerts(
+    conn: &Connection,
+    include_triggered: bool,
+) -> Result<Vec<PriceAlert>, rusqlite::Error> {
+    let sql = if include_triggered {
+        "SELECT id, holding_id, alert_type, target_price, currency, triggered, created_at
+         FROM price_alerts ORDER BY created_at ASC"
+    } else {
+        "SELECT id, holding_id, alert_type, target_price, currency, triggered, created_at
+         FROM price_alerts WHERE triggered = 0 ORDER BY created_at ASC"
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let alerts = stmt
+        .query_map([], |row| {
+            let triggered_int: i64 = row.get(5)?;
+            Ok(PriceAlert {
+                id: row.get(0)?,
+                holding_id: row.get(1)?,
+                alert_type: row.get(2)?,
+                target_price: row.get(3)?,
+                currency: row.get(4)?,
+                triggered: triggered_int != 0,
+                created_at: row.get(6)?,
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(alerts)
+}
+
+pub fn mark_alert_triggered(conn: &Connection, alert_id: i64) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE price_alerts SET triggered = 1 WHERE id = ?1",
+        params![alert_id],
+    )?;
+    Ok(())
+}
+
+pub fn delete_alert(conn: &Connection, alert_id: i64) -> Result<bool, rusqlite::Error> {
+    let rows = conn.execute("DELETE FROM price_alerts WHERE id = ?1", params![alert_id])?;
+    Ok(rows > 0)
+}
+
 #[allow(dead_code)]
 pub fn holding_exists(conn: &Connection, symbol: &str) -> Result<bool, String> {
     let mut stmt = conn
@@ -870,5 +940,74 @@ mod tests {
         set_config(&conn, "greeting", "").expect("set empty");
         let val = get_config(&conn, "greeting").expect("get config");
         assert_eq!(val, Some(String::new()));
+    }
+
+    // ── Price alert tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn insert_alert_and_get_active_alerts() {
+        let conn = open_test_db();
+        let holding = insert_holding(&conn, make_input("AAPL")).expect("insert holding");
+
+        let id = insert_alert(&conn, &holding.id, "above", 200.0, "USD").expect("insert alert");
+        assert!(id > 0);
+
+        let alerts = get_alerts(&conn, false).expect("get active alerts");
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].holding_id, holding.id);
+        assert_eq!(alerts[0].alert_type, "above");
+        assert!((alerts[0].target_price - 200.0).abs() < 0.001);
+        assert_eq!(alerts[0].currency, "USD");
+        assert!(!alerts[0].triggered);
+    }
+
+    #[test]
+    fn mark_alert_triggered_hides_from_active_query() {
+        let conn = open_test_db();
+        let holding = insert_holding(&conn, make_input("MSFT")).expect("insert holding");
+        let id = insert_alert(&conn, &holding.id, "below", 100.0, "USD").expect("insert alert");
+
+        mark_alert_triggered(&conn, id).expect("mark triggered");
+
+        let active = get_alerts(&conn, false).expect("get active");
+        assert_eq!(active.len(), 0);
+
+        let all = get_alerts(&conn, true).expect("get all");
+        assert_eq!(all.len(), 1);
+        assert!(all[0].triggered);
+    }
+
+    #[test]
+    fn delete_alert_removes_row() {
+        let conn = open_test_db();
+        let holding = insert_holding(&conn, make_input("TSLA")).expect("insert holding");
+        let id = insert_alert(&conn, &holding.id, "above", 300.0, "USD").expect("insert alert");
+
+        let deleted = delete_alert(&conn, id).expect("delete alert");
+        assert!(deleted);
+
+        let alerts = get_alerts(&conn, true).expect("get all after delete");
+        assert_eq!(alerts.len(), 0);
+    }
+
+    #[test]
+    fn delete_nonexistent_alert_returns_false() {
+        let conn = open_test_db();
+        let deleted = delete_alert(&conn, 9999).expect("delete nonexistent");
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn alert_cascade_deleted_with_holding() {
+        let conn = open_test_db();
+        // Enable foreign keys for the cascade to fire
+        conn.execute_batch("PRAGMA foreign_keys = ON;").expect("fk on");
+        let holding = insert_holding(&conn, make_input("NVDA")).expect("insert holding");
+        insert_alert(&conn, &holding.id, "above", 500.0, "USD").expect("insert alert");
+
+        delete_holding(&conn, &holding.id).expect("delete holding");
+
+        let alerts = get_alerts(&conn, true).expect("get alerts after cascade");
+        assert_eq!(alerts.len(), 0);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,9 @@ pub fn run() {
             commands::get_symbol_price,
             commands::get_config_cmd,
             commands::set_config_cmd,
+            commands::add_price_alert,
+            commands::get_price_alerts,
+            commands::delete_price_alert,
         ])
         .run(tauri::generate_context!());
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -262,3 +262,24 @@ pub struct RefreshResult {
     /// Symbols for which the price fetch failed (network error, HTTP error, parse failure).
     pub failed_symbols: Vec<String>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceAlert {
+    pub id: i64,
+    pub holding_id: String,
+    pub alert_type: String,
+    pub target_price: f64,
+    pub currency: String,
+    pub triggered: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAlertRequest {
+    pub holding_id: String,
+    pub alert_type: String,
+    pub target_price: f64,
+    pub currency: String,
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Settings } from './components/Settings';
 import { ToastProvider } from './components/ui/Toast';
 import { useToast } from './components/ui/Toast';
 import { KeyboardShortcutsOverlay } from './components/ui/KeyboardShortcutsOverlay';
+import { AlertBanner } from './components/ui/AlertBanner';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { PortfolioProvider, usePortfolio } from './hooks/usePortfolio';
 import { useConfig } from './hooks/useConfig';
@@ -144,6 +145,7 @@ export default function App() {
       <PortfolioProvider>
         <BrowserRouter>
           <AppRoutes />
+          <AlertBanner />
         </BrowserRouter>
       </PortfolioProvider>
     </ToastProvider>

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -4,6 +4,7 @@ import {
   Plus,
   Pencil,
   Trash2,
+  Bell,
   ChevronUp,
   ChevronDown,
   Upload,
@@ -13,6 +14,7 @@ import {
 import { usePortfolio } from '../hooks/usePortfolio';
 import { AddHoldingModal } from './AddHoldingModal';
 import { ImportHoldingsModal } from './ImportHoldingsModal';
+import { PriceAlertModal } from './PriceAlertModal';
 import { Badge } from './ui/Badge';
 import { EmptyState } from './ui/EmptyState';
 import { useToast } from './ui/Toast';
@@ -153,6 +155,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkDeletePending, setBulkDeletePending] = useState(false);
+  const [alertHolding, setAlertHolding] = useState<HoldingWithPrice | null>(null);
 
   // Auto-open the add-holding modal when navigated here via keyboard shortcut (?add=1)
   useEffect(() => {
@@ -1037,6 +1040,21 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               <Pencil size={13} />
                             </button>
                             <button
+                              onClick={() => setAlertHolding(h)}
+                              title="Set Price Alert"
+                              style={{
+                                background: 'none',
+                                border: 'none',
+                                color: 'var(--text-muted)',
+                                cursor: 'pointer',
+                                padding: 3,
+                                display: 'flex',
+                                alignItems: 'center',
+                              }}
+                            >
+                              <Bell size={13} />
+                            </button>
+                            <button
                               onClick={() => setPendingDelete(h.id)}
                               title="Delete"
                               style={{
@@ -1189,6 +1207,17 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
         onImport={handleImport}
         onPreview={previewImportCsv}
       />
+      {alertHolding && (
+        <PriceAlertModal
+          holding={alertHolding}
+          isOpen={true}
+          onClose={() => setAlertHolding(null)}
+          onSaved={() => {
+            setAlertHolding(null);
+            showToast('Price alert set', 'success');
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/PriceAlertModal.tsx
+++ b/src/components/PriceAlertModal.tsx
@@ -1,0 +1,275 @@
+import { useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Bell } from 'lucide-react';
+import type { CreateAlertRequest, Holding, HoldingWithPrice, PriceAlert } from '../types/portfolio';
+import { formatNumber } from '../lib/format';
+
+interface PriceAlertModalProps {
+  holding: Holding | HoldingWithPrice;
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function PriceAlertModal({ holding, isOpen, onClose, onSaved }: PriceAlertModalProps) {
+  const [alertType, setAlertType] = useState<'above' | 'below'>('above');
+  const [targetPrice, setTargetPrice] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const currentPrice = 'currentPrice' in holding ? holding.currentPrice : undefined;
+
+  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  }
+
+  function handleClose() {
+    setTargetPrice('');
+    setAlertType('above');
+    setError(null);
+    onClose();
+  }
+
+  async function handleSave() {
+    const parsed = parseFloat(targetPrice);
+    if (!targetPrice || isNaN(parsed) || parsed <= 0) {
+      setError('Target price must be a positive number.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const request: CreateAlertRequest = {
+        holdingId: holding.id,
+        alertType,
+        targetPrice: parsed,
+        currency: holding.currency,
+      };
+
+      await invoke<PriceAlert>('add_price_alert', { alert: request });
+      onSaved();
+      handleClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      onClick={handleOverlayClick}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--bg-surface)',
+          border: '1px solid var(--border-primary)',
+          borderRadius: '2px',
+          width: '100%',
+          maxWidth: 420,
+          padding: '24px',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            marginBottom: 20,
+          }}
+        >
+          <Bell size={16} style={{ color: 'var(--color-warning)' }} />
+          <span
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontWeight: 600,
+              fontSize: 14,
+              color: 'var(--text-primary)',
+            }}
+          >
+            Set Price Alert
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              marginLeft: 4,
+            }}
+          >
+            {holding.symbol}
+          </span>
+        </div>
+
+        {currentPrice !== undefined && (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--text-secondary)',
+              marginBottom: 16,
+            }}
+          >
+            Current price:{' '}
+            <span style={{ color: 'var(--text-primary)' }}>
+              {formatNumber(currentPrice, 2)} {holding.currency}
+            </span>
+          </div>
+        )}
+
+        {/* Alert type toggle */}
+        <div style={{ marginBottom: 16 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              marginBottom: 8,
+            }}
+          >
+            Alert Type
+          </div>
+          <div style={{ display: 'flex', gap: 0 }}>
+            {(['above', 'below'] as const).map((type) => (
+              <button
+                key={type}
+                onClick={() => setAlertType(type)}
+                style={{
+                  flex: 1,
+                  padding: '8px 0',
+                  background: alertType === type ? 'var(--color-accent)' : 'var(--bg-surface)',
+                  border: '1px solid var(--border-primary)',
+                  borderRight: type === 'above' ? 'none' : '1px solid var(--border-primary)',
+                  color: alertType === type ? '#fff' : 'var(--text-secondary)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 12,
+                  fontWeight: alertType === type ? 600 : 400,
+                  cursor: 'pointer',
+                  textTransform: 'capitalize',
+                  transition: 'background 150ms, color 150ms',
+                }}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Target price input */}
+        <div style={{ marginBottom: 20 }}>
+          <label
+            style={{
+              display: 'block',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              marginBottom: 8,
+            }}
+          >
+            Target Price ({holding.currency})
+          </label>
+          <input
+            type="number"
+            min="0.000001"
+            step="any"
+            value={targetPrice}
+            onChange={(e) => {
+              setTargetPrice(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleSave();
+              if (e.key === 'Escape') handleClose();
+            }}
+            placeholder="e.g. 195.00"
+            autoFocus
+            style={{
+              width: '100%',
+              background: 'var(--bg-surface-alt)',
+              border: error ? '1px solid var(--color-loss)' : '1px solid var(--border-primary)',
+              color: 'var(--text-primary)',
+              padding: '8px 10px',
+              fontSize: 13,
+              fontFamily: 'var(--font-mono)',
+              borderRadius: '2px',
+              outline: 'none',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-loss)',
+              marginBottom: 16,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={handleClose}
+            disabled={saving}
+            style={{
+              padding: '7px 16px',
+              background: 'transparent',
+              border: '1px solid var(--border-primary)',
+              color: 'var(--text-secondary)',
+              borderRadius: '2px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              cursor: saving ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleSave()}
+            disabled={saving}
+            style={{
+              padding: '7px 16px',
+              background: saving ? 'var(--text-muted)' : 'var(--color-accent)',
+              border: 'none',
+              color: '#fff',
+              borderRadius: '2px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: saving ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {saving ? 'Saving...' : 'Set Alert'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/AlertBanner.tsx
+++ b/src/components/ui/AlertBanner.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { Bell, X } from 'lucide-react';
+import { formatNumber } from '../../lib/format';
+
+interface AlertTriggeredPayload {
+  alertId: number;
+  holdingId: string;
+  symbol: string;
+  alertType: 'above' | 'below';
+  targetPrice: number;
+  currentPrice: number;
+  currency: string;
+}
+
+interface AlertEntry {
+  id: string;
+  payload: AlertTriggeredPayload;
+}
+
+export function AlertBanner() {
+  const [alerts, setAlerts] = useState<AlertEntry[]>([]);
+
+  useEffect(() => {
+    // No-op in browser mode when Tauri is not available
+    if (
+      typeof window === 'undefined' ||
+      !(window as unknown as Record<string, unknown>).__TAURI__
+    ) {
+      return;
+    }
+
+    let unlisten: (() => void) | undefined;
+
+    import('@tauri-apps/api/event')
+      .then(({ listen }) => {
+        return listen<AlertTriggeredPayload>('price-alert-triggered', (event) => {
+          const entry: AlertEntry = {
+            id: `${event.payload.alertId}-${Date.now()}`,
+            payload: event.payload,
+          };
+          setAlerts((prev) => [...prev, entry]);
+
+          // Auto-dismiss after 5 seconds
+          setTimeout(() => {
+            setAlerts((prev) => prev.filter((a) => a.id !== entry.id));
+          }, 5000);
+        });
+      })
+      .then((fn) => {
+        unlisten = fn;
+      })
+      .catch((e) => {
+        console.warn('AlertBanner: failed to register event listener:', e);
+      });
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  function dismiss(id: string) {
+    setAlerts((prev) => prev.filter((a) => a.id !== id));
+  }
+
+  if (alerts.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 24,
+        right: 24,
+        zIndex: 2000,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        maxWidth: 380,
+      }}
+    >
+      {alerts.map((entry) => {
+        const { payload } = entry;
+        const priceStr = `${formatNumber(payload.targetPrice, 2)} ${payload.currency}`;
+        const message = `${payload.symbol} crossed ${priceStr} (${payload.alertType} threshold)`;
+
+        return (
+          <div
+            key={entry.id}
+            role="alert"
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 10,
+              padding: '12px 14px',
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--color-warning)',
+              borderLeft: '4px solid var(--color-warning)',
+              borderRadius: '2px',
+              boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+              animation: 'fadeIn 200ms ease',
+            }}
+          >
+            <Bell
+              size={14}
+              style={{ color: 'var(--color-warning)', flexShrink: 0, marginTop: 1 }}
+            />
+            <span
+              style={{
+                flex: 1,
+                fontFamily: 'var(--font-mono)',
+                fontSize: 12,
+                color: 'var(--text-primary)',
+                lineHeight: 1.5,
+              }}
+            >
+              {message}
+            </span>
+            <button
+              onClick={() => dismiss(entry.id)}
+              aria-label="Dismiss alert"
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--text-muted)',
+                cursor: 'pointer',
+                padding: 0,
+                display: 'flex',
+                alignItems: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -146,6 +146,23 @@ export interface PreviewImportResult {
   readyCount: number;
   skipCount: number;
 }
+export interface PriceAlert {
+  id: number;
+  holdingId: string;
+  alertType: 'above' | 'below';
+  targetPrice: number;
+  currency: string;
+  triggered: boolean;
+  createdAt: string;
+}
+
+export interface CreateAlertRequest {
+  holdingId: string;
+  alertType: 'above' | 'below';
+  targetPrice: number;
+  currency: string;
+}
+
 // ── Tauri Command Signatures ──
 
 // invoke('get_portfolio')           → PortfolioSnapshot
@@ -158,3 +175,6 @@ export interface PreviewImportResult {
 // invoke('run_stress_test_cmd', { scenario }) → StressResult
 // invoke('search_symbols', { query }) → SymbolResult[]
 // invoke('get_symbol_price', { symbol }) → PriceData
+// invoke('add_price_alert', { alert }) → PriceAlert
+// invoke('get_price_alerts', { includeTriggered }) → PriceAlert[]
+// invoke('delete_price_alert', { id }) → boolean


### PR DESCRIPTION
## Summary
- **#105** — Full price alert system: set above/below thresholds per holding, get notified when crossed
- DB: `price_alerts` table with cascade-delete on holding removal
- Backend: `add_price_alert`, `get_price_alerts`, `delete_price_alert` commands + alert checking wired into `refresh_prices`
- Frontend: Bell icon per Holdings row opens `PriceAlertModal`; `AlertBanner` listens to `price-alert-triggered` Tauri events and stacks dismissible warnings

## Test plan
- [x] 5 new Rust unit tests (insert, filter, cascade, delete) — 69 total pass
- [x] TypeScript clean
- [ ] Set an "above" alert on AAPL at current price - 1 → refresh prices → banner fires
- [ ] Delete a holding → its alerts are also deleted (ON DELETE CASCADE)
- [ ] Multiple alerts stack in the banner, each auto-dismiss after 5s

Closes #105