### PR TITLE
docs: update README, features, roadmap, and CHANGELOG to reflect current state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-4] - 2026-03-21
+
+### Added
+- **Annual Dividend Income** — Dashboard card shows trailing 12-month dividend income from recorded payment events; FX-converted to base currency per dividend
+
+### Changed
+- **Database layer migrated to SQLx** — replaced rusqlite / `Mutex<Connection>` with an async `SqlitePool` (WAL mode, 5-second busy timeout, FK enforcement); all DB functions are now `async fn`; schema managed via `src-tauri/migrations/`
+- **Frontend directory renamed** — `src/` → `frontend/` for clearer project structure; all config files (vite, tsconfig, vitest, eslint, package.json, CI) updated accordingly
+- **Export/Import extended** — JSON export/import now includes transactions and dividends in addition to holdings, alerts, and config
+- **`isTauri()` guard** — all `invoke()` calls wrapped with an `isTauri()` check so the frontend works in browser dev mode
+- **Static benchmark series removed** — Performance chart benchmark overlay now fetches live data on demand only
+
+### Fixed
+- Async deadlock in `get_base_currency` — removed `block_on` inside async command, now properly `await`ed
+- LRU eviction in symbol search cache — evicts oldest entry instead of clearing the entire cache
+- `cost_basis_method` lowercased before storing to prevent case-mismatch bugs
+- `import_data` DELETE operations run inside a single SQLx transaction for atomicity
+- Snapshot retention extended from 30 days to 730 days (2 years of daily snapshots)
+- `delete_account` fixed to guard by UUID instead of account type string
+- `busy_timeout(5000ms)` set on the SQLx pool to prevent immediate lock errors under concurrent access
+- Dividend FX conversion logs a warning when the required rate is missing
+
+## [0.1.0-3] - 2026-03-18
+
+### Added
+- **Analytics view** — sector breakdown donut, country exposure, weighted beta, P/E, dividend yield, realized gains, and HHI portfolio concentration score
+- **Transaction History view** — per-holding buy/sell log; feeds AVCO and FIFO cost basis calculations
+- **Accounts modal** — manage named accounts (TFSA, RRSP, FHSA, Taxable, Crypto, Other); holdings assigned to accounts for account-level filtering
+- **Action Center** — quick-access side panel surfacing recent alert triggers and a fast transaction entry form
+- **Help screen** — keyboard shortcuts reference accessible via `?` key; also accessible from the sidebar
+
+### Fixed
+- In-app toast notifications when price alerts trigger during auto-refresh
+- Dashboard chart overflow clipped; Action Center collapsed state persisted correctly; account selector z-index corrected
+- Custom Select component replaces all native `<select>` elements; date inputs styled consistently
+- Analytics sector data sourced from `quoteSummary/assetProfile`; geographic chart hidden when data is too sparse
+- FK constraint on transaction inserts; CSV import account fallback; alert symbol dropdown fixed
+- Portfolio Value card whitespace; Top Movers count display; Holdings toolbar alignment
+- Backup/restore extended to include alerts and config (previously holdings only)
+- Price currency fallback when Yahoo Finance omits the `currency` field
+- AVCO calculation corrected for partial-sell lot matching
+- Alert errors surfaced in TopBar after each refresh
+- Daily P&L and performance chart panic guards added for empty price history
+- `delete_account` column reference fixed; `init_db` migration guard added; FX rate inversion bug fixed
+
 ## [0.2.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ Release builds are published from tags matching `v*.*.*` and first appear as dra
 - **Rebalancing** — Set target allocation weights per holding; see drift from target, required trades, and deployable cash guidance
 - **Price Alerts** — Set above/below price threshold alerts per symbol; triggered alerts are flagged in the UI
 - **Dividend Tracking** — Record dividend payments per unit with ex-date and pay-date; view payout history and totals by symbol
+- **Transaction History** — Log buy/sell transactions per holding; used for AVCO / FIFO cost basis calculations
+- **Analytics** — Sector breakdown, country exposure, weighted beta, P/E, dividend yield, realized gains, and portfolio risk metrics
+- **Accounts** — Manage named accounts (TFSA, RRSP, FHSA, Taxable, Crypto, Other); holdings assigned to accounts for account-level filtering
+- **Action Center** — Quick-access side panel for recent price alert triggers and fast transaction entry
 - **Settings** — Configure base currency (CAD, USD, EUR, GBP, AUD, CHF, JPY), auto-refresh interval (1m–1hr), and cost basis method (AVCO / FIFO)
 - **Multi-currency** — USD, EUR, GBP, CHF, JPY, and more; all positions converted to base currency at live FX rates fetched on demand
 - **Keyboard shortcuts** — Full keyboard navigation; press `?` to see all shortcuts
-- **Backup / Restore** — Export and import all holdings as JSON for portable backups
+- **Backup / Restore** — Export and import all data (holdings, alerts, transactions, dividends, config) as JSON
 
 ---
 
@@ -49,13 +53,13 @@ Release builds are published from tags matching `v*.*.*` and first appear as dra
 | Layer     | Technology                                        |
 |-----------|---------------------------------------------------|
 | Shell     | [Tauri v2](https://tauri.app)                     |
-| Backend   | Rust — tokio, reqwest, rusqlite, chrono, uuid     |
+| Backend   | Rust — tokio, reqwest, sqlx, chrono, uuid         |
 | Frontend  | React 18 + TypeScript + Vite                      |
 | Styling   | Tailwind CSS v4                                   |
 | Charts    | [Recharts](https://recharts.org)                  |
 | Icons     | [lucide-react](https://lucide.dev)                |
 | Router    | react-router-dom v7                               |
-| Database  | SQLite (bundled via rusqlite)                     |
+| Database  | SQLite via SQLx (WAL mode, async connection pool) |
 
 ---
 
@@ -75,7 +79,7 @@ portfolio-tracker/
 │       ├── fx.rs       # FX rate fetching + conversion helpers
 │       ├── search.rs   # Symbol search via Yahoo Finance
 │       └── stress.rs   # Stress test engine
-└── src/                # React frontend
+└── frontend/           # React frontend
     ├── App.tsx         # Router, providers, keyboard shortcut wiring
     ├── components/
     │   ├── Dashboard.tsx           # Route /
@@ -85,9 +89,13 @@ portfolio-tracker/
     │   ├── Rebalance.tsx           # Route /rebalance
     │   ├── Alerts.tsx              # Route /alerts
     │   ├── Dividends.tsx           # Route /dividends
+    │   ├── TransactionHistory.tsx  # Route /transactions
+    │   ├── Analytics.tsx           # Route /analytics
     │   ├── Settings.tsx            # Route /settings
     │   ├── AddHoldingModal.tsx     # Add / edit holding dialog
     │   ├── ImportHoldingsModal.tsx # CSV import dialog
+    │   ├── AccountsModal.tsx       # Named account management
+    │   ├── ActionCenter.tsx        # Quick-access alerts + transactions panel
     │   ├── Layout.tsx              # App shell: sidebar + topbar + content
     │   ├── Sidebar.tsx             # Icon nav, mini portfolio value
     │   ├── TopBar.tsx              # Refresh, base currency picker, daily P&L
@@ -102,12 +110,13 @@ portfolio-tracker/
     │   ├── format.ts               # Currency / number / percent formatters
     │   ├── colors.ts               # PnL color helpers
     │   ├── constants.ts            # Preset scenarios, asset/account configs
+    │   ├── tauri.ts                # isTauri() guard + tauriInvoke wrapper
     │   └── currencyContext.tsx     # Base currency React context
     └── types/
         └── portfolio.ts            # TypeScript types (mirrors Rust structs exactly)
 ```
 
-The Rust backend exposes Tauri commands that the React frontend calls via `invoke()`. The SQLite database lives in the macOS app data directory (`~/Library/Application Support/portfolio-tracker/portfolio.db`). Price data is fetched from Yahoo Finance on demand and cached locally between refreshes.
+The Rust backend exposes Tauri commands that the React frontend calls via `tauriInvoke()` (wrapped with an `isTauri()` guard for browser dev mode). The SQLite database lives in the macOS app data directory (`~/Library/Application Support/portfolio-tracker/portfolio.db`) and is accessed via an async SQLx connection pool with WAL mode enabled. Price data is fetched from Yahoo Finance on demand and cached locally between refreshes.
 
 ---
 
@@ -137,7 +146,7 @@ cargo tauri dev     # Full Tauri app (Rust backend + React frontend)
 npm run dev         # Frontend only in browser (mock data, no Rust required)
 ```
 
-> **First run:** `cargo tauri dev` will be slow on the first build — rusqlite compiles SQLite from source. Subsequent builds are fast.
+> **First run:** `cargo tauri dev` will be slow on the first build — Rust dependencies compile from source. Subsequent builds are fast thanks to incremental compilation and `swatinem/rust-cache` in CI.
 
 ### First-time setup
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -321,6 +321,85 @@ If a rate cannot be fetched, the most recently cached rate is used and a warning
 
 ---
 
+## Transaction History
+
+The Transaction History view shows every buy and sell transaction recorded for each holding, used to calculate cost basis under the selected AVCO or FIFO method.
+
+### Logging a Transaction
+
+Click **Add Transaction** and fill in:
+
+| Field | Description |
+|-------|-------------|
+| Holding | The holding this transaction belongs to |
+| Type | Buy or Sell |
+| Quantity | Number of units transacted |
+| Price | Price per unit in the holding's native currency |
+| Date | Transaction date and time |
+
+Transactions feed directly into the cost basis calculations shown in the Holdings table. The AVCO method averages all purchase prices; FIFO uses the oldest lot first on each sale.
+
+---
+
+## Analytics
+
+The Analytics view provides portfolio-level risk and composition metrics derived from Yahoo Finance fundamental data.
+
+### Sector Breakdown
+
+A donut chart and table showing what percentage of your portfolio (by market value) falls into each GICS sector (Technology, Financials, Energy, etc.). Cash and unclassified holdings are grouped as "Other".
+
+### Country Exposure
+
+Breakdown of portfolio weight by the country of domicile of each holding. Useful for understanding geographic concentration risk.
+
+### Risk Metrics
+
+| Metric | Description |
+|--------|-------------|
+| Weighted Beta | Portfolio-level beta, weighted by market value |
+| Portfolio Yield | Weighted dividend yield across all holdings |
+| P/E Ratio | Weighted price-to-earnings ratio |
+| Largest Position | Weight of the single largest holding |
+| HHI Concentration | Herfindahl–Hirschman Index — higher = more concentrated |
+| Top Sector | Sector with the greatest portfolio weight |
+
+### Realized Gains
+
+Displays the cumulative realized gain/loss from all completed sell transactions, calculated using the configured cost basis method (AVCO or FIFO).
+
+> Analytics data is fetched from Yahoo Finance on first visit and cached for up to 24 hours so subsequent navigation is instant.
+
+---
+
+## Accounts
+
+The Accounts feature lets you organize holdings by named account (TFSA, RRSP, FHSA, Taxable, Crypto, Other). Each account has a name, type, and optional notes.
+
+### Managing Accounts
+
+Open the **Accounts** modal from the Holdings toolbar. You can:
+- Create named accounts (e.g. "Questrade TFSA", "Wealthsimple RRSP")
+- Delete accounts that have no holdings assigned
+
+Holdings are assigned to an account when you add or edit them. The Holdings table can be filtered by account using the account dropdown.
+
+---
+
+## Action Center
+
+The Action Center is a quick-access side panel that surfaces recent price alert triggers and provides a fast path to log transactions without navigating away from your current view.
+
+### Alert Triggers
+
+Recent alert triggers appear in a list with symbol, threshold crossed, and timestamp. Triggered alerts can be reset directly from the Action Center.
+
+### Fast Transaction Entry
+
+The Action Center includes a compact transaction form. Enter symbol, type (buy/sell), quantity, and price to log a transaction immediately.
+
+---
+
 ## Keyboard Shortcuts
 
 Press `?` at any time to open the shortcuts overlay. Full list:
@@ -336,6 +415,7 @@ Press `?` at any time to open the shortcuts overlay. Full list:
 | `⌘E` | Export holdings to CSV |
 | `⌘,` | Open Settings |
 | `?` | Toggle keyboard shortcuts overlay |
+| `Esc` | Close overlays / modals |
 
 > Shortcuts do not fire when focus is inside an input, textarea, or select field.
 
@@ -343,6 +423,6 @@ Press `?` at any time to open the shortcuts overlay. Full list:
 
 ## Backup and Restore
 
-Use **Export Data** (in the Holdings menu) to download your full holdings list as a JSON file. Use **Import Data** to restore from that file. Import replaces all current holdings — export first if you want to preserve existing data.
+Use **Export Data** (in the Holdings menu) to download a full JSON backup — holdings, alerts, transactions, dividends, and settings. Use **Import Data** to restore from that file. Import replaces all current data — export first if you want to preserve existing data.
 
-For a CSV-based backup, use **Export CSV** (`⌘E`) from the Holdings view.
+For a CSV-based backup of holdings only, use **Export CSV** (`⌘E`) from the Holdings view.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,10 +26,16 @@ Incremental improvements to the existing feature set.
 | ✅ | Auto-refresh | Background price refresh on a configurable interval (1m–1hr) with TopBar countdown. |
 | ✅ | Symbol Search | Live symbol autocomplete via Yahoo Finance with local caching. |
 | ✅ | Keyboard Shortcuts | Full keyboard navigation; `?` to see all shortcuts. |
-| ✅ | JSON Backup / Restore | Export and import all holdings as JSON. |
-| 🔲 | In-app Alert Notifications | Show a toast / notification when a price alert fires during auto-refresh (see [#158](https://github.com/GitError/portfolio-tracker/issues/158)). |
-| 🔲 | Full Backup / Restore | Extend export/import to include alerts, dividends, and settings — not just holdings (see [#159](https://github.com/GitError/portfolio-tracker/issues/159)). |
-| 🔲 | Dark / Light Theme Toggle | Add a light theme variant. The current terminal-dark theme remains the default. |
+| ✅ | JSON Backup / Restore | Export and import all data — holdings, alerts, transactions, dividends, and config. |
+| ✅ | In-app Alert Notifications | Toast notifications when price alerts fire during auto-refresh. |
+| ✅ | Transaction History | Per-holding buy/sell log; drives AVCO and FIFO cost basis calculations. |
+| ✅ | Analytics | Sector breakdown, country exposure, weighted beta, P/E, dividend yield, realized gains, and HHI concentration. |
+| ✅ | Accounts Modal | Named account management (TFSA, RRSP, FHSA, Taxable, Crypto, Other). |
+| ✅ | Action Center | Quick-access side panel for alert triggers and fast transaction entry. |
+| ✅ | Annual Dividend Income | Dashboard card shows trailing 12-month dividend income from recorded payment events. |
+| ✅ | SQLx Migration | Database layer migrated from rusqlite to SQLx with async connection pool and WAL mode. |
+| 🔲 | Dark / Light Theme Toggle | Light theme variant selectable in Settings (tracked as [#264](https://github.com/GitError/portfolio-tracker/issues/264)). |
+| 🔲 | i18n / Multi-language | Language picker in Settings; i18next-based translations (tracked as [#263](https://github.com/GitError/portfolio-tracker/issues/263)). |
 
 ---
 
@@ -64,5 +70,8 @@ Features that require significant architectural work or are still being evaluate
 
 | Version | Feature |
 |---------|---------|
-| v0.1.x | CSV import/export, historical snapshots, benchmark overlay, price alerts, account types, rebalancing with target weights, dividend tracking, settings panel, configurable base currency, auto-refresh, symbol search, keyboard shortcuts, JSON backup/restore |
+| v0.1.0-4 | SQLx migration (async pool + WAL mode), `src/` → `frontend/` rename, export/import extended to include transactions and dividends |
+| v0.1.0-3 | Annual dividend income in Dashboard, backend hardening, analytics and performance fixes |
+| v0.1.0-2 | Transaction History, Analytics, Accounts modal, Action Center, in-app alert toast notifications, full backup/restore |
+| v0.2.0 | CSV import/export, historical snapshots, price alerts, account types, rebalancing, dividend tracking, settings panel, configurable base currency, auto-refresh, symbol search, keyboard shortcuts, JSON backup/restore |
 | v0.1.0 | Initial release: Dashboard, Holdings, Performance, Stress Test, multi-currency FX, local SQLite persistence |


### PR DESCRIPTION
## Summary
- **README**: tech stack table updated (rusqlite → SQLx + WAL mode), architecture diagram updated (`src/` → `frontend/`), feature list adds Transaction History, Analytics, Accounts, Action Center; removes stale rusqlite first-build note
- **docs/features.md**: new sections for Transaction History, Analytics, Accounts, Action Center, and a complete Keyboard Shortcuts table (with Esc); removed duplicate/incomplete shortcuts section; Backup & Restore note updated to reflect full export coverage
- **docs/roadmap.md**: newly completed items marked ✅ (Transaction History, Analytics, Accounts, Action Center, alert toasts, annual dividend income, SQLx migration, full backup/restore); stale issue references (#158, #159) removed; Dark/Light theme and i18n linked to their tracking issues (#264, #263); Recently Shipped table updated for 0.1.0-2 through 0.1.0-4
- **CHANGELOG.md**: added entries for v0.1.0-4 (SQLx migration, frontend rename, export/import, fixes) and v0.1.0-3 (Analytics, Transaction History, Accounts, Action Center, Help screen, fixes)

## Test Plan
- [ ] README renders correctly on GitHub (no broken links, accurate file paths)
- [ ] CHANGELOG entries are factual and match merged PRs
- [ ] Roadmap ✅ items all reflect genuinely merged features
- [ ] No speculative or forward-looking content in features.md

Closes #270