### PR TITLE
fix: use custom Select component for alert symbol dropdown (#205 #209)

### DIFF
--- a/src/components/Alerts.tsx
+++ b/src/components/Alerts.tsx
@@ -54,9 +54,9 @@ function AddAlertForm({ holdings, onAdd, onCancel }: AddAlertFormProps) {
     });
   };
 
-  function handleSymbolChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const selected = holdings.find((h) => h.symbol === e.target.value);
-    setSymbol(e.target.value);
+  function handleSymbolChange(value: string) {
+    const selected = holdings.find((h) => h.symbol === value);
+    setSymbol(value);
     // Auto-clear threshold when symbol changes so user doesn't carry over stale price
     if (selected) setThreshold('');
   }
@@ -95,18 +95,11 @@ function AddAlertForm({ holdings, onAdd, onCancel }: AddAlertFormProps) {
         <div>
           <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 4 }}>SYMBOL</div>
           {holdings.length > 0 ? (
-            <select
-              style={{ ...inputStyle, fontFamily: 'var(--font-mono)' }}
+            <Select
               value={symbol}
               onChange={handleSymbolChange}
-              required
-            >
-              {holdings.map((h) => (
-                <option key={h.id} value={h.symbol}>
-                  {h.symbol} — {h.name}
-                </option>
-              ))}
-            </select>
+              options={holdings.map((h) => ({ value: h.symbol, label: `${h.symbol} — ${h.name}` }))}
+            />
           ) : (
             <input
               style={inputStyle}


### PR DESCRIPTION
## Summary

- **#209**: Replace the native `<select>` for the symbol field in the Add Alert form with the existing `ui/Select` custom component — both the Symbol and Direction dropdowns now use the same styled component for visual consistency
- **#205**: Confirmed already handled — `ImportHoldingsModal` already wraps both preview and import calls in try/catch with inline error display; the Rust CSV parser already uses `?`-propagation with human-readable error messages

## Test plan
- [ ] Add Alert: Symbol and Direction dropdowns have identical visual style (dark background, border, chevron)
- [ ] Selecting a symbol from the dropdown works correctly
- [ ] Import a malformed CSV — error is shown inline in the modal, modal stays open, no black screen