### PR TITLE
fix(tests): update TransactionHistory mock to use get_transactions_paginated

### DIFF
--- a/frontend/components/__tests__/TransactionHistory.test.tsx
+++ b/frontend/components/__tests__/TransactionHistory.test.tsx
@@ -106,7 +106,14 @@ const mockHoldings = [
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => true,
   tauriInvoke: vi.fn((cmd: string) => {
-    if (cmd === 'get_transactions') return Promise.resolve(mockTransactions);
+    if (cmd === 'get_transactions_paginated')
+      return Promise.resolve({
+        items: mockTransactions,
+        total: mockTransactions.length,
+        page: 1,
+        pageSize: 500,
+        totalPages: 1,
+      });
     if (cmd === 'delete_transaction') return Promise.resolve(true);
     return Promise.resolve(null);
   }),


### PR DESCRIPTION
## Summary
- Updates the `TransactionHistory` test mock to respond to `get_transactions_paginated` (returning a `PaginatedResult`) instead of the deprecated `get_transactions` command
- Fixes the CI failure introduced when the component was migrated off the deprecated command

## Test plan
- [x] `TransactionHistory.test.tsx` — 9/9 tests passing locally