### PR TITLE
fix: Portfolio Value card whitespace, Top Movers count, Holdings toolbar alignment (#206 #207)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import { formatCurrency, formatCompact, formatPercent } from '../lib/format';
 import { pnlColor } from '../lib/colors';
@@ -66,6 +66,7 @@ function topMoversTitle(lastUpdated: string | undefined): string {
 }
 
 export function Dashboard({ portfolio, loading }: DashboardProps) {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const accountFilter = (searchParams.get('account') ?? 'all') as 'all' | AccountType;
 
@@ -373,6 +374,37 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
                   : '—'}
               </div>
             </div>
+            <div>
+              <div style={{ ...LABEL, marginBottom: 2 }}>Holdings</div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 13,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                {portfolio
+                  ? `${filteredHoldings.length} position${filteredHoldings.length !== 1 ? 's' : ''}`
+                  : '—'}
+              </div>
+            </div>
+            <div>
+              <div style={{ ...LABEL, marginBottom: 2 }}>Last Refreshed</div>
+              <div
+                style={{
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 13,
+                  color: 'var(--text-secondary)',
+                }}
+              >
+                {portfolio
+                  ? new Date(portfolio.lastUpdated).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })
+                  : '—'}
+              </div>
+            </div>
           </div>
         </div>
 
@@ -508,11 +540,42 @@ export function Dashboard({ portfolio, loading }: DashboardProps) {
             background: 'var(--bg-surface)',
             display: 'flex',
             flexDirection: 'column',
-            minHeight: 0,
+            minHeight: 220,
             overflow: 'hidden',
           }}
         >
-          <div style={{ ...LABEL, flexShrink: 0 }}>{topMoversTitle(portfolio?.lastUpdated)}</div>
+          <div
+            style={{
+              ...LABEL,
+              flexShrink: 0,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 8,
+            }}
+          >
+            <span>{topMoversTitle(portfolio?.lastUpdated)}</span>
+            {portfolio &&
+              filteredHoldings.filter((h) => h.assetType !== 'cash').length >
+                config.topMoversCount && (
+                <button
+                  onClick={() => void navigate('/holdings')}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    color: 'var(--color-accent)',
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 11,
+                    cursor: 'pointer',
+                    padding: 0,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                  }}
+                >
+                  View all →
+                </button>
+              )}
+          </div>
           <div style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
             <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
               <thead>

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -429,7 +429,6 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
         style={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
           flexWrap: 'wrap',
           gap: 10,
           marginBottom: 16,
@@ -460,7 +459,15 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
             {holdings.length} positions
           </span>
         </div>
-        <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div
+          style={{
+            display: 'flex',
+            gap: 10,
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            marginLeft: 'auto',
+          }}
+        >
           <input
             type="text"
             value={search}


### PR DESCRIPTION
## Summary

- **#206**: Add "Holdings" position count and "Last Refreshed" time cells to the Portfolio Value card to fill the empty space below cost basis/gain metrics; increase Top Movers `minHeight` to 220px so 5 rows always display; add "View all →" link when portfolio has more than 5 non-cash holdings
- **#207**: Add `marginLeft: auto` to the Holdings toolbar controls group so search, account selector, filters, and Add Holding button are flush-right at all window widths

## Test plan
- [ ] Dashboard Portfolio Value card: no large blank area below gain/loss; Holdings count and last-refreshed time visible
- [ ] Top Movers: shows up to 5 rows; "View all →" appears when >5 non-cash holdings
- [ ] Holdings toolbar: all controls aligned to the right edge; layout holds on window resize