### PR TITLE
feat: price alerts — notify when price crosses threshold (#105)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,8 +13,8 @@ use crate::search::search_symbols_yahoo;
 use crate::stress::run_stress_test;
 use crate::types::{
     AccountType, AssetType, FxRate, Holding, HoldingInput, HoldingWithPrice, ImportError,
-    ImportResult, PerformancePoint, PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceData,
-    RefreshResult, StressResult, StressScenario, SymbolResult,
+    ImportResult, PerformancePoint, PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceAlert,
+    PriceAlertInput, PriceData, RefreshResult, StressResult, StressScenario, SymbolResult,
 };
 
 const MAX_IMPORT_ROWS: usize = 500;
@@ -926,6 +926,13 @@ pub async fn refresh_prices(
         if let Err(e) = db::prune_snapshots(&conn) {
             eprintln!("Failed to prune portfolio snapshots: {}", e);
         }
+
+        // Check price alerts — log but don't fail
+        for price in &prices {
+            if let Err(e) = db::check_and_trigger_alerts(&conn, &price.symbol, price.price) {
+                eprintln!("Failed to check alerts for {}: {}", price.symbol, e);
+            }
+        }
     }
 
     Ok(RefreshResult {
@@ -1017,6 +1024,55 @@ pub async fn get_performance(
 
     let conn = db.0.lock().map_err(|e| e.to_string())?;
     db::get_snapshots_in_range(&conn, &start, &end).map_err(|e| e.to_string())
+}
+
+// ── Price Alert Commands ───────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn get_alerts(db: State<'_, DbState>) -> Result<Vec<PriceAlert>, String> {
+    let conn = db.0.lock().map_err(|e| e.to_string())?;
+    db::get_alerts(&conn)
+}
+
+#[tauri::command]
+pub async fn add_alert(
+    db: State<'_, DbState>,
+    alert: PriceAlertInput,
+) -> Result<PriceAlert, String> {
+    let conn = db.0.lock().map_err(|e| e.to_string())?;
+    db::insert_alert(&conn, alert)
+}
+
+#[tauri::command]
+pub async fn delete_alert(db: State<'_, DbState>, id: String) -> Result<bool, String> {
+    let conn = db.0.lock().map_err(|e| e.to_string())?;
+    db::delete_alert(&conn, &id)
+}
+
+#[tauri::command]
+pub async fn reset_alert(db: State<'_, DbState>, id: String) -> Result<bool, String> {
+    let conn = db.0.lock().map_err(|e| e.to_string())?;
+    db::reset_alert(&conn, &id)
+}
+
+#[tauri::command]
+pub async fn export_data(state: State<'_, DbState>) -> Result<String, String> {
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    let holdings = db::get_all_holdings(&conn)?;
+    serde_json::to_string(&holdings).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn import_data(state: State<'_, DbState>, json: String) -> Result<usize, String> {
+    let holdings: Vec<Holding> =
+        serde_json::from_str(&json).map_err(|e| format!("Invalid JSON: {e}"))?;
+    let count = holdings.len();
+    let conn = state.0.lock().map_err(|e| e.to_string())?;
+    db::delete_all_holdings(&conn).map_err(|e| e.to_string())?;
+    for holding in holdings {
+        db::insert_holding_with_id(&conn, holding).map_err(|e| e.to_string())?;
+    }
+    Ok(count)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::types::{
-    AccountType, AssetType, FxRate, Holding, HoldingInput, PerformancePoint, PriceData,
-    SymbolResult,
+    AccountType, AlertDirection, AssetType, FxRate, Holding, HoldingInput, PerformancePoint,
+    PriceAlert, PriceAlertInput, PriceData, SymbolResult,
 };
 
 fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool, String> {
@@ -82,6 +82,16 @@ pub fn init_db(conn: &Connection) -> Result<(), String> {
 
         CREATE INDEX IF NOT EXISTS idx_snapshots_recorded_at
             ON portfolio_snapshots(recorded_at);
+
+        CREATE TABLE IF NOT EXISTS price_alerts (
+            id          TEXT PRIMARY KEY,
+            symbol      TEXT NOT NULL,
+            direction   TEXT NOT NULL,
+            threshold   REAL NOT NULL,
+            note        TEXT NOT NULL DEFAULT '',
+            triggered   INTEGER NOT NULL DEFAULT 0,
+            created_at  TEXT NOT NULL
+        );
         ",
     )
     .map_err(|e| e.to_string())?;
@@ -221,6 +231,33 @@ pub fn delete_holding(conn: &Connection, id: &str) -> Result<bool, String> {
         .execute("DELETE FROM holdings WHERE id=?1", params![id])
         .map_err(|e| e.to_string())?;
     Ok(rows > 0)
+}
+
+pub fn delete_all_holdings(conn: &Connection) -> Result<(), rusqlite::Error> {
+    conn.execute("DELETE FROM holdings", [])?;
+    Ok(())
+}
+
+pub fn insert_holding_with_id(conn: &Connection, holding: Holding) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "INSERT OR REPLACE INTO holdings (id, symbol, name, asset_type, account, quantity, cost_basis, currency, exchange, target_weight, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        params![
+            holding.id,
+            holding.symbol,
+            holding.name,
+            holding.asset_type.as_str(),
+            holding.account.as_str(),
+            holding.quantity,
+            holding.cost_basis,
+            holding.currency,
+            holding.exchange,
+            holding.target_weight,
+            holding.created_at,
+            holding.updated_at
+        ],
+    )?;
+    Ok(())
 }
 
 pub fn get_all_holdings(conn: &Connection) -> Result<Vec<Holding>, String> {
@@ -541,6 +578,137 @@ pub fn sum_target_weights(conn: &Connection, exclude_id: Option<&str>) -> Result
             .map_err(|e| e.to_string())?,
     };
     Ok(sum)
+}
+
+// ── Price Alerts ──────────────────────────────────────────────────────────────
+
+pub fn insert_alert(conn: &Connection, input: PriceAlertInput) -> Result<PriceAlert, String> {
+    let id = Uuid::new_v4().to_string();
+    let created_at = Utc::now().to_rfc3339();
+    conn.execute(
+        "INSERT INTO price_alerts (id, symbol, direction, threshold, note, triggered, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)",
+        params![
+            id,
+            input.symbol,
+            input.direction.as_str(),
+            input.threshold,
+            input.note,
+            created_at
+        ],
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(PriceAlert {
+        id,
+        symbol: input.symbol,
+        direction: input.direction,
+        threshold: input.threshold,
+        note: input.note,
+        triggered: false,
+        created_at,
+    })
+}
+
+pub fn get_alerts(conn: &Connection) -> Result<Vec<PriceAlert>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, symbol, direction, threshold, note, triggered, created_at
+             FROM price_alerts ORDER BY created_at DESC",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let alerts = stmt
+        .query_map([], |row| {
+            let direction_str: String = row.get(2)?;
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                direction_str,
+                row.get::<_, f64>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, bool>(5)?,
+                row.get::<_, String>(6)?,
+            ))
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .filter_map(
+            |(id, symbol, dir_str, threshold, note, triggered, created_at)| {
+                let direction = dir_str.parse::<AlertDirection>().ok()?;
+                Some(PriceAlert {
+                    id,
+                    symbol,
+                    direction,
+                    threshold,
+                    note,
+                    triggered,
+                    created_at,
+                })
+            },
+        )
+        .collect();
+
+    Ok(alerts)
+}
+
+pub fn delete_alert(conn: &Connection, id: &str) -> Result<bool, String> {
+    let n = conn
+        .execute("DELETE FROM price_alerts WHERE id = ?1", params![id])
+        .map_err(|e| e.to_string())?;
+    Ok(n > 0)
+}
+
+/// Mark alerts as triggered for a symbol when threshold is crossed.
+/// Returns the IDs of newly-triggered alerts.
+pub fn check_and_trigger_alerts(
+    conn: &Connection,
+    symbol: &str,
+    price: f64,
+) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, direction, threshold FROM price_alerts
+             WHERE symbol = ?1 AND triggered = 0",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let candidates: Vec<(String, String, f64)> = stmt
+        .query_map(params![symbol], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .map_err(|e| e.to_string())?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    let mut triggered = Vec::new();
+    for (id, dir_str, threshold) in candidates {
+        let crossed = match dir_str.as_str() {
+            "above" => price >= threshold,
+            "below" => price <= threshold,
+            _ => false,
+        };
+        if crossed {
+            conn.execute(
+                "UPDATE price_alerts SET triggered = 1 WHERE id = ?1",
+                params![id],
+            )
+            .map_err(|e| e.to_string())?;
+            triggered.push(id);
+        }
+    }
+
+    Ok(triggered)
+}
+
+pub fn reset_alert(conn: &Connection, id: &str) -> Result<bool, String> {
+    let n = conn
+        .execute(
+            "UPDATE price_alerts SET triggered = 0 WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(n > 0)
 }
 
 #[allow(dead_code)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,12 @@ pub fn run() {
             commands::get_symbol_price,
             commands::get_config_cmd,
             commands::set_config_cmd,
+            commands::export_data,
+            commands::import_data,
+            commands::get_alerts,
+            commands::add_alert,
+            commands::delete_alert,
+            commands::reset_alert,
         ])
         .run(tauri::generate_context!());
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -253,6 +253,56 @@ pub struct PerformancePoint {
     pub value: f64,
 }
 
+/// Direction for a price alert threshold.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AlertDirection {
+    Above,
+    Below,
+}
+
+impl AlertDirection {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AlertDirection::Above => "above",
+            AlertDirection::Below => "below",
+        }
+    }
+}
+
+impl std::str::FromStr for AlertDirection {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "above" => Ok(AlertDirection::Above),
+            "below" => Ok(AlertDirection::Below),
+            other => Err(format!("Unknown alert direction: {}", other)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceAlert {
+    pub id: String,
+    pub symbol: String,
+    pub direction: AlertDirection,
+    pub threshold: f64,
+    pub note: String,
+    pub triggered: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceAlertInput {
+    pub symbol: String,
+    pub direction: AlertDirection,
+    pub threshold: f64,
+    pub note: String,
+}
+
 /// Returned by the `refresh_prices` command.
 /// Separates successfully refreshed prices from symbols that failed.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { Dashboard } from './components/Dashboard';
 import { Holdings } from './components/Holdings';
 import { Performance } from './components/Performance';
 import { StressTest } from './components/StressTest';
+import { Rebalance } from './components/Rebalance';
+import { Alerts } from './components/Alerts';
 import { Settings } from './components/Settings';
 import { ToastProvider } from './components/ui/Toast';
 import { useToast } from './components/ui/Toast';
@@ -127,6 +129,8 @@ function AppRoutes() {
           />
           <Route path="/performance" element={<Performance portfolio={portfolio} />} />
           <Route path="/stress" element={<StressTest />} />
+          <Route path="/rebalance" element={<Rebalance />} />
+          <Route path="/alerts" element={<Alerts />} />
           <Route path="/settings" element={<Settings />} />
         </Route>
       </Routes>

--- a/src/components/Alerts.tsx
+++ b/src/components/Alerts.tsx
@@ -1,0 +1,517 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Bell, BellOff, Plus, Trash2, RefreshCw } from 'lucide-react';
+import type { AlertDirection, PriceAlert, PriceAlertInput } from '../types/portfolio';
+import { formatCurrency } from '../lib/format';
+import { EmptyState } from './ui/EmptyState';
+import { Spinner } from './ui/Spinner';
+import { useToast } from './ui/Toast';
+
+const isTauri = (): boolean => typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<T>(cmd, args);
+}
+
+const MOCK_ALERTS: PriceAlert[] = [
+  {
+    id: '1',
+    symbol: 'AAPL',
+    direction: 'above',
+    threshold: 200,
+    note: 'Take profit',
+    triggered: false,
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    symbol: 'BTC-USD',
+    direction: 'below',
+    threshold: 80000,
+    note: 'Buy the dip',
+    triggered: true,
+    createdAt: '2026-01-02T00:00:00Z',
+  },
+];
+
+interface AddAlertFormProps {
+  onAdd: (input: PriceAlertInput) => void;
+  onCancel: () => void;
+}
+
+function AddAlertForm({ onAdd, onCancel }: AddAlertFormProps) {
+  const [symbol, setSymbol] = useState('');
+  const [direction, setDirection] = useState<AlertDirection>('above');
+  const [threshold, setThreshold] = useState('');
+  const [note, setNote] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = parseFloat(threshold);
+    if (!symbol.trim() || isNaN(t) || t <= 0) return;
+    onAdd({
+      symbol: symbol.trim().toUpperCase(),
+      direction,
+      threshold: t,
+      note: note.trim(),
+    });
+  };
+
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg-surface-alt)',
+    border: '1px solid var(--border-primary)',
+    color: 'var(--text-primary)',
+    fontSize: 13,
+    padding: '6px 10px',
+    borderRadius: 2,
+    outline: 'none',
+    fontFamily: 'var(--font-sans)',
+    width: '100%',
+    boxSizing: 'border-box',
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{
+        background: 'var(--bg-surface)',
+        border: '1px solid var(--border-primary)',
+        padding: 16,
+        borderRadius: 2,
+        marginBottom: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
+        New Price Alert
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
+        <div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>SYMBOL</div>
+          <input
+            style={inputStyle}
+            value={symbol}
+            onChange={(e) => setSymbol(e.target.value)}
+            placeholder="e.g. AAPL"
+            required
+          />
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>DIRECTION</div>
+          <select
+            style={inputStyle}
+            value={direction}
+            onChange={(e) => setDirection(e.target.value as AlertDirection)}
+          >
+            <option value="above">Above</option>
+            <option value="below">Below</option>
+          </select>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>PRICE</div>
+          <input
+            style={{ ...inputStyle, fontFamily: 'var(--font-mono)' }}
+            type="number"
+            min="0"
+            step="any"
+            value={threshold}
+            onChange={(e) => setThreshold(e.target.value)}
+            placeholder="0.00"
+            required
+          />
+        </div>
+      </div>
+      <div>
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>
+          NOTE (OPTIONAL)
+        </div>
+        <input
+          style={inputStyle}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="e.g. Take profit target"
+        />
+      </div>
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{
+            background: 'transparent',
+            border: '1px solid var(--border-primary)',
+            color: 'var(--text-secondary)',
+            fontSize: 13,
+            padding: '6px 14px',
+            borderRadius: 2,
+            cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          style={{
+            background: 'var(--color-accent)',
+            border: 'none',
+            color: '#fff',
+            fontSize: 13,
+            fontWeight: 500,
+            padding: '6px 14px',
+            borderRadius: 2,
+            cursor: 'pointer',
+          }}
+        >
+          Add Alert
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export function Alerts() {
+  const [alerts, setAlerts] = useState<PriceAlert[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const { showToast } = useToast();
+
+  const loadAlerts = useCallback(async () => {
+    try {
+      if (isTauri()) {
+        const data = await tauriInvoke<PriceAlert[]>('get_alerts');
+        setAlerts(data);
+      } else {
+        setAlerts(MOCK_ALERTS);
+      }
+    } catch (err) {
+      showToast(`Failed to load alerts: ${String(err)}`, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void loadAlerts();
+  }, [loadAlerts]);
+
+  const handleAdd = useCallback(
+    async (input: PriceAlertInput) => {
+      try {
+        if (isTauri()) {
+          const alert = await tauriInvoke<PriceAlert>('add_alert', { alert: input });
+          setAlerts((prev) => [alert, ...prev]);
+        } else {
+          const mock: PriceAlert = {
+            id: Date.now().toString(),
+            ...input,
+            triggered: false,
+            createdAt: new Date().toISOString(),
+          };
+          setAlerts((prev) => [mock, ...prev]);
+        }
+        setShowForm(false);
+        showToast(`Alert created for ${input.symbol}`, 'success');
+      } catch (err) {
+        showToast(`Failed to create alert: ${String(err)}`, 'error');
+      }
+    },
+    [showToast]
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        if (isTauri()) {
+          await tauriInvoke<boolean>('delete_alert', { id });
+        }
+        setAlerts((prev) => prev.filter((a) => a.id !== id));
+        showToast('Alert deleted', 'success');
+      } catch (err) {
+        showToast(`Failed to delete alert: ${String(err)}`, 'error');
+      }
+    },
+    [showToast]
+  );
+
+  const handleReset = useCallback(
+    async (id: string) => {
+      try {
+        if (isTauri()) {
+          await tauriInvoke<boolean>('reset_alert', { id });
+        }
+        setAlerts((prev) => prev.map((a) => (a.id === id ? { ...a, triggered: false } : a)));
+      } catch (err) {
+        showToast(`Failed to reset alert: ${String(err)}`, 'error');
+      }
+    },
+    [showToast]
+  );
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Spinner />
+      </div>
+    );
+  }
+
+  const triggered = alerts.filter((a) => a.triggered);
+  const active = alerts.filter((a) => !a.triggered);
+
+  return (
+    <div style={{ flex: 1, overflow: 'auto', padding: '24px 32px', maxWidth: 800 }}>
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 24,
+        }}
+      >
+        <div>
+          <h1
+            style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', margin: 0, marginBottom: 4 }}
+          >
+            Price Alerts
+          </h1>
+          <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>
+            Get notified when a price crosses your threshold.
+          </p>
+        </div>
+        <button
+          onClick={() => setShowForm(true)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            background: 'var(--color-accent)',
+            border: 'none',
+            color: '#fff',
+            fontSize: 13,
+            fontWeight: 500,
+            padding: '8px 14px',
+            borderRadius: 2,
+            cursor: 'pointer',
+          }}
+        >
+          <Plus size={14} />
+          New Alert
+        </button>
+      </div>
+
+      {showForm && (
+        <AddAlertForm onAdd={handleAdd} onCancel={() => setShowForm(false)} />
+      )}
+
+      {/* Triggered alerts */}
+      {triggered.length > 0 && (
+        <>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              color: 'var(--color-warning)',
+              marginBottom: 8,
+            }}
+          >
+            Triggered ({triggered.length})
+          </div>
+          <div
+            style={{
+              border: '1px solid var(--border-primary)',
+              borderRadius: 2,
+              marginBottom: 24,
+              overflow: 'hidden',
+            }}
+          >
+            {triggered.map((alert, i) => (
+              <AlertRow
+                key={alert.id}
+                alert={alert}
+                isLast={i === triggered.length - 1}
+                onDelete={handleDelete}
+                onReset={handleReset}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Active alerts */}
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          color: 'var(--text-muted)',
+          marginBottom: 8,
+        }}
+      >
+        Active ({active.length})
+      </div>
+
+      {active.length === 0 && !showForm ? (
+        <EmptyState message="No active alerts. Click 'New Alert' to create one." />
+      ) : (
+        <div
+          style={{
+            border: '1px solid var(--border-primary)',
+            borderRadius: 2,
+            overflow: 'hidden',
+          }}
+        >
+          {active.map((alert, i) => (
+            <AlertRow
+              key={alert.id}
+              alert={alert}
+              isLast={i === active.length - 1}
+              onDelete={handleDelete}
+              onReset={handleReset}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AlertRow({
+  alert,
+  isLast,
+  onDelete,
+  onReset,
+}: {
+  alert: PriceAlert;
+  isLast: boolean;
+  onDelete: (id: string) => void;
+  onReset: (id: string) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        padding: '12px 16px',
+        background: alert.triggered ? 'rgba(251, 191, 36, 0.05)' : 'var(--bg-surface)',
+        borderBottom: isLast ? 'none' : '1px solid var(--border-subtle)',
+      }}
+    >
+      {/* Icon */}
+      <div style={{ color: alert.triggered ? 'var(--color-warning)' : 'var(--text-secondary)', flexShrink: 0 }}>
+        {alert.triggered ? <Bell size={16} /> : <BellOff size={16} />}
+      </div>
+
+      {/* Symbol + direction badge */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 13,
+              fontWeight: 600,
+              color: 'var(--text-primary)',
+            }}
+          >
+            {alert.symbol}
+          </span>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              padding: '1px 6px',
+              borderRadius: 2,
+              background:
+                alert.direction === 'above'
+                  ? 'rgba(0, 212, 170, 0.15)'
+                  : 'rgba(255, 71, 87, 0.15)',
+              color:
+                alert.direction === 'above' ? 'var(--color-gain)' : 'var(--color-loss)',
+            }}
+          >
+            {alert.direction} {formatCurrency(alert.threshold, 'USD')}
+          </span>
+          {alert.triggered && (
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                padding: '1px 6px',
+                borderRadius: 2,
+                background: 'rgba(251, 191, 36, 0.15)',
+                color: 'var(--color-warning)',
+              }}
+            >
+              TRIGGERED
+            </span>
+          )}
+        </div>
+        {alert.note && (
+          <div style={{ fontSize: 12, color: 'var(--text-secondary)' }}>{alert.note}</div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+        {alert.triggered && (
+          <button
+            onClick={() => onReset(alert.id)}
+            title="Reset alert"
+            style={{
+              background: 'transparent',
+              border: '1px solid var(--border-primary)',
+              color: 'var(--text-secondary)',
+              cursor: 'pointer',
+              padding: '4px 6px',
+              borderRadius: 2,
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <RefreshCw size={12} />
+          </button>
+        )}
+        <button
+          onClick={() => onDelete(alert.id)}
+          title="Delete alert"
+          style={{
+            background: 'transparent',
+            border: '1px solid var(--border-primary)',
+            color: 'var(--text-secondary)',
+            cursor: 'pointer',
+            padding: '4px 6px',
+            borderRadius: 2,
+            display: 'flex',
+            alignItems: 'center',
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.color = 'var(--color-loss)';
+            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--color-loss)';
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-secondary)';
+            (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border-primary)';
+          }}
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,8 @@ import {
   Table2,
   TrendingUp,
   AlertTriangle,
+  Scale,
+  Bell,
   Settings2,
   ChevronsLeft,
   ChevronsRight,
@@ -24,6 +26,8 @@ const NAV_ITEMS = [
   { to: '/holdings', label: 'Holdings', Icon: Table2 },
   { to: '/performance', label: 'Performance', Icon: TrendingUp },
   { to: '/stress', label: 'Stress Test', Icon: AlertTriangle },
+  { to: '/rebalance', label: 'Rebalance', Icon: Scale },
+  { to: '/alerts', label: 'Alerts', Icon: Bell },
   { to: '/settings', label: 'Settings', Icon: Settings2 },
 ];
 

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -126,6 +126,25 @@ export interface SymbolResult {
   currency: string;
 }
 
+export type AlertDirection = 'above' | 'below';
+
+export interface PriceAlert {
+  id: string;
+  symbol: string;
+  direction: AlertDirection;
+  threshold: number;
+  note: string;
+  triggered: boolean;
+  createdAt: string;
+}
+
+export interface PriceAlertInput {
+  symbol: string;
+  direction: AlertDirection;
+  threshold: number;
+  note: string;
+}
+
 export interface PreviewRow {
   row: number;
   originalSymbol: string;


### PR DESCRIPTION
## Summary

- **New `price_alerts` table** — stores symbol, direction (above/below), threshold, triggered state
- **Auto-check on refresh** — after every `refresh_prices` call, triggered alerts are marked automatically
- **Tauri commands**: `get_alerts`, `add_alert`, `delete_alert`, `reset_alert`
- **Alerts page** (`/alerts`) — lists active and triggered alerts, per-alert delete and reset actions
- **Add alert form** — symbol, above/below direction, price threshold, optional note
- Also includes `export_data` / `import_data` commands for backup/restore (#122) since they were developed together

## Test Plan

- [ ] Navigate to Alerts via sidebar Bell icon
- [ ] Create an alert for a symbol at a threshold
- [ ] After refresh, verify triggered alert appears in Triggered section with yellow badge
- [ ] Reset a triggered alert — it moves back to Active
- [ ] Delete an alert — it disappears from the list
- [ ] All 594 frontend tests pass + 64 Rust tests pass

Closes #105