### PR TITLE
fix: restore PASSIVE mode for periodic WAL checkpoint

### DIFF
--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1444,7 +1444,7 @@ pub async fn get_dividends_paginated(
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 /// Create an in-memory SQLite pool with all migrations applied.
-/// Accessible from other test modules within the crate.
+/// Accessible from other test modules within the crate (including `maintenance`).
 #[cfg(test)]
 pub(crate) async fn open_test_db() -> SqlitePool {
     let pool = SqlitePool::connect("sqlite::memory:")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod csv;
 mod db;
 pub mod error;
 mod fx;
+mod maintenance;
 mod portfolio;
 mod price;
 mod search;
@@ -136,32 +137,11 @@ pub fn run() {
             // Spawn background WAL checkpoint task to prevent unbounded WAL growth.
             // A watch channel provides a graceful shutdown signal: the sender is stored in
             // app state so the on_window_event handler can signal shutdown on app exit.
-            let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
-            let wal_pool = pool.clone();
-            tauri::async_runtime::spawn(async move {
-                // Checkpoint WAL every 5 min to bound WAL file growth; safe for low-write desktop workloads.
-                let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
-                interval.tick().await; // skip immediate first tick
-                loop {
-                    tokio::select! {
-                        _ = interval.tick() => {
-                            match sqlx::query("PRAGMA wal_checkpoint(RESTART)")
-                                .execute(&wal_pool)
-                                .await
-                            {
-                                Ok(_) => tracing::debug!("WAL checkpoint complete"),
-                                Err(e) => tracing::warn!("WAL checkpoint failed: {}", e),
-                            }
-                        }
-                        _ = shutdown_rx.changed() => {
-                            if *shutdown_rx.borrow() {
-                                tracing::info!("WAL checkpoint task shutting down");
-                                break;
-                            }
-                        }
-                    }
-                }
-            });
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            tauri::async_runtime::spawn(maintenance::run_wal_checkpoint_loop(
+                pool.clone(),
+                shutdown_rx,
+            ));
 
             app.manage(DbState(pool));
             app.manage(HttpClient(http_client));

--- a/src-tauri/src/maintenance.rs
+++ b/src-tauri/src/maintenance.rs
@@ -1,0 +1,65 @@
+use sqlx::SqlitePool;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// Interval between periodic WAL checkpoints.
+pub const WAL_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Runs a single WAL checkpoint in PASSIVE mode. PASSIVE checkpoints as many WAL
+/// frames as it can without waiting on locks held by readers or writers, so it
+/// never blocks the rest of the app — unlike RESTART/TRUNCATE, which block until
+/// all readers finish.
+pub async fn checkpoint_once(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query("PRAGMA wal_checkpoint(PASSIVE)")
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Periodically checkpoints the WAL until signaled to shut down via `shutdown_rx`.
+pub async fn run_wal_checkpoint_loop(pool: SqlitePool, mut shutdown_rx: watch::Receiver<bool>) {
+    let mut interval = tokio::time::interval(WAL_CHECKPOINT_INTERVAL);
+    interval.tick().await; // skip immediate first tick
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                match checkpoint_once(&pool).await {
+                    Ok(_) => tracing::debug!("WAL checkpoint complete"),
+                    Err(e) => tracing::warn!("WAL checkpoint failed: {}", e),
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    tracing::info!("WAL checkpoint task shutting down");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_test_db;
+
+    #[tokio::test]
+    async fn checkpoint_once_succeeds() {
+        let pool = open_test_db().await;
+        assert!(checkpoint_once(&pool).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn run_wal_checkpoint_loop_exits_on_shutdown_signal() {
+        let pool = open_test_db().await;
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let handle = tokio::spawn(run_wal_checkpoint_loop(pool, shutdown_rx));
+        shutdown_tx.send(true).expect("send shutdown signal");
+
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("loop should exit promptly after shutdown signal")
+            .expect("task should not panic");
+    }
+}


### PR DESCRIPTION
## Summary

Issue #585 asked for a periodic background WAL checkpoint to prevent unbounded WAL file growth during heavy price-refresh sessions, with the acceptance criterion that the checkpoint use a non-blocking mode (`PASSIVE` or `TRUNCATE`).

That background task already existed (`lib.rs`, spawned at app init) — it was originally added running `PRAGMA wal_checkpoint(PASSIVE)`, but was silently switched to `PRAGMA wal_checkpoint(RESTART)` in a large bundled refactor PR (#397) with no mention of the mode change in the commit message. `RESTART` blocks via the busy-handler until all readers finish, which is exactly the blocking behavior the issue's acceptance criteria call out as unacceptable — it can stall other pool connections during active price refreshes.

- Reverted the checkpoint mode to `PASSIVE`, which checkpoints as many WAL frames as possible without waiting on locks from readers or writers.
- Extracted the loop out of the inline `setup()` closure into a new `src-tauri/src/maintenance.rs` module, so the checkpoint logic is unit-testable in isolation from the Tauri app builder.

## Test plan

- [x] `cargo test --locked` — 225 backend tests pass, including two new tests in `maintenance::tests` (`checkpoint_once_succeeds`, `run_wal_checkpoint_loop_exits_on_shutdown_signal`)
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean
- [x] Full pre-push pipeline (lint, typecheck, frontend build, backend build, 252 frontend tests, 225 backend tests, clippy) — all green

Closes #585