### PR TITLE
test: pin stale price/FX cache fallback behavior (#577)

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1560,6 +1560,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_cached_prices_returns_rows_older_than_60_minutes() {
+        // Regression guard for #316/#577: get_cached_prices must NOT filter out
+        // rows older than 60 minutes. Stale prices should still surface to the
+        // caller so build_portfolio_snapshot can use them instead of cost_basis.
+        let pool = open_test_db().await;
+        let three_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        let price = PriceData {
+            symbol: "AAPL".to_string(),
+            price: 150.0,
+            currency: "USD".to_string(),
+            change: 1.0,
+            change_percent: 0.5,
+            updated_at: three_hours_ago,
+            open: None,
+            previous_close: None,
+            volume: None,
+        };
+        upsert_price(&pool, &price).await.expect("upsert price");
+
+        let prices = get_cached_prices(&pool).await.expect("get cached prices");
+        assert_eq!(prices.len(), 1);
+        assert!((prices[0].price - 150.0).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn get_fx_rates_returns_rows_older_than_60_minutes() {
+        // Regression guard for #316/#577: get_fx_rates must NOT filter out
+        // rows older than 60 minutes.
+        let pool = open_test_db().await;
+        let three_hours_ago = (chrono::Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        let rate = FxRate {
+            pair: "USDCAD".to_string(),
+            rate: 1.4,
+            updated_at: three_hours_ago,
+        };
+        upsert_fx_rate(&pool, &rate).await.expect("upsert fx");
+
+        let rates = get_fx_rates(&pool).await.expect("get fx rates");
+        assert_eq!(rates.len(), 1);
+        assert!((rates[0].rate - 1.4).abs() < 0.001);
+    }
+
+    #[tokio::test]
     async fn get_symbol_cache_exact_finds_symbol_case_insensitively() {
         let pool = open_test_db().await;
         let symbol = SymbolResult {

--- a/src-tauri/src/portfolio.rs
+++ b/src-tauri/src/portfolio.rs
@@ -592,6 +592,73 @@ mod tests {
     }
 
     #[test]
+    fn build_portfolio_snapshot_stale_but_present_price_is_used_over_cost_basis() {
+        // Regression guard for #316/#577: a cached price older than 60 minutes
+        // (market closed, no refresh) must still be used as current_price —
+        // cost_basis is only a fallback for a true cache miss (no row at all).
+        let holding = make_holding("AAPL", AssetType::Stock, 10.0, 50.0, "USD");
+        let three_hours_ago = (Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        let prices = vec![PriceData {
+            symbol: "AAPL".to_string(),
+            price: 180.0,
+            currency: "USD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: three_hours_ago,
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "USD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        // Stale (3h old) cached price is used, not cost_basis (50.0).
+        assert!((snapshot.holdings[0].current_price - 180.0).abs() < 0.001);
+        // Still under 24h, so not flagged as stale.
+        assert!(!snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_price_older_than_24h_flagged_stale_but_still_used() {
+        // A price older than PRICE_STALE_SECS (24h) is flagged stale for the UI,
+        // but must still be used as current_price rather than cost_basis.
+        let holding = make_holding("AAPL", AssetType::Stock, 10.0, 50.0, "USD");
+        let two_days_ago = (Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
+        let prices = vec![PriceData {
+            symbol: "AAPL".to_string(),
+            price: 180.0,
+            currency: "USD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: two_days_ago,
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "USD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!((snapshot.holdings[0].current_price - 180.0).abs() < 0.001);
+        assert!(snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
     fn build_portfolio_snapshot_missing_fx_marks_holding_as_stale() {
         // When FX rate is unavailable, fx_stale = true and rate defaults to 1.0.
         let holding = make_holding("AAPL", AssetType::Stock, 1.0, 100.0, "USD");


### PR DESCRIPTION
## Summary

Issue #577 re-reports a bug that was already fixed in `f34c090` (closing #316, March 2026):

- `get_cached_prices()` / `get_fx_rates()` in `src-tauri/src/db.rs` have no `updated_at` age filter — they return every row unconditionally.
- `build_portfolio_snapshot` in `src-tauri/src/portfolio.rs` only falls back to `cost_basis` when there's a true cache miss (no row for that symbol at all). A stale-but-present price is used as-is, with `price_is_stale` set when it's older than 24h.
- The frontend already surfaces this via `priceIsStale`/`fxStale` indicators (`Holdings.tsx`, `TopBar.tsx`).

**No production code changes.** This PR adds regression tests pinning the current (correct) behavior so it can't silently regress back to the pre-`f34c090` state:

- `db.rs`: `get_cached_prices` / `get_fx_rates` return rows older than 60 minutes
- `portfolio.rs`: a 3h-old cached price is used over `cost_basis`, and a 48h-old price is flagged `price_is_stale` but its value is still used

Recommend closing #577 as a duplicate of #316 once this merges.

## Test plan

- [x] `cargo test --locked` — 223 passed, 0 failed (includes 4 new tests)
- [x] `cargo fmt --check` / clippy clean
- [x] Frontend lint/typecheck/test suite (pre-push hook) passed
- [x] Verified via `git log -S` that the 60-minute filter was already removed by commit f34c090