### PR TITLE
feat: Action Center insights, dashboard layout fix, Performance refresh prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,10 @@ function AppRoutes() {
               />
             }
           />
-          <Route path="/performance" element={<Performance portfolio={portfolio} />} />
+          <Route
+            path="/performance"
+            element={<Performance portfolio={portfolio} onRefresh={refreshPrices} />}
+          />
           <Route path="/stress" element={<StressTest />} />
           <Route path="/rebalance" element={<Rebalance />} />
           <Route path="/alerts" element={<Alerts />} />

--- a/src/components/ActionCenter.tsx
+++ b/src/components/ActionCenter.tsx
@@ -1,0 +1,253 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  AlertTriangle,
+  AlertCircle,
+  Info,
+  CheckCircle,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import type { ActionInsight, InsightSeverity } from '../types/portfolio';
+
+interface ActionCenterProps {
+  insights: ActionInsight[];
+}
+
+// ─── Severity helpers ──────────────────────────────────────────────────────
+
+const SEVERITY_COLOR: Record<InsightSeverity, string> = {
+  critical: 'var(--color-loss)',
+  warning: 'var(--color-warning)',
+  info: 'var(--color-accent)',
+};
+
+const SEVERITY_BG: Record<InsightSeverity, string> = {
+  critical: 'rgba(255, 71, 87, 0.08)',
+  warning: 'rgba(251, 191, 36, 0.08)',
+  info: 'rgba(59, 130, 246, 0.08)',
+};
+
+function SeverityIcon({ severity, size = 15 }: { severity: InsightSeverity; size?: number }) {
+  const color = SEVERITY_COLOR[severity];
+  if (severity === 'critical') return <AlertCircle size={size} color={color} />;
+  if (severity === 'warning') return <AlertTriangle size={size} color={color} />;
+  return <Info size={size} color={color} />;
+}
+
+// ─── Single insight card ──────────────────────────────────────────────────
+
+interface InsightCardProps {
+  insight: ActionInsight;
+}
+
+function InsightCard({ insight }: InsightCardProps) {
+  const navigate = useNavigate();
+  const color = SEVERITY_COLOR[insight.severity];
+  const bg = SEVERITY_BG[insight.severity];
+
+  function handleCta() {
+    if (insight.linkTo) {
+      navigate(insight.linkTo);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 12,
+        padding: '12px 14px',
+        background: bg,
+        border: `1px solid ${color}26`,
+        borderLeft: `3px solid ${color}`,
+      }}
+    >
+      {/* Icon */}
+      <div style={{ paddingTop: 1, flexShrink: 0 }}>
+        <SeverityIcon severity={insight.severity} size={14} />
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 12,
+            fontWeight: 600,
+            color: 'var(--text-primary)',
+            marginBottom: 3,
+          }}
+        >
+          {insight.title}
+        </div>
+        <div
+          style={{
+            fontFamily: 'var(--font-sans)',
+            fontSize: 11,
+            color: 'var(--text-secondary)',
+            lineHeight: 1.5,
+          }}
+        >
+          {insight.explanation}
+        </div>
+      </div>
+
+      {/* CTA */}
+      {insight.action && insight.linkTo && (
+        <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+          <button
+            onClick={handleCta}
+            style={{
+              background: 'transparent',
+              border: `1px solid ${color}66`,
+              borderRadius: 2,
+              padding: '3px 8px',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: color,
+              cursor: 'pointer',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {insight.action}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Action Center panel ──────────────────────────────────────────────────
+
+export function ActionCenter({ insights }: ActionCenterProps) {
+  const [expanded, setExpanded] = useState(true);
+
+  const criticalCount = insights.filter((i) => i.severity === 'critical').length;
+  const warningCount = insights.filter((i) => i.severity === 'warning').length;
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-surface)',
+        border: '1px solid var(--border-primary)',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          cursor: 'pointer',
+          borderBottom: expanded ? '1px solid var(--border-subtle)' : 'none',
+          userSelect: 'none',
+        }}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--text-muted)',
+              fontFamily: 'var(--font-mono)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+            }}
+          >
+            Action Center
+          </span>
+
+          {/* Badge summary when collapsed or when there are active issues */}
+          {insights.length > 0 && (
+            <div style={{ display: 'flex', gap: 5 }}>
+              {criticalCount > 0 && (
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 3,
+                    padding: '1px 5px',
+                    background: 'rgba(255, 71, 87, 0.15)',
+                    border: '1px solid rgba(255, 71, 87, 0.3)',
+                    borderRadius: 2,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-loss)',
+                    fontWeight: 600,
+                  }}
+                >
+                  <AlertCircle size={9} />
+                  {criticalCount}
+                </span>
+              )}
+              {warningCount > 0 && (
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 3,
+                    padding: '1px 5px',
+                    background: 'rgba(251, 191, 36, 0.15)',
+                    border: '1px solid rgba(251, 191, 36, 0.3)',
+                    borderRadius: 2,
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 10,
+                    color: 'var(--color-warning)',
+                    fontWeight: 600,
+                  }}
+                >
+                  <AlertTriangle size={9} />
+                  {warningCount}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div style={{ color: 'var(--text-muted)', display: 'flex', alignItems: 'center' }}>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </div>
+      </div>
+
+      {/* Body */}
+      {expanded && (
+        <div>
+          {insights.length === 0 ? (
+            // Empty state
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '16px',
+                color: 'var(--text-muted)',
+              }}
+            >
+              <CheckCircle size={16} color="var(--color-gain)" />
+              <span
+                style={{
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 12,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                No actions needed — portfolio looks good
+              </span>
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {insights.map((insight) => (
+                <InsightCard key={insight.id} insight={insight} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -10,9 +10,11 @@ import {
   CURRENCY_COLORS,
 } from '../lib/constants';
 import { EmptyState } from './ui/EmptyState';
+import { ActionCenter } from './ActionCenter';
+import { useActionInsights } from '../hooks/useActionInsights';
 import { config } from '../lib/config';
 import { Select } from './ui/Select';
-import type { AccountType, PortfolioSnapshot } from '../types/portfolio';
+import type { AccountType, HoldingWithPrice, PortfolioSnapshot } from '../types/portfolio';
 
 interface DashboardProps {
   portfolio: PortfolioSnapshot | null;
@@ -107,6 +109,7 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
   }, [filteredHoldings]);
 
   const [allocView, setAllocView] = useState<'type' | 'account'>('type');
+  const actionInsights = useActionInsights(portfolio, filteredHoldings as HoldingWithPrice[]);
 
   const allocationData = useMemo(() => {
     if (!portfolio || totals.totalValue === 0) return [];
@@ -264,773 +267,801 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
   }
 
   return (
-    <div
-      className="dashboard-grid"
-      style={{
-        gridTemplateRows: 'minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto',
-      }}
-    >
-      {/* Panel 1 — Portfolio Value (spans 2 cols) */}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <ActionCenter insights={actionInsights} />
       <div
+        className="dashboard-grid"
         style={{
-          ...PANEL,
-          gridColumn: 'span 2',
-          background: 'var(--bg-surface)',
-          minHeight: 0,
-          overflow: 'hidden',
+          gridTemplateRows: 'auto auto auto auto',
         }}
       >
-        <div style={LABEL}>Portfolio Value ({baseCurrency})</div>
-        <div style={{ width: 180, marginBottom: 12 }}>
-          <Select
-            value={accountFilter}
-            onChange={(value) => setAccountFilter(value as 'all' | AccountType)}
-            options={[
-              { value: 'all', label: 'All Accounts' },
-              ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
-            ]}
-          />
-        </div>
+        {/* Panel 1 — Portfolio Value (spans 2 cols) */}
         <div
           style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 48,
-            fontWeight: 600,
-            color: 'var(--text-primary)',
-            lineHeight: 1.1,
-            letterSpacing: '-0.02em',
+            ...PANEL,
+            gridColumn: 'span 2',
+            background: 'var(--bg-surface)',
+            minHeight: 0,
+            overflow: 'hidden',
           }}
         >
-          {portfolio ? formatCurrency(totals.totalValue, baseCurrency) : '—'}
-        </div>
-        <div style={{ display: 'flex', gap: 24, marginTop: 10, alignItems: 'baseline' }}>
-          <span
+          <div style={LABEL}>Portfolio Value ({baseCurrency})</div>
+          <div style={{ width: 180, marginBottom: 12 }}>
+            <Select
+              value={accountFilter}
+              onChange={(value) => setAccountFilter(value as 'all' | AccountType)}
+              options={[
+                { value: 'all', label: 'All Accounts' },
+                ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
+              ]}
+            />
+          </div>
+          <div
             style={{
               fontFamily: 'var(--font-mono)',
-              fontSize: 16,
+              fontSize: 48,
               fontWeight: 600,
-              color: pnlColor(totals.dailyPnl),
+              color: 'var(--text-primary)',
+              lineHeight: 1.1,
+              letterSpacing: '-0.02em',
             }}
           >
-            {portfolio
-              ? `${totals.dailyPnl >= 0 ? '+' : ''}${formatCurrency(totals.dailyPnl, baseCurrency)}`
-              : '—'}
-          </span>
-          {portfolio && (
+            {portfolio ? formatCurrency(totals.totalValue, baseCurrency) : '—'}
+          </div>
+          <div style={{ display: 'flex', gap: 24, marginTop: 10, alignItems: 'baseline' }}>
             <span
               style={{
                 fontFamily: 'var(--font-mono)',
-                fontSize: 13,
+                fontSize: 16,
+                fontWeight: 600,
                 color: pnlColor(totals.dailyPnl),
               }}
             >
-              today
-            </span>
-          )}
-        </div>
-        <div
-          style={{
-            borderTop: '1px solid var(--border-subtle)',
-            marginTop: 14,
-            paddingTop: 14,
-            display: 'flex',
-            gap: 32,
-          }}
-        >
-          <div>
-            <div style={{ ...LABEL, marginBottom: 2 }}>Cost Basis ({baseCurrency})</div>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 13,
-                color: 'var(--text-secondary)',
-              }}
-            >
-              {portfolio ? formatCurrency(totals.totalCost, baseCurrency) : '—'}
-            </div>
-          </div>
-          <div>
-            <div style={{ ...LABEL, marginBottom: 2 }}>Total Gain/Loss ({baseCurrency})</div>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 13,
-                color: pnlColor(totals.totalGainLoss),
-              }}
-            >
               {portfolio
-                ? `${totals.totalGainLoss >= 0 ? '+' : ''}${formatCurrency(totals.totalGainLoss, baseCurrency)} (${formatPercent(totals.totalGainLossPercent)})`
+                ? `${totals.dailyPnl >= 0 ? '+' : ''}${formatCurrency(totals.dailyPnl, baseCurrency)}`
                 : '—'}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Panel 2 — Asset Allocation */}
-      <div
-        style={{
-          ...PANEL,
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div
-          style={{
-            flexShrink: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginBottom: 8,
-          }}
-        >
-          <div style={{ ...LABEL, marginBottom: 0 }}>Allocation ({baseCurrency})</div>
-          <div style={{ display: 'flex', gap: 0 }}>
-            {(['type', 'account'] as const).map((view) => (
-              <button
-                key={view}
-                onClick={() => setAllocView(view)}
-                style={{
-                  padding: '2px 8px',
-                  fontSize: 10,
-                  fontFamily: 'var(--font-mono)',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.06em',
-                  background: allocView === view ? 'var(--color-accent)' : 'transparent',
-                  border: '1px solid var(--border-primary)',
-                  borderLeft: view === 'account' ? 'none' : '1px solid var(--border-primary)',
-                  color: allocView === view ? '#fff' : 'var(--text-muted)',
-                  cursor: 'pointer',
-                  borderRadius: 0,
-                }}
-              >
-                {view === 'type' ? 'Asset Type' : 'Account'}
-              </button>
-            ))}
-          </div>
-        </div>
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={allocView === 'type' ? allocationData : accountAllocationData}
-                cx="50%"
-                cy="50%"
-                innerRadius={50}
-                outerRadius={72}
-                dataKey="value"
-                strokeWidth={0}
-              >
-                {(allocView === 'type' ? allocationData : accountAllocationData).map((entry, i) => (
-                  <Cell key={i} fill={entry.color} />
-                ))}
-              </Pie>
-              <CenterLabel text={allocView === 'type' ? 'Allocation' : 'Accounts'} />
-              <Tooltip
-                contentStyle={{
-                  background: 'var(--bg-surface)',
-                  border: '1px solid var(--border-primary)',
-                  borderRadius: 0,
-                  fontSize: 12,
-                  fontFamily: 'var(--font-mono)',
-                }}
-                formatter={(v: unknown) => [formatCurrency(Number(v), baseCurrency), '']}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-        <div
-          style={{ flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 4, marginTop: 8 }}
-        >
-          {(allocView === 'type' ? allocationData : accountAllocationData).map((d) => (
-            <div
-              key={d.name}
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                fontSize: 11,
-              }}
-            >
+            </span>
+            {portfolio && (
               <span
                 style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  color: 'var(--text-secondary)',
                   fontFamily: 'var(--font-mono)',
+                  fontSize: 13,
+                  color: pnlColor(totals.dailyPnl),
                 }}
               >
-                <span
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: '50%',
-                    background: d.color,
-                    display: 'inline-block',
-                  }}
-                />
-                {d.name}
+                today
               </span>
-              <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
-                {d.pct.toFixed(1)}% · {formatCurrency(d.value, baseCurrency)}
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Panel 3 — Top Movers (spans 2 cols) — #45 */}
-      <div
-        style={{
-          ...PANEL,
-          gridColumn: 'span 2',
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...LABEL, flexShrink: 0 }}>{topMoversTitle(portfolio?.lastUpdated)}</div>
-        <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
-            <thead>
-              <tr>
-                {['Symbol', 'Name', 'Change %', `Change (${baseCurrency})`].map((col) => (
-                  <th
-                    key={col}
-                    style={{
-                      textAlign:
-                        col === 'Change %' || col === `Change (${baseCurrency})` ? 'right' : 'left',
-                      padding: '4px 0',
-                      color: 'var(--text-muted)',
-                      fontWeight: 400,
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 10,
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.06em',
-                      borderBottom: '1px solid var(--border-primary)',
-                    }}
-                  >
-                    {col}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {topMovers.map((h) => {
-                const dailyChange = h.marketValueCad * (h.dailyChangePercent / 100);
-                const arrow =
-                  h.dailyChangePercent > 0 ? '\u25b2' : h.dailyChangePercent < 0 ? '\u25bc' : '';
-                return (
-                  <tr key={h.id} style={{ borderBottom: '1px solid var(--border-subtle)' }}>
-                    <td
-                      style={{
-                        padding: '6px 0',
-                        fontFamily: 'var(--font-mono)',
-                        fontWeight: 600,
-                        color: 'var(--text-primary)',
-                        fontSize: 12,
-                      }}
-                    >
-                      {h.symbol}
-                    </td>
-                    <td style={{ padding: '6px 0', color: 'var(--text-secondary)', fontSize: 11 }}>
-                      {h.name}
-                    </td>
-                    <td
-                      style={{
-                        padding: '6px 0',
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: pnlColor(h.dailyChangePercent),
-                      }}
-                    >
-                      {arrow && (
-                        <span style={{ marginRight: 3, color: pnlColor(h.dailyChangePercent) }}>
-                          {arrow}
-                        </span>
-                      )}
-                      {formatPercent(h.dailyChangePercent)}
-                    </td>
-                    <td
-                      style={{
-                        padding: '6px 0',
-                        textAlign: 'right',
-                        fontFamily: 'var(--font-mono)',
-                        color: pnlColor(dailyChange),
-                      }}
-                    >
-                      {dailyChange >= 0 ? '+' : ''}
-                      {formatCurrency(dailyChange, baseCurrency)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {/* Panel 4 — Currency Exposure */}
-      <div
-        style={{
-          ...PANEL,
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...LABEL, flexShrink: 0 }}>Currency Exposure ({baseCurrency} base)</div>
-        <div style={{ flex: 1, minHeight: 0 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={currencyData}
-                cx="50%"
-                cy="50%"
-                innerRadius={50}
-                outerRadius={72}
-                dataKey="value"
-                strokeWidth={0}
-              >
-                {currencyData.map((entry, i) => (
-                  <Cell key={i} fill={entry.color} />
-                ))}
-              </Pie>
-              <CenterLabel text="Currency" />
-              <Tooltip
-                contentStyle={{
-                  background: 'var(--bg-surface)',
-                  border: '1px solid var(--border-primary)',
-                  borderRadius: 0,
-                  fontSize: 12,
-                  fontFamily: 'var(--font-mono)',
-                }}
-                formatter={(v: unknown) => [formatCurrency(Number(v), baseCurrency), '']}
-              />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-        <div
-          style={{ flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 4, marginTop: 8 }}
-        >
-          {currencyData.map((d) => (
-            <div
-              key={d.name}
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                fontSize: 11,
-              }}
-            >
-              <span
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  color: 'var(--text-secondary)',
-                  fontFamily: 'var(--font-mono)',
-                }}
-              >
-                <span
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: '50%',
-                    background: d.color,
-                    display: 'inline-block',
-                  }}
-                />
-                {d.name}
-              </span>
-              <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
-                {d.pct.toFixed(1)}%
-              </span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Row 3 — By Account (#49), Concentration (#50), Cash (#51) */}
-
-      {/* Panel 6 — By Account (#49) */}
-      <div
-        style={{
-          ...PANEL,
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...LABEL, flexShrink: 0 }}>By Account</div>
-        {accountData.length === 0 ? (
+            )}
+          </div>
           <div
             style={{
-              color: 'var(--text-muted)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 12,
+              borderTop: '1px solid var(--border-subtle)',
+              marginTop: 14,
+              paddingTop: 14,
+              display: 'flex',
+              gap: 32,
+            }}
+          >
+            <div>
+              <div style={{ ...LABEL, marginBottom: 2 }}>Cost Basis ({baseCurrency})</div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 13,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                {portfolio ? formatCurrency(totals.totalCost, baseCurrency) : '—'}
+              </div>
+            </div>
+            <div>
+              <div style={{ ...LABEL, marginBottom: 2 }}>Total Gain/Loss ({baseCurrency})</div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 13,
+                  color: pnlColor(totals.totalGainLoss),
+                }}
+              >
+                {portfolio
+                  ? `${totals.totalGainLoss >= 0 ? '+' : ''}${formatCurrency(totals.totalGainLoss, baseCurrency)} (${formatPercent(totals.totalGainLossPercent)})`
+                  : '—'}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Panel 2 — Asset Allocation */}
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: 8,
+            }}
+          >
+            <div style={{ ...LABEL, marginBottom: 0 }}>Allocation ({baseCurrency})</div>
+            <div style={{ display: 'flex', gap: 0 }}>
+              {(['type', 'account'] as const).map((view) => (
+                <button
+                  key={view}
+                  onClick={() => setAllocView(view)}
+                  style={{
+                    padding: '2px 8px',
+                    fontSize: 10,
+                    fontFamily: 'var(--font-mono)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                    background: allocView === view ? 'var(--color-accent)' : 'transparent',
+                    border: '1px solid var(--border-primary)',
+                    borderLeft: view === 'account' ? 'none' : '1px solid var(--border-primary)',
+                    color: allocView === view ? '#fff' : 'var(--text-muted)',
+                    cursor: 'pointer',
+                    borderRadius: 0,
+                  }}
+                >
+                  {view === 'type' ? 'Asset Type' : 'Account'}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={allocView === 'type' ? allocationData : accountAllocationData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={72}
+                  dataKey="value"
+                  strokeWidth={0}
+                >
+                  {(allocView === 'type' ? allocationData : accountAllocationData).map(
+                    (entry, i) => (
+                      <Cell key={i} fill={entry.color} />
+                    )
+                  )}
+                </Pie>
+                <CenterLabel text={allocView === 'type' ? 'Allocation' : 'Accounts'} />
+                <Tooltip
+                  contentStyle={{
+                    background: 'var(--bg-surface)',
+                    border: '1px solid var(--border-primary)',
+                    borderRadius: 0,
+                    fontSize: 12,
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                  formatter={(v: unknown) => [formatCurrency(Number(v), baseCurrency), '']}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
               marginTop: 8,
             }}
           >
-            No account data
-          </div>
-        ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {accountData.map((acct) => (
-              <div key={acct.value}>
-                <div
+            {(allocView === 'type' ? allocationData : accountAllocationData).map((d) => (
+              <div
+                key={d.name}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  fontSize: 11,
+                }}
+              >
+                <span
                   style={{
                     display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'baseline',
-                    marginBottom: 4,
+                    alignItems: 'center',
+                    gap: 6,
+                    color: 'var(--text-secondary)',
+                    fontFamily: 'var(--font-mono)',
                   }}
                 >
                   <span
                     style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
-                      color: acct.isSelected ? 'var(--color-accent)' : 'var(--text-secondary)',
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.06em',
-                      fontWeight: acct.isSelected ? 600 : 400,
-                    }}
-                  >
-                    {acct.label}
-                  </span>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
-                      color: acct.isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
-                    }}
-                  >
-                    {formatCurrency(acct.amount, baseCurrency)}{' '}
-                    <span style={{ color: 'var(--text-muted)' }}>{acct.pct.toFixed(1)}%</span>
-                  </span>
-                </div>
-                <div
-                  style={{
-                    height: 4,
-                    background: 'var(--bg-surface-alt)',
-                    border: '1px solid var(--border-subtle)',
-                  }}
-                >
-                  <div
-                    style={{
-                      height: '100%',
-                      width: `${acct.pct}%`,
-                      background: acct.isSelected ? 'var(--color-accent)' : 'var(--border-primary)',
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: d.color,
+                      display: 'inline-block',
                     }}
                   />
-                </div>
+                  {d.name}
+                </span>
+                <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                  {d.pct.toFixed(1)}% · {formatCurrency(d.value, baseCurrency)}
+                </span>
               </div>
             ))}
           </div>
-        )}
-      </div>
+        </div>
 
-      {/* Panel 7 — Concentration (#50) */}
-      <div
-        style={{
-          ...PANEL,
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...LABEL, flexShrink: 0 }}>Concentration</div>
-        {concentrationData.length === 0 ? (
+        {/* Panel 3 — Top Movers (spans 2 cols) — #45 */}
+        <div
+          style={{
+            ...PANEL,
+            gridColumn: 'span 2',
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ ...LABEL, flexShrink: 0 }}>{topMoversTitle(portfolio?.lastUpdated)}</div>
+          <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+              <thead>
+                <tr>
+                  {['Symbol', 'Name', 'Change %', `Change (${baseCurrency})`].map((col) => (
+                    <th
+                      key={col}
+                      style={{
+                        textAlign:
+                          col === 'Change %' || col === `Change (${baseCurrency})`
+                            ? 'right'
+                            : 'left',
+                        padding: '4px 0',
+                        color: 'var(--text-muted)',
+                        fontWeight: 400,
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 10,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                        borderBottom: '1px solid var(--border-primary)',
+                      }}
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {topMovers.map((h) => {
+                  const dailyChange = h.marketValueCad * (h.dailyChangePercent / 100);
+                  const arrow =
+                    h.dailyChangePercent > 0 ? '\u25b2' : h.dailyChangePercent < 0 ? '\u25bc' : '';
+                  return (
+                    <tr key={h.id} style={{ borderBottom: '1px solid var(--border-subtle)' }}>
+                      <td
+                        style={{
+                          padding: '6px 0',
+                          fontFamily: 'var(--font-mono)',
+                          fontWeight: 600,
+                          color: 'var(--text-primary)',
+                          fontSize: 12,
+                        }}
+                      >
+                        {h.symbol}
+                      </td>
+                      <td
+                        style={{ padding: '6px 0', color: 'var(--text-secondary)', fontSize: 11 }}
+                      >
+                        {h.name}
+                      </td>
+                      <td
+                        style={{
+                          padding: '6px 0',
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: pnlColor(h.dailyChangePercent),
+                        }}
+                      >
+                        {arrow && (
+                          <span style={{ marginRight: 3, color: pnlColor(h.dailyChangePercent) }}>
+                            {arrow}
+                          </span>
+                        )}
+                        {formatPercent(h.dailyChangePercent)}
+                      </td>
+                      <td
+                        style={{
+                          padding: '6px 0',
+                          textAlign: 'right',
+                          fontFamily: 'var(--font-mono)',
+                          color: pnlColor(dailyChange),
+                        }}
+                      >
+                        {dailyChange >= 0 ? '+' : ''}
+                        {formatCurrency(dailyChange, baseCurrency)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Panel 4 — Currency Exposure */}
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ ...LABEL, flexShrink: 0 }}>Currency Exposure ({baseCurrency} base)</div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={currencyData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={72}
+                  dataKey="value"
+                  strokeWidth={0}
+                >
+                  {currencyData.map((entry, i) => (
+                    <Cell key={i} fill={entry.color} />
+                  ))}
+                </Pie>
+                <CenterLabel text="Currency" />
+                <Tooltip
+                  contentStyle={{
+                    background: 'var(--bg-surface)',
+                    border: '1px solid var(--border-primary)',
+                    borderRadius: 0,
+                    fontSize: 12,
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                  formatter={(v: unknown) => [formatCurrency(Number(v), baseCurrency), '']}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
           <div
             style={{
-              color: 'var(--text-muted)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 12,
+              flexShrink: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
               marginTop: 8,
             }}
           >
-            No non-cash holdings
+            {currencyData.map((d) => (
+              <div
+                key={d.name}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  fontSize: 11,
+                }}
+              >
+                <span
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    color: 'var(--text-secondary)',
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      background: d.color,
+                      display: 'inline-block',
+                    }}
+                  />
+                  {d.name}
+                </span>
+                <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                  {d.pct.toFixed(1)}%
+                </span>
+              </div>
+            ))}
           </div>
-        ) : (
-          <>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 5, flex: 1 }}>
-              {concentrationData.map((h) => {
-                const assetColor =
-                  ASSET_TYPE_CONFIG[h.assetType as keyof typeof ASSET_TYPE_CONFIG]?.color ?? '#888';
-                return (
+        </div>
+
+        {/* Row 3 — By Account (#49), Concentration (#50), Cash (#51) */}
+
+        {/* Panel 6 — By Account (#49) */}
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ ...LABEL, flexShrink: 0 }}>By Account</div>
+          {accountData.length === 0 ? (
+            <div
+              style={{
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 12,
+                marginTop: 8,
+              }}
+            >
+              No account data
+            </div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {accountData.map((acct) => (
+                <div key={acct.value}>
                   <div
-                    key={h.id}
                     style={{
                       display: 'flex',
                       justifyContent: 'space-between',
-                      alignItems: 'center',
-                      fontSize: 11,
+                      alignItems: 'baseline',
+                      marginBottom: 4,
                     }}
                   >
                     <span
                       style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 6,
                         fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-primary)',
-                        fontWeight: 600,
+                        fontSize: 11,
+                        color: acct.isSelected ? 'var(--color-accent)' : 'var(--text-secondary)',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                        fontWeight: acct.isSelected ? 600 : 400,
                       }}
                     >
-                      <span
-                        style={{
-                          width: 7,
-                          height: 7,
-                          borderRadius: '50%',
-                          background: assetColor,
-                          display: 'inline-block',
-                          flexShrink: 0,
-                        }}
-                      />
-                      {h.symbol}
+                      {acct.label}
                     </span>
                     <span
                       style={{
                         fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-secondary)',
+                        fontSize: 11,
+                        color: acct.isSelected ? 'var(--text-primary)' : 'var(--text-secondary)',
+                      }}
+                    >
+                      {formatCurrency(acct.amount, baseCurrency)}{' '}
+                      <span style={{ color: 'var(--text-muted)' }}>{acct.pct.toFixed(1)}%</span>
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      height: 4,
+                      background: 'var(--bg-surface-alt)',
+                      border: '1px solid var(--border-subtle)',
+                    }}
+                  >
+                    <div
+                      style={{
+                        height: '100%',
+                        width: `${acct.pct}%`,
+                        background: acct.isSelected
+                          ? 'var(--color-accent)'
+                          : 'var(--border-primary)',
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Panel 7 — Concentration (#50) */}
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ ...LABEL, flexShrink: 0 }}>Concentration</div>
+          {concentrationData.length === 0 ? (
+            <div
+              style={{
+                color: 'var(--text-muted)',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 12,
+                marginTop: 8,
+              }}
+            >
+              No non-cash holdings
+            </div>
+          ) : (
+            <>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 5, flex: 1 }}>
+                {concentrationData.map((h) => {
+                  const assetColor =
+                    ASSET_TYPE_CONFIG[h.assetType as keyof typeof ASSET_TYPE_CONFIG]?.color ??
+                    '#888';
+                  return (
+                    <div
+                      key={h.id}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
                         fontSize: 11,
                       }}
                     >
-                      {h.weightPct.toFixed(1)}%
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-            {concentrationStats && (
-              <div
-                style={{
-                  borderTop: '1px solid var(--border-subtle)',
-                  marginTop: 10,
-                  paddingTop: 10,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 3,
-                }}
-              >
+                      <span
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 6,
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-primary)',
+                          fontWeight: 600,
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: '50%',
+                            background: assetColor,
+                            display: 'inline-block',
+                            flexShrink: 0,
+                          }}
+                        />
+                        {h.symbol}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-secondary)',
+                          fontSize: 11,
+                        }}
+                      >
+                        {h.weightPct.toFixed(1)}%
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+              {concentrationStats && (
                 <div
                   style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 11,
-                    color: 'var(--text-muted)',
+                    borderTop: '1px solid var(--border-subtle)',
+                    marginTop: 10,
+                    paddingTop: 10,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 3,
                   }}
                 >
-                  Largest:{' '}
-                  <span style={{ color: 'var(--text-secondary)' }}>
-                    {concentrationStats.largest.toFixed(1)}%
-                  </span>
-                  {'  '}Top 3:{' '}
-                  <span style={{ color: 'var(--text-secondary)' }}>
-                    {concentrationStats.top3.toFixed(1)}%
-                  </span>
-                </div>
-                {concentrationStats.hasRisk && (
                   <div
                     style={{
                       fontFamily: 'var(--font-mono)',
                       fontSize: 11,
-                      color: 'var(--color-warning)',
+                      color: 'var(--text-muted)',
                     }}
                   >
-                    &#9888; Concentration risk
+                    Largest:{' '}
+                    <span style={{ color: 'var(--text-secondary)' }}>
+                      {concentrationStats.largest.toFixed(1)}%
+                    </span>
+                    {'  '}Top 3:{' '}
+                    <span style={{ color: 'var(--text-secondary)' }}>
+                      {concentrationStats.top3.toFixed(1)}%
+                    </span>
                   </div>
-                )}
-              </div>
-            )}
-          </>
-        )}
-      </div>
-
-      {/* Panel 8 — Cash (#51) */}
-      <div
-        style={{
-          ...PANEL,
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
-        }}
-      >
-        <div style={{ ...LABEL, flexShrink: 0 }}>Cash</div>
-        {cashData.positions.length === 0 ? (
-          <div
-            style={{
-              color: 'var(--text-muted)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 12,
-              marginTop: 8,
-            }}
-          >
-            No cash positions
-          </div>
-        ) : (
-          <>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 20,
-                fontWeight: 600,
-                color: 'var(--color-cash)',
-                marginBottom: 2,
-              }}
-            >
-              {formatCurrency(cashData.totalCash, baseCurrency)}
-            </div>
-            <div
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 11,
-                color: 'var(--text-muted)',
-                marginBottom: 12,
-              }}
-            >
-              Investable Cash
-              <span style={{ marginLeft: 6, color: 'var(--text-secondary)' }}>
-                {cashData.cashPct.toFixed(1)}% of portfolio
-              </span>
-            </div>
-            {cashData.positions.length > 1 && (
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-                {cashData.positions.map((pos) => (
-                  <div
-                    key={pos.ccy}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      fontSize: 11,
-                    }}
-                  >
-                    <span
+                  {concentrationStats.hasRisk && (
+                    <div
                       style={{
                         fontFamily: 'var(--font-mono)',
-                        color: 'var(--text-secondary)',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 6,
+                        fontSize: 11,
+                        color: 'var(--color-warning)',
                       }}
                     >
-                      <span
-                        style={{
-                          width: 7,
-                          height: 7,
-                          borderRadius: '50%',
-                          background: CURRENCY_COLORS[pos.ccy] ?? '#888',
-                          display: 'inline-block',
-                        }}
-                      />
-                      {pos.ccy} Cash
-                    </span>
-                    <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
-                      {formatCurrency(pos.amount, baseCurrency)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
-      </div>
+                      &#9888; Concentration risk
+                    </div>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
 
-      {/* Panel 5 — Quick Stats (full width) */}
-      <div
-        style={{
-          ...PANEL,
-          gridColumn: 'span 3',
-          background: 'var(--bg-surface)',
-          display: 'flex',
-          gap: 0,
-        }}
-      >
-        {[
-          {
-            label: 'Positions',
-            value: portfolio
-              ? String(filteredHoldings.filter((h) => h.assetType !== 'cash').length)
-              : '—',
-            sub: portfolio ? `${filteredHoldings.length} total` : '',
-          },
-          {
-            label: 'Best Performer',
-            value: stats?.best ? stats.best.symbol : '—',
-            sub: stats?.best ? formatPercent(stats.best.gainLossPercent) : '',
-            subColor: stats?.best ? pnlColor(stats.best.gainLossPercent) : undefined,
-          },
-          {
-            label: 'Worst Performer',
-            value: stats?.worst ? stats.worst.symbol : '—',
-            sub: stats?.worst ? formatPercent(stats.worst.gainLossPercent) : '',
-            subColor: stats?.worst ? pnlColor(stats.worst.gainLossPercent) : undefined,
-          },
-          {
-            label: 'Cash Position',
-            value: stats ? formatCompact(stats.cashTotal) : '—',
-            sub:
-              stats && totals.totalValue > 0
-                ? `${((stats.cashTotal / totals.totalValue) * 100).toFixed(1)}% of portfolio`
-                : '',
-          },
-          {
-            label: 'Realized Gains',
-            value: portfolio
-              ? `${portfolio.realizedGains >= 0 ? '+' : ''}${formatCurrency(portfolio.realizedGains, baseCurrency)}`
-              : '—',
-            sub: 'All time',
-            subColor: portfolio ? pnlColor(portfolio.realizedGains) : undefined,
-            valueColor: portfolio ? pnlColor(portfolio.realizedGains) : undefined,
-          },
-        ].map((stat, i, arr) => (
-          <div
-            key={stat.label}
-            style={{
-              flex: 1,
-              padding: '0 20px',
-              borderRight: i < arr.length - 1 ? '1px solid var(--border-subtle)' : 'none',
-            }}
-          >
-            <div style={LABEL}>{stat.label}</div>
+        {/* Panel 8 — Cash (#51) */}
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: 0,
+            overflow: 'hidden',
+          }}
+        >
+          <div style={{ ...LABEL, flexShrink: 0 }}>Cash</div>
+          {cashData.positions.length === 0 ? (
             <div
               style={{
+                color: 'var(--text-muted)',
                 fontFamily: 'var(--font-mono)',
-                fontSize: 20,
-                fontWeight: 600,
-                color:
-                  'valueColor' in stat && stat.valueColor ? stat.valueColor : 'var(--text-primary)',
+                fontSize: 12,
+                marginTop: 8,
               }}
             >
-              {stat.value}
+              No cash positions
             </div>
-            {stat.sub && (
+          ) : (
+            <>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 20,
+                  fontWeight: 600,
+                  color: 'var(--color-cash)',
+                  marginBottom: 2,
+                }}
+              >
+                {formatCurrency(cashData.totalCash, baseCurrency)}
+              </div>
               <div
                 style={{
                   fontFamily: 'var(--font-mono)',
                   fontSize: 11,
-                  color: stat.subColor ?? 'var(--text-muted)',
-                  marginTop: 2,
+                  color: 'var(--text-muted)',
+                  marginBottom: 12,
                 }}
               >
-                {stat.sub}
+                Investable Cash
+                <span style={{ marginLeft: 6, color: 'var(--text-secondary)' }}>
+                  {cashData.cashPct.toFixed(1)}% of portfolio
+                </span>
               </div>
-            )}
-          </div>
-        ))}
+              {cashData.positions.length > 1 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+                  {cashData.positions.map((pos) => (
+                    <div
+                      key={pos.ccy}
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        fontSize: 11,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: 'var(--font-mono)',
+                          color: 'var(--text-secondary)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 6,
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: '50%',
+                            background: CURRENCY_COLORS[pos.ccy] ?? '#888',
+                            display: 'inline-block',
+                          }}
+                        />
+                        {pos.ccy} Cash
+                      </span>
+                      <span
+                        style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}
+                      >
+                        {formatCurrency(pos.amount, baseCurrency)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Panel 5 — Quick Stats (full width) */}
+        <div
+          style={{
+            ...PANEL,
+            gridColumn: 'span 3',
+            background: 'var(--bg-surface)',
+            display: 'flex',
+            gap: 0,
+          }}
+        >
+          {[
+            {
+              label: 'Positions',
+              value: portfolio
+                ? String(filteredHoldings.filter((h) => h.assetType !== 'cash').length)
+                : '—',
+              sub: portfolio ? `${filteredHoldings.length} total` : '',
+            },
+            {
+              label: 'Best Performer',
+              value: stats?.best ? stats.best.symbol : '—',
+              sub: stats?.best ? formatPercent(stats.best.gainLossPercent) : '',
+              subColor: stats?.best ? pnlColor(stats.best.gainLossPercent) : undefined,
+            },
+            {
+              label: 'Worst Performer',
+              value: stats?.worst ? stats.worst.symbol : '—',
+              sub: stats?.worst ? formatPercent(stats.worst.gainLossPercent) : '',
+              subColor: stats?.worst ? pnlColor(stats.worst.gainLossPercent) : undefined,
+            },
+            {
+              label: 'Cash Position',
+              value: stats ? formatCompact(stats.cashTotal) : '—',
+              sub:
+                stats && totals.totalValue > 0
+                  ? `${((stats.cashTotal / totals.totalValue) * 100).toFixed(1)}% of portfolio`
+                  : '',
+            },
+            {
+              label: 'Realized Gains',
+              value: portfolio
+                ? `${portfolio.realizedGains >= 0 ? '+' : ''}${formatCurrency(portfolio.realizedGains, baseCurrency)}`
+                : '—',
+              sub: 'All time',
+              subColor: portfolio ? pnlColor(portfolio.realizedGains) : undefined,
+              valueColor: portfolio ? pnlColor(portfolio.realizedGains) : undefined,
+            },
+          ].map((stat, i, arr) => (
+            <div
+              key={stat.label}
+              style={{
+                flex: 1,
+                padding: '0 20px',
+                borderRight: i < arr.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+              }}
+            >
+              <div style={LABEL}>{stat.label}</div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 20,
+                  fontWeight: 600,
+                  color:
+                    'valueColor' in stat && stat.valueColor
+                      ? stat.valueColor
+                      : 'var(--text-primary)',
+                }}
+              >
+                {stat.value}
+              </div>
+              {stat.sub && (
+                <div
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 11,
+                    color: stat.subColor ?? 'var(--text-muted)',
+                    marginTop: 2,
+                  }}
+                >
+                  {stat.sub}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Performance.tsx
+++ b/src/components/Performance.tsx
@@ -88,6 +88,7 @@ const PANEL: React.CSSProperties = {
 
 interface PerformanceProps {
   portfolio: PortfolioSnapshot | null;
+  onRefresh?: () => void;
 }
 
 const STAT_LABEL: React.CSSProperties = {
@@ -143,7 +144,7 @@ function CustomTooltip({
   );
 }
 
-export function Performance({ portfolio }: PerformanceProps) {
+export function Performance({ portfolio, onRefresh }: PerformanceProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const range = (searchParams.get('range') as Range) || '1Y';
   const accountFilter = (searchParams.get('account') as 'all' | AccountType) || 'all';
@@ -266,7 +267,10 @@ export function Performance({ portfolio }: PerformanceProps) {
   if (perfIsEmpty) {
     return (
       <div style={{ ...PANEL }}>
-        <EmptyState message="Performance history will appear here after your first price refresh." />
+        <EmptyState
+          message="Performance history will appear here after your first price refresh."
+          action={onRefresh ? { label: 'Refresh Prices', onClick: onRefresh } : undefined}
+        />
       </div>
     );
   }

--- a/src/hooks/useActionInsights.ts
+++ b/src/hooks/useActionInsights.ts
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import type {
+  ActionInsight,
+  HoldingWithPrice,
+  InsightSeverity,
+  PortfolioSnapshot,
+} from '../types/portfolio';
+
+// ─── Severity sort order ───────────────────────────────────────────────────
+const SEVERITY_RANK: Record<InsightSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+};
+
+// ─── Pure builder function (testable without React) ───────────────────────
+
+export function buildInsights(
+  snapshot: PortfolioSnapshot,
+  holdings: HoldingWithPrice[]
+): ActionInsight[] {
+  if (holdings.length === 0 || snapshot.totalValue <= 0) return [];
+
+  const insights: ActionInsight[] = [];
+
+  // ── 1. target_drift ───────────────────────────────────────────────────────
+  for (const holding of holdings) {
+    if (!holding.targetWeight || holding.targetWeight <= 0) continue;
+
+    const drift = Math.abs(holding.weight - holding.targetWeight);
+    if (drift <= 0.05) continue;
+
+    const severity: InsightSeverity = drift > 0.1 ? 'critical' : 'warning';
+    const driftPct = (drift * 100).toFixed(1);
+    const actualPct = (holding.weight * 100).toFixed(1);
+    const targetPct = (holding.targetWeight * 100).toFixed(1);
+    const direction = holding.weight > holding.targetWeight ? 'overweight' : 'underweight';
+
+    insights.push({
+      id: `target_drift_${holding.id}`,
+      type: 'target_drift',
+      severity,
+      title: `${holding.symbol} is ${direction} by ${driftPct}%`,
+      explanation: `Current weight ${actualPct}% vs target ${targetPct}%. Consider rebalancing.`,
+      metrics: {
+        current: actualPct,
+        target: targetPct,
+        drift: driftPct,
+      },
+      action: 'Review Rebalance',
+      linkTo: '/rebalance',
+    });
+  }
+
+  // ── 2. concentration_risk ─────────────────────────────────────────────────
+  for (const holding of holdings) {
+    const weightPct = holding.weight * 100;
+    if (weightPct <= 30) continue;
+
+    const severity: InsightSeverity = weightPct > 50 ? 'critical' : 'warning';
+
+    insights.push({
+      id: `concentration_risk_${holding.id}`,
+      type: 'concentration_risk',
+      severity,
+      title: `${holding.symbol} dominates the portfolio`,
+      explanation: `${holding.symbol} represents ${weightPct.toFixed(1)}% of portfolio — consider diversifying.`,
+      metrics: {
+        weight: weightPct.toFixed(1),
+      },
+      action: 'View Holdings',
+      linkTo: '/holdings',
+    });
+  }
+
+  // ── 3. idle_cash ──────────────────────────────────────────────────────────
+  const cashHoldings = holdings.filter((h) => h.assetType === 'cash');
+  const totalCash = cashHoldings.reduce((sum, h) => sum + h.marketValueCad, 0);
+  const cashPct = (totalCash / snapshot.totalValue) * 100;
+
+  if (cashPct > 20) {
+    insights.push({
+      id: 'idle_cash',
+      type: 'idle_cash',
+      severity: 'info',
+      title: 'High cash allocation',
+      explanation: `Cash represents ${cashPct.toFixed(1)}% of portfolio — consider deploying.`,
+      metrics: {
+        cashPct: cashPct.toFixed(1),
+      },
+      action: 'View Holdings',
+      linkTo: '/holdings',
+    });
+  }
+
+  // ── 4. missing_targets ────────────────────────────────────────────────────
+  const withoutTarget = holdings.filter((h) => !h.targetWeight || h.targetWeight <= 0);
+  if (withoutTarget.length > holdings.length / 2) {
+    insights.push({
+      id: 'missing_targets',
+      type: 'missing_targets',
+      severity: 'info',
+      title: 'Target weights not set',
+      explanation: `${withoutTarget.length} of ${holdings.length} holdings have no target weight. Set targets to enable rebalancing recommendations.`,
+      metrics: {
+        missing: withoutTarget.length,
+        total: holdings.length,
+      },
+      action: 'Set Targets',
+      linkTo: '/rebalance',
+    });
+  }
+
+  // ── Sort: critical → warning → info, then by estimated impact (weight desc) ──
+  return [...insights].sort((a, b) => {
+    const severityDiff = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (severityDiff !== 0) return severityDiff;
+    // Secondary: holding weight (extracted from metrics if available, else 0)
+    const aWeight = typeof a.metrics?.weight === 'string' ? parseFloat(a.metrics.weight) : 0;
+    const bWeight = typeof b.metrics?.weight === 'string' ? parseFloat(b.metrics.weight) : 0;
+    return bWeight - aWeight;
+  });
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────
+
+export function useActionInsights(
+  snapshot: PortfolioSnapshot | null,
+  holdings: HoldingWithPrice[]
+): ActionInsight[] {
+  return useMemo(() => {
+    if (!snapshot) return [];
+    return buildInsights(snapshot, holdings);
+  }, [snapshot, holdings]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -122,13 +122,13 @@ body::after {
 }
 
 /* #133 — Dashboard responsive grid: stack to 1 column at narrow widths */
+/* #169 — Use min-height instead of fixed height to prevent content overflow */
 .dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: 1px;
   background: var(--border-primary);
   border: 1px solid var(--border-primary);
-  height: 100%;
   min-height: 0;
 }
 

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -289,6 +289,24 @@ export interface PortfolioAnalytics {
   countryBreakdown: CountryWeight[];
 }
 
+export type InsightSeverity = 'info' | 'warning' | 'critical';
+
+export interface ActionInsight {
+  id: string;
+  type:
+    | 'target_drift'
+    | 'concentration_risk'
+    | 'idle_cash'
+    | 'missing_targets'
+    | 'account_imbalance';
+  severity: InsightSeverity;
+  title: string;
+  explanation: string;
+  metrics?: Record<string, string | number>;
+  action?: string;
+  linkTo?: string; // route path like '/rebalance', '/holdings'
+}
+
 // ── Tauri Command Signatures ──
 
 // invoke('get_portfolio')           → PortfolioSnapshot


### PR DESCRIPTION
## Summary
- **#160**: Performance view empty state now shows a "Refresh Prices" button that triggers a live price fetch, enabling snapshot recording on first launch.
- **#168**: New `ActionCenter` panel at the top of Dashboard generates prioritized portfolio insights: target drift, concentration risk, idle cash, and missing target weights. Sorted by severity (critical → warning → info). Collapses when no insights are present.
- **#169**: Dashboard grid rows changed from `minmax(0, 1fr)` (fixed viewport-height division) to `auto` (content-driven sizing). Outer flex wrapper ensures ActionCenter + grid scroll together. Eliminates content being clipped at normal zoom levels.

## New files
- `src/components/ActionCenter.tsx` — insight cards with severity colors, CTA buttons, collapsible header
- `src/hooks/useActionInsights.ts` — `buildInsights()` pure function + `useActionInsights()` hook

## Test plan
- [ ] Dashboard shows Action Center panel above the grid
- [ ] Concentration >30%: warning card; >50%: critical card
- [ ] Cash >20%: info card; missing targets for most holdings: info card
- [ ] Empty portfolio or all-clear: no cards shown
- [ ] Dashboard panels fully visible at 100% zoom without manual zoom-out
- [ ] Performance empty state shows "Refresh Prices" button; clicking it fetches prices

Closes #160, #168, #169