### PR TITLE
fix: use quoteSummary assetProfile for sector data; hide geo chart when sparse (#191)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1368,8 +1368,59 @@ pub async fn get_rebalance_suggestions(
 
 // ── Analytics Commands ────────────────────────────────────────────────────────
 
+/// Fetch per-symbol sector/industry/country from Yahoo Finance's v11 quoteSummary
+/// `assetProfile` module. Returns `None` for all three fields on any fetch/parse failure
+/// (failures are soft — they don't abort the whole analytics call).
+async fn fetch_asset_profile(
+    client: &reqwest::Client,
+    symbol: &str,
+) -> (String, Option<String>, Option<String>, Option<String>) {
+    let url = crate::config::YAHOO_QUOTE_SUMMARY_URL.replace("{}", symbol);
+
+    let json: Option<serde_json::Value> = async {
+        let resp = client
+            .get(&url)
+            .header("User-Agent", crate::config::USER_AGENT)
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.json::<serde_json::Value>().await.ok()
+    }
+    .await;
+
+    let profile = json
+        .as_ref()
+        .and_then(|v| v.pointer("/quoteSummary/result/0/assetProfile"));
+
+    let extract = |key: &str| -> Option<String> {
+        profile
+            .and_then(|p| p.get(key))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+    };
+
+    (
+        symbol.to_string(),
+        extract("sector"),
+        extract("industry"),
+        extract("country"),
+    )
+}
+
 /// Fetch enriched symbol metadata (sector, industry, country, market cap, etc.)
-/// from Yahoo Finance's v7 quote endpoint.
+/// for the given list of symbols.
+///
+/// * Sector, industry, and country are fetched from the v11 `quoteSummary` / `assetProfile`
+///   endpoint, which reliably returns these fields (unlike the v7 quote endpoint).
+/// * Numeric fields (market cap, P/E, dividend yield, beta) continue to come from the
+///   bulk v7 quote endpoint.
+///
+/// Both requests are issued concurrently. A failure on either is treated as a soft
+/// error so that partial data is still returned.
 pub(crate) async fn get_symbol_metadata_internal(
     client: &reqwest::Client,
     symbols: &[String],
@@ -1378,65 +1429,83 @@ pub(crate) async fn get_symbol_metadata_internal(
         return Ok(vec![]);
     }
 
+    // ── 1. Bulk quote request for numeric fields ──────────────────────────────
     let joined = symbols.join(",");
-    let url = crate::config::YAHOO_QUOTE_URL.replace("{}", &joined);
+    let quote_url = crate::config::YAHOO_QUOTE_URL.replace("{}", &joined);
 
-    let response = client
-        .get(&url)
+    let quote_future = client
+        .get(&quote_url)
         .header("User-Agent", crate::config::USER_AGENT)
-        .send()
-        .await
-        .map_err(|e| format!("Metadata request failed: {}", e))?;
+        .send();
 
-    if !response.status().is_success() {
-        return Err(format!(
-            "Metadata request returned HTTP {}",
-            response.status()
-        ));
+    // ── 2. Per-symbol assetProfile requests for sector/industry/country ───────
+    let profile_futures: Vec<_> = symbols
+        .iter()
+        .map(|s| fetch_asset_profile(client, s))
+        .collect();
+
+    // Run both concurrently
+    let (quote_response, profile_results) =
+        futures::future::join(quote_future, futures::future::join_all(profile_futures)).await;
+
+    // Parse bulk quote response (best-effort). The response future has already resolved
+    // via `join`; we now just need to await the body deserialization.
+    let quote_json: Option<serde_json::Value> = async {
+        let resp = quote_response.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.json::<serde_json::Value>().await.ok()
     }
+    .await;
 
-    let json: serde_json::Value = response
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse metadata response: {}", e))?;
-
-    let results = json
-        .pointer("/quoteResponse/result")
-        .and_then(|v| v.as_array())
-        .cloned()
+    let quote_items: HashMap<String, serde_json::Value> = quote_json
+        .and_then(|json| {
+            json.pointer("/quoteResponse/result")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|item| {
+                            let sym = item.get("symbol")?.as_str()?.to_string();
+                            Some((sym, item.clone()))
+                        })
+                        .collect()
+                })
+        })
         .unwrap_or_default();
 
-    let metadata: Vec<SymbolMetadata> = results
+    // Build a lookup map: symbol → (sector, industry, country) from assetProfile
+    type SectorTuple = (Option<String>, Option<String>, Option<String>);
+    let profile_map: HashMap<String, SectorTuple> = profile_results
         .into_iter()
-        .map(|item| {
-            let symbol = item
-                .get("symbol")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
+        .map(|(sym, sector, industry, country)| (sym, (sector, industry, country)))
+        .collect();
+
+    // ── 3. Merge into SymbolMetadata ─────────────────────────────────────────
+    let metadata: Vec<SymbolMetadata> = symbols
+        .iter()
+        .map(|symbol| {
+            let quote = quote_items.get(symbol);
+            let (sector, industry, country) = profile_map
+                .get(symbol)
+                .cloned()
+                .unwrap_or((None, None, None));
+
             SymbolMetadata {
-                symbol,
-                sector: item
-                    .get("sector")
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string()),
-                industry: item
-                    .get("industry")
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string()),
-                country: item
-                    .get("country")
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string()),
-                market_cap: item.get("marketCap").and_then(|v| v.as_f64()),
-                pe_ratio: item.get("trailingPE").and_then(|v| v.as_f64()),
-                dividend_yield: item
-                    .get("trailingAnnualDividendYield")
+                symbol: symbol.clone(),
+                sector,
+                industry,
+                country,
+                market_cap: quote
+                    .and_then(|q| q.get("marketCap"))
                     .and_then(|v| v.as_f64()),
-                beta: item.get("beta").and_then(|v| v.as_f64()),
+                pe_ratio: quote
+                    .and_then(|q| q.get("trailingPE"))
+                    .and_then(|v| v.as_f64()),
+                dividend_yield: quote
+                    .and_then(|q| q.get("trailingAnnualDividendYield"))
+                    .and_then(|v| v.as_f64()),
+                beta: quote.and_then(|q| q.get("beta")).and_then(|v| v.as_f64()),
             }
         })
         .collect();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -16,6 +16,11 @@ pub const YAHOO_CHART_URL: &str =
 
 pub const YAHOO_QUOTE_URL: &str = "https://query1.finance.yahoo.com/v7/finance/quote?symbols={}";
 
+/// Endpoint for per-symbol fundamental metadata (sector, industry, country).
+/// Replace `{}` with the symbol. Returns `quoteSummary.result[0].assetProfile`.
+pub const YAHOO_QUOTE_SUMMARY_URL: &str =
+    "https://query2.finance.yahoo.com/v11/finance/quoteSummary/{}?modules=assetProfile";
+
 /// User-Agent sent with every outbound HTTP request.
 /// Yahoo Finance returns 403 without a browser-like UA string.
 pub const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -233,6 +233,17 @@ export function Analytics() {
       value: parseFloat(c.weightPercent.toFixed(2)),
     })) ?? [];
 
+  // Only show geographic breakdown when at least 50% of non-cash holdings have
+  // country data. The v7 quote endpoint does not reliably return country, so we
+  // hide the chart until the data quality is sufficient.
+  const showGeographicBreakdown = (() => {
+    if (!analytics || analytics.metadata.length === 0) return false;
+    const withCountry = analytics.metadata.filter(
+      (m) => m.country != null && m.country !== ''
+    ).length;
+    return withCountry / analytics.metadata.length >= 0.5;
+  })();
+
   return (
     <div
       style={{
@@ -260,7 +271,7 @@ export function Analytics() {
               color: 'var(--text-secondary)',
             }}
           >
-            Sector, geographic breakdown and risk metrics
+            Sector breakdown and risk metrics
           </p>
         </div>
         <button
@@ -379,7 +390,12 @@ export function Analytics() {
 
           {/* ── Section 2 & 3: Charts row ── */}
           <div
-            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 32 }}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: showGeographicBreakdown ? '1fr 1fr' : '1fr',
+              gap: 20,
+              marginBottom: 32,
+            }}
           >
             {/* Sector Pie */}
             <section
@@ -448,83 +464,85 @@ export function Analytics() {
               )}
             </section>
 
-            {/* Country Bar */}
-            <section
-              style={{
-                background: 'var(--bg-surface)',
-                border: '1px solid var(--border-primary)',
-                borderRadius: 2,
-                padding: '20px',
-              }}
-            >
-              <h2
+            {/* Country Bar — only shown when >= 50% of holdings have country data */}
+            {showGeographicBreakdown && (
+              <section
                 style={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: 'var(--text-secondary)',
-                  textTransform: 'uppercase',
-                  letterSpacing: '0.05em',
-                  margin: '0 0 16px',
+                  background: 'var(--bg-surface)',
+                  border: '1px solid var(--border-primary)',
+                  borderRadius: 2,
+                  padding: '20px',
                 }}
               >
-                Geographic Breakdown
-              </h2>
-              {barData.length > 0 ? (
-                <ResponsiveContainer width="100%" height={260}>
-                  <BarChart
-                    data={barData}
-                    layout="vertical"
-                    margin={{ top: 0, right: 20, left: 10, bottom: 0 }}
-                  >
-                    <CartesianGrid
-                      strokeDasharray="3 3"
-                      stroke="var(--border-subtle)"
-                      horizontal={false}
-                    />
-                    <XAxis
-                      type="number"
-                      tickFormatter={(v: number) => `${v}%`}
-                      tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
-                      axisLine={{ stroke: 'var(--border-primary)' }}
-                      tickLine={false}
-                    />
-                    <YAxis
-                      type="category"
-                      dataKey="name"
-                      tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
-                      axisLine={false}
-                      tickLine={false}
-                      width={90}
-                    />
-                    <Tooltip
-                      formatter={(value) => [`${(value as number).toFixed(2)}%`, 'Weight']}
-                      contentStyle={{
-                        background: 'var(--bg-surface)',
-                        border: '1px solid var(--border-primary)',
-                        borderRadius: 2,
-                        fontSize: 12,
-                        color: 'var(--text-primary)',
-                      }}
-                      cursor={{ fill: 'var(--bg-surface-hover)' }}
-                    />
-                    <Bar dataKey="value" fill="var(--color-accent)" radius={0} />
-                  </BarChart>
-                </ResponsiveContainer>
-              ) : (
-                <div
+                <h2
                   style={{
-                    height: 260,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color: 'var(--text-muted)',
                     fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--text-secondary)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    margin: '0 0 16px',
                   }}
                 >
-                  No geographic data available
-                </div>
-              )}
-            </section>
+                  Geographic Breakdown
+                </h2>
+                {barData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height={260}>
+                    <BarChart
+                      data={barData}
+                      layout="vertical"
+                      margin={{ top: 0, right: 20, left: 10, bottom: 0 }}
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke="var(--border-subtle)"
+                        horizontal={false}
+                      />
+                      <XAxis
+                        type="number"
+                        tickFormatter={(v: number) => `${v}%`}
+                        tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
+                        axisLine={{ stroke: 'var(--border-primary)' }}
+                        tickLine={false}
+                      />
+                      <YAxis
+                        type="category"
+                        dataKey="name"
+                        tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
+                        axisLine={false}
+                        tickLine={false}
+                        width={90}
+                      />
+                      <Tooltip
+                        formatter={(value) => [`${(value as number).toFixed(2)}%`, 'Weight']}
+                        contentStyle={{
+                          background: 'var(--bg-surface)',
+                          border: '1px solid var(--border-primary)',
+                          borderRadius: 2,
+                          fontSize: 12,
+                          color: 'var(--text-primary)',
+                        }}
+                        cursor={{ fill: 'var(--bg-surface-hover)' }}
+                      />
+                      <Bar dataKey="value" fill="var(--color-accent)" radius={0} />
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div
+                    style={{
+                      height: 260,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      color: 'var(--text-muted)',
+                      fontSize: 13,
+                    }}
+                  >
+                    No geographic data available
+                  </div>
+                )}
+              </section>
+            )}
           </div>
 
           {/* ── Section 4: Holdings Detail Table ── */}


### PR DESCRIPTION
## Summary

- **#191**: Replace the `/v7/finance/quote` bulk endpoint with per-symbol `/v11/finance/quoteSummary?modules=assetProfile` calls for sector/industry/country data (the v7 endpoint doesn't return these fields reliably)
- Concurrent fetch: assetProfile requests run alongside the existing bulk quote request; results are merged so `marketCap`, `trailingPE`, `beta`, and `dividendYield` still come from the v7 quote
- Geographic Breakdown section is now hidden unless ≥50% of holdings have country data; the grid collapses to full-width single column when the chart is absent

## Test plan
- [ ] Analytics page: sector breakdown shows actual sectors (Technology, Financials, etc.) for stock/ETF holdings, not just "Unknown"
- [ ] Cash holdings still appear as "Cash" in sector breakdown
- [ ] Geographic Breakdown chart only appears when meaningful country data is available
- [ ] When geo chart is hidden, sector breakdown uses full-width layout
- [ ] No regression on marketCap / PE ratio / beta in the metrics table