### PR TITLE
chore: remove dead constants, move MAX_IMPORT_ROWS, extract mock dividends

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -21,8 +21,6 @@ use crate::types::{
     Transaction, TransactionInput,
 };
 
-const MAX_IMPORT_ROWS: usize = 500;
-
 pub struct DbState(pub Mutex<rusqlite::Connection>);
 pub struct HttpClient(pub reqwest::Client);
 
@@ -229,8 +227,11 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
     let mut rows = Vec::new();
 
     for (index, record) in reader.records().enumerate() {
-        if rows.len() >= MAX_IMPORT_ROWS {
-            return Err(format!("CSV import is limited to {} rows", MAX_IMPORT_ROWS));
+        if rows.len() >= crate::config::MAX_IMPORT_ROWS {
+            return Err(format!(
+                "CSV import is limited to {} rows",
+                crate::config::MAX_IMPORT_ROWS
+            ));
         }
 
         let row = index + 2;

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -9,21 +9,10 @@
 /// In the future this will become a runtime user setting stored in the DB.
 pub const BASE_CURRENCY: &str = "CAD";
 
-/// All currencies the app can hold positions in / fetch FX rates for.
-#[expect(
-    dead_code,
-    reason = "Centralized for the config refactor; not all call sites use it yet"
-)]
-pub const SUPPORTED_CURRENCIES: &[&str] = &["CAD", "USD", "EUR", "GBP", "JPY", "CHF", "AUD"];
-
 // ── External APIs ─────────────────────────────────────────────────────────────
 
 pub const YAHOO_CHART_URL: &str =
     "https://query1.finance.yahoo.com/v8/finance/chart/{}?interval=1d&range=1d";
-
-#[expect(dead_code, reason = "Reserved for future direct search API usage")]
-pub const YAHOO_SEARCH_URL: &str =
-    "https://query1.finance.yahoo.com/v1/finance/search?q={}&quotesCount=8&newsCount=0&enableFuzzyQuery=false";
 
 pub const YAHOO_QUOTE_URL: &str = "https://query1.finance.yahoo.com/v7/finance/quote?symbols={}";
 
@@ -35,21 +24,12 @@ pub const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
 
 pub const DB_FILE_NAME: &str = "portfolio.db";
 
+// ── Import limits ─────────────────────────────────────────────────────────────
+
+/// Maximum number of rows accepted in a single CSV import.
+pub const MAX_IMPORT_ROWS: usize = 500;
+
 // ── Cache TTLs ────────────────────────────────────────────────────────────────
-
-/// How long (seconds) a cached price is considered fresh before re-fetching.
-#[expect(
-    dead_code,
-    reason = "Cache freshness logic is being centralized incrementally"
-)]
-pub const PRICE_CACHE_TTL_SECS: i64 = 300; // 5 minutes
-
-/// How long (seconds) a cached FX rate is considered fresh.
-#[expect(
-    dead_code,
-    reason = "Cache freshness logic is being centralized incrementally"
-)]
-pub const FX_CACHE_TTL_SECS: i64 = 900; // 15 minutes
 
 /// How long (seconds) a symbol search result is cached.
 pub const SEARCH_CACHE_TTL_SECS: i64 = 300; // 5 minutes

--- a/src/components/Dividends.tsx
+++ b/src/components/Dividends.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DollarSign, Plus, Trash2 } from 'lucide-react';
 import type { Dividend, DividendInput, Holding } from '../types/portfolio';
 import { formatCurrency } from '../lib/format';
+import { MOCK_DIVIDENDS, MOCK_HOLDINGS } from '../lib/mockData';
 import { EmptyState } from './ui/EmptyState';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
@@ -12,46 +13,6 @@ async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Prom
   const { invoke } = await import('@tauri-apps/api/core');
   return invoke<T>(cmd, args);
 }
-
-const MOCK_DIVIDENDS: Dividend[] = [
-  {
-    id: 1,
-    holdingId: 'h1',
-    symbol: 'VDY.TO',
-    amountPerUnit: 0.118,
-    currency: 'CAD',
-    exDate: '2026-01-15',
-    payDate: '2026-01-31',
-    createdAt: '2026-01-01T00:00:00Z',
-  },
-  {
-    id: 2,
-    holdingId: 'h2',
-    symbol: 'AAPL',
-    amountPerUnit: 0.25,
-    currency: 'USD',
-    exDate: '2026-02-07',
-    payDate: '2026-02-13',
-    createdAt: '2026-01-20T00:00:00Z',
-  },
-];
-
-const MOCK_HOLDINGS: Holding[] = [
-  {
-    id: 'h1',
-    symbol: 'VDY.TO',
-    name: 'Vanguard FTSE Canadian High Dividend',
-    assetType: 'etf',
-    account: 'tfsa',
-    quantity: 100,
-    costBasis: 42,
-    currency: 'CAD',
-    exchange: 'TSX',
-    targetWeight: 0,
-    createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-01-01T00:00:00Z',
-  },
-];
 
 interface AddDividendFormProps {
   holdings: Holding[];

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,4 +1,4 @@
-import type { Holding, HoldingWithPrice, PortfolioSnapshot } from '../types/portfolio';
+import type { Dividend, Holding, HoldingWithPrice, PortfolioSnapshot } from '../types/portfolio';
 
 const USD_CAD = 1.36;
 const EUR_CAD = 1.47;
@@ -305,6 +305,29 @@ function buildSnapshot(): PortfolioSnapshot {
 }
 
 export const MOCK_SNAPSHOT: PortfolioSnapshot = buildSnapshot();
+
+export const MOCK_DIVIDENDS: Dividend[] = [
+  {
+    id: 1,
+    holdingId: 'h1',
+    symbol: 'VDY.TO',
+    amountPerUnit: 0.118,
+    currency: 'CAD',
+    exDate: '2026-01-15',
+    payDate: '2026-01-31',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    holdingId: 'h2',
+    symbol: 'AAPL',
+    amountPerUnit: 0.25,
+    currency: 'USD',
+    exDate: '2026-02-07',
+    payDate: '2026-02-13',
+    createdAt: '2026-01-20T00:00:00Z',
+  },
+];
 
 export const MOCK_HOLDINGS: Holding[] = RAW_HOLDINGS.map(
   ({


### PR DESCRIPTION
## Summary
- Remove unused constants from `config.rs` (`SUPPORTED_CURRENCIES`, `YAHOO_SEARCH_URL`, cache TTL constants)
- Move `MAX_IMPORT_ROWS` constant from `commands.rs` inline to `config.rs`; update callsites to use `crate::config::MAX_IMPORT_ROWS`
- Extract inline mock dividend/holding arrays from `Dividends.tsx` into `src/lib/mockData.ts`

## Test plan
- [ ] `cargo clippy -- -D warnings` passes (no dead code warnings)
- [ ] `cargo test` passes
- [ ] Dividends view still renders mock data correctly in non-Tauri mode

Closes #174 (partial — cleanup items)