### PR TITLE
fix(ui): badges, form alignment, and top movers count

### DIFF
--- a/frontend/components/AccountsModal.tsx
+++ b/frontend/components/AccountsModal.tsx
@@ -46,7 +46,7 @@ function AccountTypeBadge({ type }: { type: string }) {
         letterSpacing: '0.08em',
         padding: '2px 6px',
         borderRadius: 2,
-        background: `${accountTypeColor(type)}22`,
+        background: `${accountTypeColor(type)}18`,
         color: accountTypeColor(type),
         border: `1px solid ${accountTypeColor(type)}55`,
       }}

--- a/frontend/components/AddHoldingModal.tsx
+++ b/frontend/components/AddHoldingModal.tsx
@@ -101,6 +101,9 @@ const LABEL_STYLE: React.CSSProperties = {
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
   marginBottom: 4,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 };
 
 const ERROR_STYLE: React.CSSProperties = {
@@ -590,7 +593,7 @@ export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Pro
             <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
               {/* IAD + IAD currency + Frequency */}
               <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}>
-                <Field label="Indicated Annual Div / Unit">
+                <Field label="Ann. Div / Unit">
                   <input
                     type="number"
                     value={form.indicatedAnnualDividend}

--- a/frontend/components/__tests__/AddHoldingModal.test.tsx
+++ b/frontend/components/__tests__/AddHoldingModal.test.tsx
@@ -148,14 +148,14 @@ describe('AddHoldingModal', () => {
 
   it('Advanced section is hidden by default', () => {
     renderModal();
-    expect(screen.queryByText(/indicated annual div/i)).toBeNull();
+    expect(screen.queryByText(/ann\. div/i)).toBeNull();
   });
 
   it('toggles Advanced section when the toggle button is clicked', () => {
     renderModal();
     const toggleBtn = screen.getByText(/advanced/i);
     fireEvent.click(toggleBtn);
-    expect(screen.getByText(/indicated annual div/i)).toBeTruthy();
+    expect(screen.getByText(/ann\. div/i)).toBeTruthy();
   });
 
   it('backdrop click triggers onClose', () => {

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -21,8 +21,9 @@ export function Badge({ type }: BadgeProps) {
     <span
       style={{
         ...BADGE_STYLE,
+        background: `${config.color}18`,
         color: config.color,
-        border: `1px solid ${config.color}`,
+        border: `1px solid ${config.color}55`,
       }}
     >
       {config.label}
@@ -39,6 +40,7 @@ export function AccountBadge({ account }: { account: AccountType }) {
     <span
       style={{
         ...BADGE_STYLE,
+        background: `${config.color}18`,
         color: config.color,
         border: `1px solid ${config.color}55`,
       }}

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -11,7 +11,7 @@ export const config = {
 
   // ── UI counts ────────────────────────────────────────────────────────────────
   /** Number of top movers shown in the Dashboard panel. */
-  topMoversCount: 8,
+  topMoversCount: 10,
 
   /** Minimum symbol length before SymbolSearch fires a query. */
   symbolSearchMinChars: 2,


### PR DESCRIPTION
## Summary
- **Badge styling** (`Badge.tsx`, `AccountsModal.tsx`): asset type and account type now render as filled badge pills with a subtle background tint — consistent across Holdings table and Manage Accounts modal
- **Form alignment** (`AddHoldingModal.tsx`): shortened label to `Ann. Div / Unit` and added `whiteSpace: nowrap` to `LABEL_STYLE` so grid-row labels never wrap and push inputs out of alignment
- **Top movers count** (`config.ts`): bumped `topMoversCount` from 8 → 10 to fill the panel height
- **Tests** (`AddHoldingModal.test.tsx`): updated label matcher to match renamed field

## Test plan
- [x] All 224 frontend tests pass locally
- [ ] Holdings table Type and Account columns show filled badge pills
- [ ] Manage Accounts modal badge style matches Holdings
- [ ] Add Holding → Advanced: all three fields align horizontally
- [ ] Dashboard Top Movers/Losers shows up to 10 rows per side

Closes #461
Closes #462
Closes #463