### PR TITLE
feat: add Help screen and responsive UI improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { Dividends } from './components/Dividends';
 import { Settings } from './components/Settings';
 import { TransactionHistory } from './components/TransactionHistory';
 import { Analytics } from './components/Analytics';
+import { Help } from './components/Help';
 import { ToastProvider } from './components/ui/Toast';
 import { useToast } from './components/ui/Toast';
 import { KeyboardShortcutsOverlay } from './components/ui/KeyboardShortcutsOverlay';
@@ -127,6 +128,7 @@ function AppRoutes() {
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/dividends" element={<Dividends />} />
           <Route path="/settings" element={<Settings />} />
+          <Route path="/help" element={<Help />} />
         </Route>
       </Routes>
       <KeyboardShortcutsOverlay

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -1,0 +1,283 @@
+import { BookOpen } from 'lucide-react';
+
+interface Term {
+  term: string;
+  definition: string;
+}
+
+interface HelpSection {
+  title: string;
+  terms: Term[];
+}
+
+const HELP_SECTIONS: HelpSection[] = [
+  {
+    title: 'Portfolio Basics',
+    terms: [
+      {
+        term: 'Holding',
+        definition: 'An individual asset (stock, ETF, crypto, or cash) in your portfolio.',
+      },
+      {
+        term: 'Cost Basis',
+        definition:
+          'The original purchase price per unit of an asset. Used to calculate gains and losses.',
+      },
+      {
+        term: 'Market Value',
+        definition: 'Current price × quantity, converted to your base currency.',
+      },
+      {
+        term: 'Asset Type',
+        definition:
+          'The category of an asset: Stock, ETF, Crypto, or Cash. Used to apply asset-specific shocks in stress tests.',
+      },
+      {
+        term: 'Quantity',
+        definition:
+          'The number of units of an asset you hold (shares, coins, or currency amount for cash).',
+      },
+    ],
+  },
+  {
+    title: 'Performance & Returns',
+    terms: [
+      {
+        term: 'Gain / Loss',
+        definition:
+          'The difference between current market value and your cost basis. Positive = profit, negative = loss.',
+      },
+      {
+        term: 'Daily P&L',
+        definition:
+          "Change in portfolio value since market open, based on each asset's daily price change percentage.",
+      },
+      {
+        term: 'Return (%)',
+        definition: 'Gain or loss expressed as a percentage of your total cost basis.',
+      },
+      {
+        term: 'Weight',
+        definition: "A holding's market value as a percentage of your total portfolio value.",
+      },
+      {
+        term: 'Daily Change %',
+        definition: "The percentage change in an asset's price since the previous market close.",
+      },
+    ],
+  },
+  {
+    title: 'Allocation & Rebalancing',
+    terms: [
+      {
+        term: 'Target Weight',
+        definition: 'Your desired allocation percentage for a holding or asset class.',
+      },
+      {
+        term: 'Drift',
+        definition:
+          "The difference between a holding's current weight and its target weight. Large drift signals a need to rebalance.",
+      },
+      {
+        term: 'Rebalance',
+        definition:
+          'Adjusting holdings by buying or selling to bring allocations back to target weights.',
+      },
+      {
+        term: 'Over-weight',
+        definition:
+          'A holding whose current weight exceeds its target weight, suggesting a potential sell or trim.',
+      },
+      {
+        term: 'Under-weight',
+        definition:
+          'A holding whose current weight is below its target weight, suggesting a potential buy or add.',
+      },
+    ],
+  },
+  {
+    title: 'Risk & Stress Testing',
+    terms: [
+      {
+        term: 'Drawdown',
+        definition:
+          'The peak-to-trough decline in portfolio value during a specific period. Measures downside risk.',
+      },
+      {
+        term: 'Volatility',
+        definition:
+          'The degree of variation in portfolio returns over time. Higher volatility = higher risk.',
+      },
+      {
+        term: 'Stress Scenario',
+        definition:
+          'A hypothetical market shock applied to your holdings to estimate the potential impact on your portfolio value.',
+      },
+      {
+        term: 'Shock (%)',
+        definition:
+          'The percentage change applied to an asset class or FX rate in a stress scenario (e.g., −20% for stocks).',
+      },
+      {
+        term: 'Resilience Score',
+        definition:
+          'A composite metric reflecting portfolio diversification, concentration risk, and cash buffer strength.',
+      },
+    ],
+  },
+  {
+    title: 'Currency & FX',
+    terms: [
+      {
+        term: 'Base Currency',
+        definition:
+          'The currency in which your total portfolio value is displayed. Default is CAD.',
+      },
+      {
+        term: 'FX Rate',
+        definition:
+          "Exchange rate between a holding's native currency and your base currency, used to convert market values.",
+      },
+      {
+        term: 'FX Exposure',
+        definition:
+          'The portion of your portfolio held in assets denominated in a currency other than your base currency.',
+      },
+      {
+        term: 'Cost Value (CAD)',
+        definition:
+          'Your cost basis converted to your base currency using the FX rate at the time of calculation.',
+      },
+    ],
+  },
+  {
+    title: 'Alerts & Dividends',
+    terms: [
+      {
+        term: 'Price Alert',
+        definition:
+          "A notification triggered when an asset's price crosses a threshold you configure.",
+      },
+      {
+        term: 'Alert Condition',
+        definition:
+          'The rule that triggers an alert — e.g., "price above $150" or "price below $100".',
+      },
+      {
+        term: 'Dividend',
+        definition:
+          'A payment made by a company to shareholders, recorded in Dividend History for income tracking.',
+      },
+      {
+        term: 'Yield',
+        definition: 'Annual dividend payment expressed as a percentage of the current share price.',
+      },
+    ],
+  },
+];
+
+const PAGE_WRAPPER: React.CSSProperties = {
+  maxWidth: 960,
+  margin: '0 auto',
+};
+
+const PAGE_HEADER: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 28,
+  paddingBottom: 20,
+  borderBottom: '1px solid var(--border-primary)',
+};
+
+const SECTION_CARD: React.CSSProperties = {
+  background: 'var(--bg-surface)',
+  border: '1px solid var(--border-primary)',
+  padding: '20px 24px',
+  marginBottom: 1,
+};
+
+const SECTION_HEADING: React.CSSProperties = {
+  fontSize: 10,
+  fontFamily: 'var(--font-mono)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.12em',
+  color: 'var(--text-secondary)',
+  marginBottom: 16,
+  paddingBottom: 8,
+  borderBottom: '1px solid var(--border-subtle)',
+};
+
+const TERM_GRID: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))',
+  gap: '12px 24px',
+};
+
+const TERM_ROW: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 3,
+};
+
+const TERM_LABEL: React.CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'var(--text-primary)',
+};
+
+const TERM_DEF: React.CSSProperties = {
+  fontFamily: 'var(--font-sans)',
+  fontSize: 12,
+  color: 'var(--text-secondary)',
+  lineHeight: 1.55,
+};
+
+export function Help() {
+  return (
+    <div style={PAGE_WRAPPER}>
+      {/* Page header */}
+      <div style={PAGE_HEADER}>
+        <BookOpen size={20} style={{ color: 'var(--color-accent)', flexShrink: 0 }} />
+        <div>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 16,
+              fontWeight: 700,
+              color: 'var(--text-primary)',
+            }}
+          >
+            Help &amp; Glossary
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--font-sans)',
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+              marginTop: 3,
+            }}
+          >
+            Definitions for terms used throughout Portfolio Tracker.
+          </div>
+        </div>
+      </div>
+
+      {/* Sections */}
+      {HELP_SECTIONS.map((section) => (
+        <div key={section.title} style={SECTION_CARD}>
+          <div style={SECTION_HEADING}>{section.title}</div>
+          <div style={TERM_GRID}>
+            {section.terms.map(({ term, definition }) => (
+              <div key={term} style={TERM_ROW}>
+                <span style={TERM_LABEL}>{term}</span>
+                <span style={TERM_DEF}>{definition}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   BarChart2,
   DollarSign,
   Settings2,
+  HelpCircle,
   ChevronsLeft,
   ChevronsRight,
 } from 'lucide-react';
@@ -35,6 +36,7 @@ const NAV_ITEMS = [
   { to: '/analytics', label: 'Analytics', Icon: BarChart2 },
   { to: '/dividends', label: 'Dividends', Icon: DollarSign },
   { to: '/settings', label: 'Settings', Icon: Settings2 },
+  { to: '/help', label: 'Help', Icon: HelpCircle },
 ];
 
 export function Sidebar({ portfolio }: SidebarProps) {

--- a/src/components/StressTest.tsx
+++ b/src/components/StressTest.tsx
@@ -25,6 +25,7 @@ import { formatCurrency, formatPercent, formatCompact } from '../lib/format';
 import { pnlColor } from '../lib/colors';
 import { EmptyState } from './ui/EmptyState';
 import { Select } from './ui/Select';
+import { CollapsiblePanel } from './ui/CollapsiblePanel';
 import { StressTestInfo } from './StressTestInfo';
 import { config } from '../lib/config';
 import type {
@@ -1160,124 +1161,127 @@ export function StressTest() {
 
           {/* Breakdown table */}
           {result && !allZero && (
-            <div style={{ ...PANEL, overflow: 'auto', maxHeight: 360 }}>
-              <div style={SECTION_TITLE}>Breakdown</div>
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
-                <thead style={{ position: 'sticky', top: 0 }}>
-                  <tr>
-                    {[
-                      'Symbol',
-                      'Type',
-                      `Current Value (${baseCurrency})`,
-                      'Shock',
-                      `Stressed Value (${baseCurrency})`,
-                      `Impact (${baseCurrency})`,
-                      'Impact (%)',
-                    ].map((col) => (
-                      <th
-                        key={col}
-                        style={{
-                          ...TD,
-                          background: 'var(--bg-surface-alt)',
-                          color: 'var(--text-secondary)',
-                          fontWeight: 600,
-                          textTransform: 'uppercase',
-                          letterSpacing: '0.06em',
-                          fontSize: 9,
-                          textAlign: col === 'Symbol' || col === 'Type' ? 'left' : 'right',
-                          borderBottom: '1px solid var(--border-primary)',
-                        }}
-                      >
-                        {col}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {[...result.holdingBreakdown]
-                    .sort((a, b) => a.impact - b.impact)
-                    .map((h, i) => {
-                      const holding = filteredPortfolio?.holdings.find((p) => p.id === h.holdingId);
-                      const bg = i % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
-                      return (
-                        <tr key={h.holdingId} style={{ background: bg }}>
-                          <td
-                            style={{
-                              ...TD,
-                              fontFamily: 'var(--font-mono)',
-                              fontWeight: 700,
-                              color: 'var(--text-primary)',
-                            }}
-                          >
-                            {h.symbol}
-                          </td>
-                          <td style={{ ...TD, color: 'var(--text-secondary)' }}>
-                            {holding
-                              ? (ASSET_TYPE_CONFIG[holding.assetType]?.label ?? holding.assetType)
-                              : '—'}
-                          </td>
-                          <td
-                            style={{
-                              ...TD,
-                              textAlign: 'right',
-                              fontFamily: 'var(--font-mono)',
-                              color: 'var(--text-secondary)',
-                            }}
-                          >
-                            {formatCurrency(h.currentValue, baseCurrency)}
-                          </td>
-                          <td
-                            style={{
-                              ...TD,
-                              textAlign: 'right',
-                              fontFamily: 'var(--font-mono)',
-                              color: pnlColor(h.shockApplied),
-                            }}
-                          >
-                            {h.shockApplied !== 0 ? formatPercent(h.shockApplied * 100) : '—'}
-                          </td>
-                          <td
-                            style={{
-                              ...TD,
-                              textAlign: 'right',
-                              fontFamily: 'var(--font-mono)',
-                              color: pnlColor(h.impact),
-                            }}
-                          >
-                            {formatCurrency(h.stressedValue, baseCurrency)}
-                          </td>
-                          <td
-                            style={{
-                              ...TD,
-                              textAlign: 'right',
-                              fontFamily: 'var(--font-mono)',
-                              fontWeight: 600,
-                              color: pnlColor(h.impact),
-                            }}
-                          >
-                            {h.impact !== 0
-                              ? `${h.impact >= 0 ? '+' : ''}${formatCurrency(h.impact, baseCurrency)}`
-                              : '—'}
-                          </td>
-                          <td
-                            style={{
-                              ...TD,
-                              textAlign: 'right',
-                              fontFamily: 'var(--font-mono)',
-                              color: pnlColor(h.impact),
-                              borderRight: 'none',
-                            }}
-                          >
-                            {h.impact !== 0
-                              ? formatPercent((h.impact / h.currentValue) * 100)
-                              : '—'}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                </tbody>
-              </table>
-            </div>
+            <CollapsiblePanel title="Breakdown" defaultExpanded={true}>
+              <div style={{ overflow: 'auto', maxHeight: 360 }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>
+                  <thead style={{ position: 'sticky', top: 0 }}>
+                    <tr>
+                      {[
+                        'Symbol',
+                        'Type',
+                        `Current Value (${baseCurrency})`,
+                        'Shock',
+                        `Stressed Value (${baseCurrency})`,
+                        `Impact (${baseCurrency})`,
+                        'Impact (%)',
+                      ].map((col) => (
+                        <th
+                          key={col}
+                          style={{
+                            ...TD,
+                            background: 'var(--bg-surface-alt)',
+                            color: 'var(--text-secondary)',
+                            fontWeight: 600,
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.06em',
+                            fontSize: 9,
+                            textAlign: col === 'Symbol' || col === 'Type' ? 'left' : 'right',
+                            borderBottom: '1px solid var(--border-primary)',
+                          }}
+                        >
+                          {col}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...result.holdingBreakdown]
+                      .sort((a, b) => a.impact - b.impact)
+                      .map((h, i) => {
+                        const holding = filteredPortfolio?.holdings.find(
+                          (p) => p.id === h.holdingId
+                        );
+                        const bg = i % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
+                        return (
+                          <tr key={h.holdingId} style={{ background: bg }}>
+                            <td
+                              style={{
+                                ...TD,
+                                fontFamily: 'var(--font-mono)',
+                                fontWeight: 700,
+                                color: 'var(--text-primary)',
+                              }}
+                            >
+                              {h.symbol}
+                            </td>
+                            <td style={{ ...TD, color: 'var(--text-secondary)' }}>
+                              {holding
+                                ? (ASSET_TYPE_CONFIG[holding.assetType]?.label ?? holding.assetType)
+                                : '—'}
+                            </td>
+                            <td
+                              style={{
+                                ...TD,
+                                textAlign: 'right',
+                                fontFamily: 'var(--font-mono)',
+                                color: 'var(--text-secondary)',
+                              }}
+                            >
+                              {formatCurrency(h.currentValue, baseCurrency)}
+                            </td>
+                            <td
+                              style={{
+                                ...TD,
+                                textAlign: 'right',
+                                fontFamily: 'var(--font-mono)',
+                                color: pnlColor(h.shockApplied),
+                              }}
+                            >
+                              {h.shockApplied !== 0 ? formatPercent(h.shockApplied * 100) : '—'}
+                            </td>
+                            <td
+                              style={{
+                                ...TD,
+                                textAlign: 'right',
+                                fontFamily: 'var(--font-mono)',
+                                color: pnlColor(h.impact),
+                              }}
+                            >
+                              {formatCurrency(h.stressedValue, baseCurrency)}
+                            </td>
+                            <td
+                              style={{
+                                ...TD,
+                                textAlign: 'right',
+                                fontFamily: 'var(--font-mono)',
+                                fontWeight: 600,
+                                color: pnlColor(h.impact),
+                              }}
+                            >
+                              {h.impact !== 0
+                                ? `${h.impact >= 0 ? '+' : ''}${formatCurrency(h.impact, baseCurrency)}`
+                                : '—'}
+                            </td>
+                            <td
+                              style={{
+                                ...TD,
+                                textAlign: 'right',
+                                fontFamily: 'var(--font-mono)',
+                                color: pnlColor(h.impact),
+                                borderRight: 'none',
+                              }}
+                            >
+                              {h.impact !== 0
+                                ? formatPercent((h.impact / h.currentValue) * 100)
+                                : '—'}
+                            </td>
+                          </tr>
+                        );
+                      })}
+                  </tbody>
+                </table>
+              </div>
+            </CollapsiblePanel>
           )}
         </div>
       </div>

--- a/src/components/ui/CollapsiblePanel.tsx
+++ b/src/components/ui/CollapsiblePanel.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+export interface CollapsiblePanelProps {
+  title: string;
+  defaultExpanded?: boolean;
+  children: React.ReactNode;
+}
+
+export function CollapsiblePanel({
+  title,
+  defaultExpanded = true,
+  children,
+}: CollapsiblePanelProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <div
+      style={{
+        background: 'var(--bg-surface)',
+        border: '1px solid var(--border-primary)',
+        marginBottom: 1,
+      }}
+    >
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '14px 20px',
+          background: 'transparent',
+          border: 'none',
+          borderBottom: expanded ? '1px solid var(--border-subtle)' : 'none',
+          cursor: 'pointer',
+          color: 'var(--text-secondary)',
+          transition: 'color 150ms',
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-primary)';
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.color = 'var(--text-secondary)';
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 10,
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+            color: 'var(--text-muted)',
+          }}
+        >
+          {title}
+        </span>
+        <ChevronDown
+          size={14}
+          style={{
+            flexShrink: 0,
+            transform: `rotate(${expanded ? 0 : -90}deg)`,
+            transition: 'transform 200ms ease',
+            color: 'var(--text-muted)',
+          }}
+        />
+      </button>
+
+      {/* Content */}
+      {expanded && <div style={{ padding: '16px 20px' }}>{children}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **#170**: New Help screen at `/help` with a glossary organized into 6 sections (Portfolio Basics, Performance & Returns, Allocation & Rebalancing, Risk & Stress Testing, Currency & FX, Alerts & Dividends). Accessible via HelpCircle icon in the sidebar. Two-column responsive grid layout.
- **#171**: New `CollapsiblePanel` reusable component with animated chevron toggle. Applied to the Stress Test results breakdown table. Layout.tsx main content area already had `overflowY: auto`.

## New files
- `src/components/Help.tsx` — glossary screen with 6 sections
- `src/components/ui/CollapsiblePanel.tsx` — reusable collapsible panel

## Test plan
- [ ] Help nav item appears in sidebar with HelpCircle icon
- [ ] `/help` route renders all 6 glossary sections
- [ ] Terms use `font-mono`, definitions use `font-sans`
- [ ] Stress Test breakdown table is inside collapsible panel; click header to toggle
- [ ] Chevron animates on expand/collapse

Closes #170, #171