### PR TITLE
fix: frontend error handling, delete guard, import reset, overflow, perf guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,15 +34,22 @@ function AppRoutes() {
     onRefresh: refreshPrices,
   });
 
+  const [currencyChanging, setCurrencyChanging] = useState(false);
+
   // Refs for imperative handles registered by Holdings
   const openAddHoldingRef = useRef<(() => void) | null>(null);
   const exportCsvRef = useRef<(() => void) | null>(null);
 
   // When base currency changes, re-fetch prices so conversions update immediately (#98)
   const handleBaseCurrencyChange = useCallback(
-    (currency: string) => {
+    async (currency: string) => {
       setBaseCurrency(currency);
-      void refreshPrices();
+      setCurrencyChanging(true);
+      try {
+        await refreshPrices();
+      } finally {
+        setCurrencyChanging(false);
+      }
     },
     [setBaseCurrency, refreshPrices]
   );
@@ -108,7 +115,7 @@ function AppRoutes() {
           element={
             <Layout
               portfolio={portfolio}
-              loading={loading}
+              loading={loading || currencyChanging}
               onRefresh={refreshPrices}
               baseCurrency={baseCurrency}
               onBaseCurrencyChange={handleBaseCurrencyChange}

--- a/src/components/AddHoldingModal.tsx
+++ b/src/components/AddHoldingModal.tsx
@@ -141,6 +141,8 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
         ? 'var(--color-warning)'
         : 'var(--color-gain)';
   const [priceFetching, setPriceFetching] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [priceFetchError, setPriceFetchError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const selectedSymbolRef = useRef<string>('');
   const firstFocusRef = useRef<HTMLInputElement | null>(null);
@@ -193,11 +195,15 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
         selectedSymbolRef.current = '';
       }
       setErrors({});
+      setSubmitError(null);
+      setPriceFetchError(null);
     } else {
       // Cancel any in-flight fetch when the modal closes
       abortRef.current?.abort();
       selectedSymbolRef.current = '';
       setPriceFetching(false);
+      setSubmitError(null);
+      setPriceFetchError(null);
     }
   }, [isOpen, editingHolding]);
 
@@ -238,7 +244,9 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
         setForm((prev) => ({ ...prev, costBasis: String(price) }));
       }
     } catch {
-      // non-fatal: user can enter cost basis manually
+      if (selectedSymbolRef.current === fetchedForSymbol) {
+        setPriceFetchError(`Could not fetch price for ${fetchedForSymbol} — enter manually`);
+      }
     } finally {
       // Only clear the fetching indicator if we are still the active request
       if (selectedSymbolRef.current === fetchedForSymbol) {
@@ -274,6 +282,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
     }
 
     setSaving(true);
+    setSubmitError(null);
     try {
       const input: HoldingInput = {
         symbol: isCash ? `${form.currency}-CASH` : form.symbol.toUpperCase(),
@@ -288,6 +297,8 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
       };
       await onSave(input);
       onClose();
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : String(e));
     } finally {
       setSaving(false);
     }
@@ -467,7 +478,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
             {!isCash && (
               <Field
                 label={priceFetching ? 'Cost Per Unit (fetching…)' : 'Cost Per Unit'}
-                error={errors.costBasis}
+                error={errors.costBasis ?? priceFetchError ?? undefined}
               >
                 <input
                   type="number"
@@ -525,6 +536,24 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
             </Field>
           </div>
         </div>
+
+        {/* Submit error */}
+        {submitError && (
+          <div
+            style={{
+              marginTop: 16,
+              padding: '9px 12px',
+              border: '1px solid var(--color-loss)',
+              background: 'rgba(255,71,87,0.08)',
+              color: 'var(--color-loss)',
+              fontSize: 12,
+              fontFamily: 'var(--font-mono)',
+              borderRadius: '2px',
+            }}
+          >
+            {submitError}
+          </div>
+        )}
 
         {/* Actions */}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 24 }}>

--- a/src/components/Holdings.tsx
+++ b/src/components/Holdings.tsx
@@ -154,6 +154,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
   const [editing, setEditing] = useState<Holding | undefined>(undefined);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkDeletePending, setBulkDeletePending] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
@@ -256,18 +257,20 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
 
   async function handleBulkDelete() {
     setBulkDeleting(true);
+    setIsDeleting(true);
     const ids = Array.from(selected);
     try {
       for (const id of ids) {
         await deleteHolding(id);
       }
       showToast(`Deleted ${ids.length} holdings`, 'info');
+      setSelected(new Set());
     } catch (e) {
       showToast(String(e), 'error');
     } finally {
       setBulkDeleting(false);
+      setIsDeleting(false);
       setBulkDeletePending(false);
-      setSelected(new Set());
     }
   }
 
@@ -295,6 +298,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
       return;
     }
     setDeletingId(id);
+    setIsDeleting(true);
     try {
       await deleteHolding(id);
       showToast('Holding deleted', 'info');
@@ -302,6 +306,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
       showToast(String(e), 'error');
     } finally {
       setDeletingId(null);
+      setIsDeleting(false);
       setPendingDelete(null);
     }
   }
@@ -1093,14 +1098,16 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                         <button
                                           onClick={() => setPendingDelete(h.id)}
                                           title="Delete"
+                                          disabled={isDeleting}
                                           style={{
                                             background: 'none',
                                             border: 'none',
                                             color: 'var(--text-muted)',
-                                            cursor: 'pointer',
+                                            cursor: isDeleting ? 'not-allowed' : 'pointer',
                                             padding: 3,
                                             display: 'flex',
                                             alignItems: 'center',
+                                            opacity: isDeleting ? 0.4 : 1,
                                           }}
                                         >
                                           <Trash2 size={13} />
@@ -1201,7 +1208,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
               </span>
               <button
                 onClick={() => setBulkDeletePending(true)}
-                disabled={bulkDeleting}
+                disabled={bulkDeleting || isDeleting}
                 style={{
                   padding: '4px 12px',
                   background: 'transparent',
@@ -1210,7 +1217,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                   borderRadius: '2px',
                   fontFamily: 'var(--font-mono)',
                   fontSize: 11,
-                  cursor: bulkDeleting ? 'not-allowed' : 'pointer',
+                  cursor: bulkDeleting || isDeleting ? 'not-allowed' : 'pointer',
                 }}
               >
                 Delete selected
@@ -1302,9 +1309,12 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                 overflowX: 'auto',
                 overflowY: 'auto',
                 maxHeight: 'calc(100vh - 260px)',
+                width: '100%',
               }}
             >
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+              <table
+                style={{ minWidth: 900, width: '100%', borderCollapse: 'collapse', fontSize: 12 }}
+              >
                 <thead style={{ position: 'sticky', top: 0, zIndex: 2 }}>
                   <tr>
                     <th style={{ ...TH, textAlign: 'center', width: 36, cursor: 'default' }}>
@@ -1339,7 +1349,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                 </thead>
                 <tbody>
                   {rows.map((h, i) => {
-                    const isDeleting = deletingId === h.id;
+                    const isRowDeleting = deletingId === h.id;
                     const isPending = pendingDelete === h.id;
                     const bg = i % 2 === 0 ? 'var(--bg-surface)' : 'var(--bg-surface-alt)';
                     return (
@@ -1348,7 +1358,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                         style={{
                           background: isPending
                             ? 'rgba(255,71,87,0.08)'
-                            : isDeleting
+                            : isRowDeleting
                               ? 'rgba(255,71,87,0.15)'
                               : selected.has(h.id)
                                 ? 'rgba(59,130,246,0.08)'
@@ -1356,12 +1366,12 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                           transition: 'background 200ms',
                         }}
                         onMouseEnter={(e) => {
-                          if (!isPending && !isDeleting && !selected.has(h.id))
+                          if (!isPending && !isRowDeleting && !selected.has(h.id))
                             (e.currentTarget as HTMLElement).style.background =
                               'var(--bg-surface-hover)';
                         }}
                         onMouseLeave={(e) => {
-                          if (!isPending && !isDeleting)
+                          if (!isPending && !isRowDeleting)
                             (e.currentTarget as HTMLElement).style.background = selected.has(h.id)
                               ? 'rgba(59,130,246,0.08)'
                               : bg;
@@ -1630,14 +1640,16 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               <button
                                 onClick={() => setPendingDelete(h.id)}
                                 title="Delete"
+                                disabled={isDeleting}
                                 style={{
                                   background: 'none',
                                   border: 'none',
-                                  color: 'var(--text-muted)',
-                                  cursor: 'pointer',
+                                  color: isDeleting ? 'var(--text-muted)' : 'var(--text-muted)',
+                                  cursor: isDeleting ? 'not-allowed' : 'pointer',
                                   padding: 3,
                                   display: 'flex',
                                   alignItems: 'center',
+                                  opacity: isDeleting ? 0.4 : 1,
                                 }}
                               >
                                 <Trash2 size={13} />

--- a/src/components/ImportHoldingsModal.tsx
+++ b/src/components/ImportHoldingsModal.tsx
@@ -183,8 +183,16 @@ export function ImportHoldingsModal({ isOpen, onClose, onImport, onPreview }: Pr
     setRunning(true);
     setError(null);
     try {
-      setResult(await onImport(csvContent));
+      const importResult = await onImport(csvContent);
+      setResult(importResult);
       setPreview(null);
+      // Reset modal to initial state after a short delay so the user can see the result
+      setTimeout(() => {
+        setResult(null);
+        setFilename('');
+        setCsvContent('');
+        onClose();
+      }, 1500);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/src/components/Performance.tsx
+++ b/src/components/Performance.tsx
@@ -202,7 +202,7 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
   const benchmarkData = useMemo(() => {
     if (!benchmark || data.length === 0) return [];
     const raw = filterByRange(benchmark.points, range);
-    if (raw.length === 0) return [];
+    if (!raw || raw.length === 0) return [];
     const first = raw[0].value || 1;
     const base = data[0]?.value ?? 0;
     return raw.map((point) => ({
@@ -263,6 +263,17 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
       <div style={{ ...PANEL }}>
         <EmptyState
           message="Performance history will appear here after your first price refresh."
+          action={onRefresh ? { label: 'Refresh Prices', onClick: onRefresh } : undefined}
+        />
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div style={{ ...PANEL }}>
+        <EmptyState
+          message="No performance data available for the selected range."
           action={onRefresh ? { label: 'Refresh Prices', onClick: onRefresh } : undefined}
         />
       </div>


### PR DESCRIPTION
## Summary
- Wrap price fetch and form submit in try/catch in AddHoldingModal (#214)
- Add `isDeleting` guard to prevent concurrent deletes in Holdings (#215)
- Await `refreshPrices()` in `handleBaseCurrencyChange` in App (#216)
- Reset ImportHoldingsModal state after successful import (#219)
- Wrap Holdings table in `overflowX: auto` container (#225)
- Guard `raw[0]` access in Performance with length check (#226)

## Test Plan
- [ ] Adding a holding with invalid symbol shows error toast (no crash)
- [ ] Rapidly clicking delete only fires one delete request
- [ ] Changing base currency triggers price refresh
- [ ] Import modal clears file/preview state after successful import
- [ ] Holdings table scrolls horizontally on narrow screens
- [ ] Performance page with zero data points shows empty state (no crash)

Closes #214 #215 #216 #219 #225 #226