### PR TITLE
fix: FK constraint on transactions, CSV account fallback, alert symbol dropdown (#189 #190)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -252,10 +252,15 @@ fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, String> 
                 AccountType::Taxable
             }
         } else {
-            account
-                .to_lowercase()
-                .parse::<AccountType>()
-                .map_err(|_| format!("Row {}: invalid_account", row))?
+            // Unknown/unrecognised account strings default to the appropriate
+            // type rather than crashing the whole import.
+            account.to_lowercase().parse::<AccountType>().unwrap_or({
+                if matches!(asset_type, AssetType::Cash) {
+                    AccountType::Cash
+                } else {
+                    AccountType::Taxable
+                }
+            })
         };
         let currency =
             parse_required_field(&record, currency_index, row, "currency")?.to_uppercase();

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -27,6 +27,11 @@ fn table_has_column(conn: &Connection, table: &str, column: &str) -> Result<bool
 }
 
 pub fn init_db(conn: &Connection) -> Result<(), String> {
+    // Enable FK enforcement for this connection. SQLite disables it by default;
+    // every connection must opt in. This must run before any DML.
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
+        .map_err(|e| e.to_string())?;
+
     conn.execute_batch(
         "
         CREATE TABLE IF NOT EXISTS holdings (

--- a/src/components/Alerts.tsx
+++ b/src/components/Alerts.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Bell, BellOff, Plus, Trash2, RefreshCw } from 'lucide-react';
-import type { AlertDirection, PriceAlert, PriceAlertInput } from '../types/portfolio';
+import type { AlertDirection, Holding, PriceAlert, PriceAlertInput } from '../types/portfolio';
 import { formatCurrency } from '../lib/format';
 import { EmptyState } from './ui/EmptyState';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
 import { isTauri, tauriInvoke } from '../lib/tauri';
+import { usePortfolio } from '../hooks/usePortfolio';
 
 const MOCK_ALERTS: PriceAlert[] = [
   {
@@ -29,12 +30,13 @@ const MOCK_ALERTS: PriceAlert[] = [
 ];
 
 interface AddAlertFormProps {
+  holdings: Holding[];
   onAdd: (input: PriceAlertInput) => void;
   onCancel: () => void;
 }
 
-function AddAlertForm({ onAdd, onCancel }: AddAlertFormProps) {
-  const [symbol, setSymbol] = useState('');
+function AddAlertForm({ holdings, onAdd, onCancel }: AddAlertFormProps) {
+  const [symbol, setSymbol] = useState(holdings[0]?.symbol ?? '');
   const [direction, setDirection] = useState<AlertDirection>('above');
   const [threshold, setThreshold] = useState('');
   const [note, setNote] = useState('');
@@ -50,6 +52,13 @@ function AddAlertForm({ onAdd, onCancel }: AddAlertFormProps) {
       note: note.trim(),
     });
   };
+
+  function handleSymbolChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const selected = holdings.find((h) => h.symbol === e.target.value);
+    setSymbol(e.target.value);
+    // Auto-clear threshold when symbol changes so user doesn't carry over stale price
+    if (selected) setThreshold('');
+  }
 
   const inputStyle: React.CSSProperties = {
     background: 'var(--bg-surface-alt)',
@@ -84,13 +93,28 @@ function AddAlertForm({ onAdd, onCancel }: AddAlertFormProps) {
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 10 }}>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>SYMBOL</div>
-          <input
-            style={inputStyle}
-            value={symbol}
-            onChange={(e) => setSymbol(e.target.value)}
-            placeholder="e.g. AAPL"
-            required
-          />
+          {holdings.length > 0 ? (
+            <select
+              style={{ ...inputStyle, fontFamily: 'var(--font-mono)' }}
+              value={symbol}
+              onChange={handleSymbolChange}
+              required
+            >
+              {holdings.map((h) => (
+                <option key={h.id} value={h.symbol}>
+                  {h.symbol} — {h.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              style={inputStyle}
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              placeholder="e.g. AAPL"
+              required
+            />
+          )}
         </div>
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>DIRECTION</div>
@@ -169,6 +193,7 @@ export function Alerts() {
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const { showToast } = useToast();
+  const { holdings } = usePortfolio();
 
   const loadAlerts = useCallback(async () => {
     try {
@@ -308,7 +333,9 @@ export function Alerts() {
         </button>
       </div>
 
-      {showForm && <AddAlertForm onAdd={handleAdd} onCancel={() => setShowForm(false)} />}
+      {showForm && (
+        <AddAlertForm holdings={holdings} onAdd={handleAdd} onCancel={() => setShowForm(false)} />
+      )}
 
       {/* Triggered alerts */}
       {triggered.length > 0 && (


### PR DESCRIPTION
## Summary

- **#189 (FK constraint)**: Enable `PRAGMA foreign_keys = ON` in `init_db` — SQLite disables FK enforcement by default per connection. The frontend was already passing the correct UUID `holding.id`, so transactions now insert successfully once enforcement is on.
- **#189 (CSV import)**: Change account-column parse failure from a hard abort to a graceful fallback — unrecognised account strings default to `taxable` (or `cash` for cash-type rows) instead of crashing the import.
- **#190**: Replace the free-text symbol `<input>` in Add Alert with a `<select>` dropdown populated from the user's current holdings (`SYMBOL — Name`). Falls back to a plain text input when no holdings exist. Selecting a holding resets the threshold to prevent stale values carrying over.

## Test plan
- [ ] Add a transaction to an existing holding — no longer fails with FOREIGN KEY constraint error
- [ ] Import a CSV with an `account` column containing unrecognised values — import completes with those rows defaulting to `taxable`
- [ ] Add Alert: symbol field shows holdings dropdown instead of free-text input
- [ ] Selecting a holding in the dropdown clears the threshold field
- [ ] When portfolio is empty, Add Alert falls back to a plain text symbol input