### PR TITLE
fix: replace native selects with custom Select component; style date inputs (#187 #188)

### DIFF
--- a/src/components/Alerts.tsx
+++ b/src/components/Alerts.tsx
@@ -3,6 +3,7 @@ import { Bell, BellOff, Plus, Trash2, RefreshCw } from 'lucide-react';
 import type { AlertDirection, PriceAlert, PriceAlertInput } from '../types/portfolio';
 import { formatCurrency } from '../lib/format';
 import { EmptyState } from './ui/EmptyState';
+import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
 import { isTauri, tauriInvoke } from '../lib/tauri';
@@ -94,14 +95,14 @@ function AddAlertForm({ onAdd, onCancel }: AddAlertFormProps) {
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>DIRECTION</div>
-          <select
-            style={inputStyle}
+          <Select
             value={direction}
-            onChange={(e) => setDirection(e.target.value as AlertDirection)}
-          >
-            <option value="above">Above</option>
-            <option value="below">Below</option>
-          </select>
+            onChange={(value) => setDirection(value as AlertDirection)}
+            options={[
+              { value: 'above', label: 'Above' },
+              { value: 'below', label: 'Below' },
+            ]}
+          />
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>PRICE</div>

--- a/src/components/Dividends.tsx
+++ b/src/components/Dividends.tsx
@@ -4,6 +4,7 @@ import type { Dividend, DividendInput, Holding } from '../types/portfolio';
 import { formatCurrency } from '../lib/format';
 import { MOCK_DIVIDENDS, MOCK_HOLDINGS } from '../lib/mockData';
 import { EmptyState } from './ui/EmptyState';
+import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
 import { isTauri, tauriInvoke } from '../lib/tauri';
@@ -61,18 +62,11 @@ function AddDividendForm({ holdings, onAdd, onCancel }: AddDividendFormProps) {
       <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr 1fr', gap: 10 }}>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>HOLDING</div>
-          <select
-            style={inputStyle}
+          <Select
             value={holdingId}
-            onChange={(e) => setHoldingId(e.target.value)}
-            required
-          >
-            {holdings.map((h) => (
-              <option key={h.id} value={h.id}>
-                {h.symbol} — {h.name}
-              </option>
-            ))}
-          </select>
+            onChange={setHoldingId}
+            options={holdings.map((h) => ({ value: h.id, label: `${h.symbol} — ${h.name}` }))}
+          />
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>
@@ -91,34 +85,38 @@ function AddDividendForm({ holdings, onAdd, onCancel }: AddDividendFormProps) {
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>CURRENCY</div>
-          <select style={inputStyle} value={currency} onChange={(e) => setCurrency(e.target.value)}>
-            {['CAD', 'USD', 'EUR', 'GBP'].map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={currency}
+            onChange={setCurrency}
+            options={['CAD', 'USD', 'EUR', 'GBP'].map((c) => ({ value: c, label: c }))}
+          />
         </div>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>EX-DATE</div>
           <input
-            style={inputStyle}
+            style={{ ...inputStyle, colorScheme: 'dark' }}
             type="date"
             value={exDate}
             onChange={(e) => setExDate(e.target.value)}
+            placeholder="YYYY-MM-DD"
             required
+            onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--color-accent)')}
+            onBlur={(e) => (e.currentTarget.style.borderColor = 'var(--border-primary)')}
           />
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>PAY DATE</div>
           <input
-            style={inputStyle}
+            style={{ ...inputStyle, colorScheme: 'dark' }}
             type="date"
             value={payDate}
             onChange={(e) => setPayDate(e.target.value)}
+            placeholder="YYYY-MM-DD"
             required
+            onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--color-accent)')}
+            onBlur={(e) => (e.currentTarget.style.borderColor = 'var(--border-primary)')}
           />
         </div>
       </div>

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -17,6 +17,7 @@ import { AddTransactionModal } from './AddTransactionModal';
 import { ImportHoldingsModal } from './ImportHoldingsModal';
 import { Badge } from './ui/Badge';
 import { EmptyState } from './ui/EmptyState';
+import { Select } from './ui/Select';
 import { useToast } from './ui/Toast';
 import { formatCurrency, formatNumber, formatPercent, isPriceStale } from '../lib/format';
 import { pnlColor } from '../lib/colors';
@@ -477,26 +478,15 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
               width: 160,
             }}
           />
-          <select
+          <Select
             value={accountFilter}
-            onChange={(e) => handleAccountFilterChange(e.target.value as 'all' | AccountType)}
-            style={{
-              background: 'var(--bg-surface)',
-              border: '1px solid var(--border-primary)',
-              color: 'var(--text-primary)',
-              padding: '6px 10px',
-              fontSize: 11,
-              fontFamily: 'var(--font-mono)',
-              borderRadius: '2px',
-            }}
-          >
-            <option value="all">All Accounts</option>
-            {ACCOUNT_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+            onChange={(value) => handleAccountFilterChange(value as 'all' | AccountType)}
+            options={[
+              { value: 'all', label: 'All Accounts' },
+              ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
+            ]}
+            style={{ width: 160 }}
+          />
           <button
             onClick={() => setGroupByAccount((prev) => !prev)}
             title={groupByAccount ? 'Disable group by account' : 'Group by account'}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import { Download, Upload } from 'lucide-react';
 import { useConfig } from '../hooks/useConfig';
 import { useAutoRefresh } from '../hooks/useAutoRefresh';
 import { AccountsModal } from './AccountsModal';
+import { Select } from './ui/Select';
 
 const CURRENCIES = ['CAD', 'USD', 'EUR', 'GBP', 'AUD', 'CHF', 'JPY'];
 
@@ -59,41 +60,6 @@ function SettingRow({
       </div>
       <div style={{ flexShrink: 0 }}>{children}</div>
     </div>
-  );
-}
-
-function Select({
-  value,
-  onChange,
-  options,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  options: { label: string; value: string }[];
-}) {
-  return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      style={{
-        background: 'var(--bg-surface-alt)',
-        border: '1px solid var(--border-primary)',
-        color: 'var(--text-primary)',
-        fontSize: 13,
-        padding: '6px 10px',
-        borderRadius: 2,
-        cursor: 'pointer',
-        outline: 'none',
-        minWidth: 160,
-        fontFamily: 'var(--font-sans)',
-      }}
-    >
-      {options.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
   );
 }
 
@@ -548,6 +514,7 @@ export function Settings() {
             value={baseCurrency}
             onChange={setBaseCurrency}
             options={CURRENCIES.map((c) => ({ label: c, value: c }))}
+            style={{ minWidth: 160 }}
           />
         </SettingRow>
       </div>
@@ -570,6 +537,7 @@ export function Settings() {
             value={autoRefreshMsStr}
             onChange={(v) => setAutoRefreshInterval(Math.round(Number(v) / 60_000))}
             options={REFRESH_OPTIONS}
+            style={{ minWidth: 160 }}
           />
         </SettingRow>
         <SettingRow


### PR DESCRIPTION
## Summary

- **#187**: Replace all native `<select>` elements with the existing `ui/Select` custom component in Holdings (account filter), Alerts (direction), Dividends (holding, currency), and Settings (base currency, auto-refresh). Removes the redundant local `Select` wrapper in Settings.
- **#188**: Apply dark-themed styling (`var(--bg-surface)`, `var(--border-primary)`) to Dividends date inputs with `colorScheme: 'dark'` for the native calendar popup. Adds focus/blur border transitions and `YYYY-MM-DD` placeholder.

## Test plan
- [ ] Holdings: account filter dropdown matches dark theme
- [ ] Alerts: direction dropdown (above/below) uses custom Select styling
- [ ] Dividends: holding and currency dropdowns use custom Select; date inputs are dark-themed and readable
- [ ] Settings: base currency and auto-refresh selects use custom component
- [ ] All dropdowns retain keyboard navigation