### PR TITLE
fix: dashboard chart overflow, Action Center collapsed, account selector z-index (#184 #185 #186)

### DIFF
--- a/src/components/ActionCenter.tsx
+++ b/src/components/ActionCenter.tsx
@@ -123,7 +123,7 @@ function InsightCard({ insight }: InsightCardProps) {
 // ─── Action Center panel ──────────────────────────────────────────────────
 
 export function ActionCenter({ insights }: ActionCenterProps) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
 
   const criticalCount = insights.filter((i) => i.severity === 'critical').length;
   const warningCount = insights.filter((i) => i.severity === 'warning').length;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -241,25 +241,28 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
 
   if (portfolio && accountFilter !== 'all' && filteredHoldings.length === 0 && !loading) {
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          gap: 16,
-        }}
-      >
-        <div style={{ width: 180 }}>
-          <Select
-            value={accountFilter}
-            onChange={(value) => setAccountFilter(value as 'all' | AccountType)}
-            options={[
-              { value: 'all', label: 'All Accounts' },
-              ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
-            ]}
-          />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <ActionCenter insights={actionInsights} />
+        <div
+          style={{
+            ...PANEL,
+            background: 'var(--bg-surface)',
+            overflow: 'visible',
+            position: 'relative',
+            zIndex: 1,
+          }}
+        >
+          <div style={LABEL}>Portfolio Value ({baseCurrency})</div>
+          <div style={{ width: 180, marginBottom: 12 }}>
+            <Select
+              value={accountFilter}
+              onChange={(value) => setAccountFilter(value as 'all' | AccountType)}
+              options={[
+                { value: 'all', label: 'All Accounts' },
+                ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
+              ]}
+            />
+          </div>
         </div>
         <EmptyState message="No holdings in this account." />
       </div>
@@ -282,7 +285,9 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
             gridColumn: 'span 2',
             background: 'var(--bg-surface)',
             minHeight: 0,
-            overflow: 'hidden',
+            overflow: 'visible',
+            position: 'relative',
+            zIndex: 1,
           }}
         >
           <div style={LABEL}>Portfolio Value ({baseCurrency})</div>
@@ -416,7 +421,7 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
               ))}
             </div>
           </div>
-          <div style={{ flex: 1, minHeight: 0 }}>
+          <div style={{ height: 200, flexShrink: 0 }}>
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Pie
@@ -604,7 +609,7 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
           }}
         >
           <div style={{ ...LABEL, flexShrink: 0 }}>Currency Exposure ({baseCurrency} base)</div>
-          <div style={{ flex: 1, minHeight: 0 }}>
+          <div style={{ height: 200, flexShrink: 0 }}>
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Pie


### PR DESCRIPTION
## Summary

- **#184**: Wrap allocation and currency exposure charts in a fixed-height (`200px`) div so `ResponsiveContainer height="100%"` has a bounded parent — prevents charts being clipped to zero height
- **#185**: Change `ActionCenter` default `expanded` state from `true` → `false` so panel is collapsed on first load
- **#186**: Remove `overflow: hidden` from Portfolio Value card to stop the account selector dropdown being clipped; fix empty-account layout so the selector stays anchored in the toolbar instead of recentering in the viewport

## Test plan
- [ ] Dashboard with holdings: allocation and currency charts visible in full (no top/bottom clipping)
- [ ] Dashboard on first load: Action Center shows collapsed (header only)
- [ ] Account Selector dropdown opens above all cards with no clipping
- [ ] Selecting an account with no holdings: selector stays in toolbar, empty state appears below