### PR TITLE
fix: replace raw invoke() with isTauri wrapper; remove static benchmark series

### DIFF
--- a/frontend/components/Analytics.tsx
+++ b/frontend/components/Analytics.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import { RefreshCw, ArrowUpDown } from 'lucide-react';
+import { isTauri, tauriInvoke } from '../lib/tauri';
 import {
   PieChart,
   Pie,
@@ -186,8 +186,22 @@ export function Analytics() {
     setLoading(true);
     setError(null);
     try {
-      const result = await invoke<PortfolioAnalytics>('get_portfolio_analytics');
-      setAnalytics(result);
+      if (isTauri()) {
+        const result = await tauriInvoke<PortfolioAnalytics>('get_portfolio_analytics');
+        setAnalytics(result);
+      } else {
+        // Browser dev mode: analytics require live data from Tauri
+        setAnalytics({
+          metadata: [],
+          sectorBreakdown: [],
+          countryBreakdown: [],
+          riskMetrics: {
+            portfolioYield: 0,
+            concentrationHhi: 0,
+            largestPositionWeight: 0,
+          },
+        });
+      }
     } catch (err) {
       setError(String(err));
     } finally {

--- a/frontend/components/Performance.tsx
+++ b/frontend/components/Performance.tsx
@@ -12,7 +12,7 @@ import {
   Cell,
 } from 'recharts';
 import { useSearchParams } from 'react-router-dom';
-import { ALL_PERF_DATA, BENCHMARK_SERIES, calcStats, filterByRange } from '../lib/perfMockData';
+import { ALL_PERF_DATA, calcStats, filterByRange } from '../lib/perfMockData';
 import type { PerfDataPoint } from '../lib/perfMockData';
 import { formatCurrency, formatCompact, formatPercent } from '../lib/format';
 import { pnlColor } from '../lib/colors';
@@ -72,7 +72,6 @@ function useRealPerformance(range: string): {
 type Range = '1D' | '1W' | '1M' | '3M' | '6M' | '1Y' | 'ALL';
 const RANGES: Range[] = ['1D', '1W', '1M', '3M', '6M', '1Y', 'ALL'];
 type AssetFilter = 'all' | AssetType;
-type BenchmarkId = 'none' | 'sp500' | 'nasdaq100' | 'tsx' | 'bitcoin';
 
 const PANEL: React.CSSProperties = {
   background: 'var(--bg-surface)',
@@ -143,7 +142,6 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
   const range = (searchParams.get('range') as Range) || '1Y';
   const accountFilter = (searchParams.get('account') as 'all' | AccountType) || 'all';
   const assetFilter = (searchParams.get('asset') as AssetFilter) || 'all';
-  const benchmarkId = (searchParams.get('benchmark') as BenchmarkId) || 'none';
   const baseCurrency = portfolio?.baseCurrency ?? 'CAD';
 
   function updateParam(key: string, value: string) {
@@ -195,34 +193,8 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
   }, [realData, scaledMockData, range]);
 
   const stats = useMemo(() => calcStats(data), [data]);
-  const benchmark = useMemo(
-    () => BENCHMARK_SERIES.find((series) => series.id === benchmarkId) ?? null,
-    [benchmarkId]
-  );
-  const benchmarkData = useMemo(() => {
-    if (!benchmark || data.length === 0) return [];
-    const raw = filterByRange(benchmark.points, range);
-    if (!raw || raw.length === 0) return [];
-    const first = raw[0].value || 1;
-    const base = data[0]?.value ?? 0;
-    return raw.map((point) => ({
-      ...point,
-      value: Math.round((point.value / first) * base * 100) / 100,
-    }));
-  }, [benchmark, data, range]);
-  const benchmarkStats = useMemo(() => calcStats(benchmarkData), [benchmarkData]);
-  const relativeReturn = useMemo(() => {
-    if (!stats || !benchmarkStats) return null;
-    return stats.totalReturnPct - benchmarkStats.totalReturnPct;
-  }, [stats, benchmarkStats]);
 
-  const mergedData = useMemo(() => {
-    const benchmarkByDate = new Map(benchmarkData.map((point) => [point.date, point.value]));
-    return data.map((point) => ({
-      ...point,
-      benchmarkValue: benchmarkByDate.get(point.date) ?? null,
-    }));
-  }, [data, benchmarkData]);
+  const mergedData = useMemo(() => data, [data]);
 
   // Thin out data for 1Y/ALL to avoid too many ticks
   const chartData = useMemo(() => {
@@ -239,13 +211,6 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
       { value: 'etf', label: ASSET_TYPE_CONFIG.etf.label },
       { value: 'cash', label: ASSET_TYPE_CONFIG.cash.label },
       { value: 'crypto', label: ASSET_TYPE_CONFIG.crypto.label },
-    ],
-    []
-  );
-  const benchmarkOptions = useMemo(
-    () => [
-      { value: 'none', label: 'No Benchmark' },
-      ...BENCHMARK_SERIES.map((series) => ({ value: series.id, label: series.label })),
     ],
     []
   );
@@ -349,13 +314,6 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
                 options={assetOptions}
               />
             </div>
-            <div style={{ width: 180 }}>
-              <Select
-                value={benchmarkId}
-                onChange={(value) => updateParam('benchmark', value)}
-                options={benchmarkOptions}
-              />
-            </div>
           </div>
           <div style={{ display: 'flex', gap: 1 }}>
             {RANGES.map((r) => (
@@ -425,17 +383,6 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
                 strokeWidth: 2,
               }}
             />
-            {benchmark && benchmarkData.length > 0 && (
-              <Area
-                type="monotone"
-                dataKey="benchmarkValue"
-                stroke="var(--color-warning)"
-                strokeWidth={2}
-                fillOpacity={0}
-                dot={false}
-                isAnimationActive={false}
-              />
-            )}
           </AreaChart>
         </ResponsiveContainer>
       </div>
@@ -546,25 +493,6 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
               value: formatCurrency(data[data.length - 1]?.value ?? 0, baseCurrency),
               sub: `as of last data point · ${baseCurrency}`,
               color: 'var(--text-primary)',
-            },
-            {
-              label: 'Benchmark',
-              value: benchmark?.label ?? 'None',
-              sub:
-                relativeReturn === null
-                  ? 'overlay disabled'
-                  : `${relativeReturn >= 0 ? '+' : ''}${relativeReturn.toFixed(2)}% vs benchmark`,
-              color: relativeReturn === null ? 'var(--text-secondary)' : pnlColor(relativeReturn),
-            },
-            {
-              label: 'Benchmark Return',
-              value:
-                benchmarkStats && benchmark ? formatPercent(benchmarkStats.totalReturnPct) : '—',
-              sub: benchmark ? `${benchmark.label} · ${range}` : 'select a benchmark',
-              color:
-                benchmarkStats && benchmark
-                  ? pnlColor(benchmarkStats.totalReturnPct)
-                  : 'var(--text-secondary)',
             },
           ].map((s, i) => (
             <div

--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import { Download, Upload } from 'lucide-react';
+import { isTauri, tauriInvoke } from '../lib/tauri';
 import { useConfig } from '../hooks/useConfig';
 import { useAutoRefresh } from '../hooks/useAutoRefresh';
 import { AccountsModal } from './AccountsModal';
@@ -154,12 +154,15 @@ function DataManagementSection() {
     setBackupStatus({ kind: 'loading' });
     const filename = buildBackupFilename();
     try {
+      if (!isTauri()) {
+        setBackupStatus({ kind: 'error', message: 'Backup is only available in the desktop app.' });
+        return;
+      }
       // The dialog plugin is not available in this build. We pass a bare
       // filename; the backend resolves it to the user's Desktop so it is
       // easy to find.
-      const destPath = filename;
-      const savedPath = await invoke<string>('backup_database', {
-        destinationPath: destPath,
+      const savedPath = await tauriInvoke<string>('backup_database', {
+        destinationPath: filename,
       });
       setBackupStatus({ kind: 'success', path: savedPath });
     } catch (err) {
@@ -183,7 +186,14 @@ function DataManagementSection() {
     const { filePath } = restoreStatus;
     setRestoreStatus({ kind: 'loading' });
     try {
-      const message = await invoke<string>('restore_database', { sourcePath: filePath });
+      if (!isTauri()) {
+        setRestoreStatus({
+          kind: 'error',
+          message: 'Restore is only available in the desktop app.',
+        });
+        return;
+      }
+      const message = await tauriInvoke<string>('restore_database', { sourcePath: filePath });
       setRestoreStatus({ kind: 'success', message });
     } catch (err) {
       setRestoreStatus({ kind: 'error', message: String(err) });

--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
-import { invoke } from '@tauri-apps/api/core';
 import { Plus, Trash2 } from 'lucide-react';
+import { isTauri, tauriInvoke } from '../lib/tauri';
 import { usePortfolio } from '../hooks/usePortfolio';
 import { AddTransactionModal } from './AddTransactionModal';
 import { EmptyState } from './ui/EmptyState';
@@ -123,8 +123,13 @@ export function TransactionHistory() {
     setLoading(true);
     setError(null);
     try {
-      const txs = await invoke<Transaction[]>('get_transactions', {});
-      setTransactions(txs);
+      if (isTauri()) {
+        const txs = await tauriInvoke<Transaction[]>('get_transactions', {});
+        setTransactions(txs);
+      } else {
+        // Browser dev mode: no transactions available without Tauri
+        setTransactions([]);
+      }
     } catch (err) {
       setError(String(err));
     } finally {
@@ -186,7 +191,9 @@ export function TransactionHistory() {
   async function handleDelete(id: string) {
     setDeletingId(id);
     try {
-      await invoke('delete_transaction', { id });
+      if (isTauri()) {
+        await tauriInvoke('delete_transaction', { id });
+      }
       setTransactions((prev) => prev.filter((tx) => tx.id !== id));
       showToast('Transaction deleted', 'info');
     } catch (err) {


### PR DESCRIPTION
## Summary
- `TransactionHistory`, `Analytics`, `Settings`: replace direct `invoke()` from `@tauri-apps/api/core` with `isTauri()` guard + `tauriInvoke` wrapper — components render gracefully in browser dev mode instead of crashing (#256)
- `Performance`: remove static hardcoded benchmark series and its stats cards — fake S&P 500 / 60-40 numbers no longer shown to users (#261)

## Test Plan
- [ ] `npm run dev` (browser mode) — Transaction History, Analytics, Settings load without errors
- [ ] Performance chart shows only portfolio value — no benchmark series or benchmark stats cards
- [ ] In Tauri build, all three components load data normally

Closes #256 #261