### PR TITLE
fix: move N+1 lookups in add_dividend/update_account into db.rs helpers

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -72,14 +72,10 @@ pub async fn update_account(
     let account_type = account.account_type.clone();
 
     let pool = &state.0;
-    // Fetch created_at for the returned struct with a targeted query (avoids N+1)
-    let created_at: Option<String> =
-        sqlx::query_scalar("SELECT created_at FROM accounts WHERE id = $1")
-            .bind(&id)
-            .fetch_optional(pool)
-            .await
-            .map_err(AppError::from)?;
-    let created_at = created_at.ok_or_else(|| format!("Account {} not found", id))?;
+    let created_at = db::get_account_created_at(pool, &id)
+        .await
+        .map_err(AppError::from)?
+        .ok_or_else(|| AppError::NotFound(format!("Account {} not found", id)))?;
 
     db::update_account(pool, &id, &name, &account_type, institution.as_deref()).await?;
 

--- a/src-tauri/src/commands/dividends.rs
+++ b/src-tauri/src/commands/dividends.rs
@@ -40,21 +40,15 @@ pub async fn add_dividend(
     dividend: DividendInput,
 ) -> Result<Dividend, AppError> {
     let pool = &db.0;
-    // Look up the symbol and currency for the holding with a targeted query (avoids N+1)
-    let row: Option<(String, String)> =
-        sqlx::query_as("SELECT symbol, currency FROM holdings WHERE id = $1")
-            .bind(dividend.holding_id.0.as_str())
-            .fetch_optional(pool)
+    let (symbol, holding_currency) =
+        db::get_holding_symbol_and_currency(pool, dividend.holding_id.0.as_str())
             .await
-            .map_err(AppError::from)?;
-    let (symbol, holding_currency) = match row {
-        Some((s, c)) => (s, c),
-        None => (String::new(), String::new()),
-    };
+            .map_err(AppError::from)?
+            .ok_or_else(|| {
+                AppError::NotFound(format!("Holding {} not found", dividend.holding_id.0))
+            })?;
     // Validate that the dividend currency matches the holding's currency.
-    if !holding_currency.is_empty()
-        && holding_currency.to_uppercase() != dividend.currency.to_uppercase()
-    {
+    if holding_currency.to_uppercase() != dividend.currency.to_uppercase() {
         return Err(AppError::Validation(format!(
             "Dividend currency {} does not match holding currency {}",
             dividend.currency, holding_currency

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -342,6 +342,21 @@ pub async fn get_all_holdings(pool: &SqlitePool) -> Result<Vec<Holding>, String>
     Ok(holdings)
 }
 
+/// Look up a holding's symbol and currency by id (single-row lookup, avoids
+/// scanning the full holdings collection just to read one field).
+pub async fn get_holding_symbol_and_currency(
+    pool: &SqlitePool,
+    id: &str,
+) -> Result<Option<(String, String)>, String> {
+    use sqlx::Row;
+    let row = sqlx::query("SELECT symbol, currency FROM holdings WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(row.map(|r| (r.get(0), r.get(1))))
+}
+
 // ── Price cache ───────────────────────────────────────────────────────────────
 
 pub async fn upsert_price(pool: &SqlitePool, price: &PriceData) -> Result<(), String> {
@@ -1104,6 +1119,16 @@ pub async fn get_accounts(pool: &SqlitePool) -> Result<Vec<Account>, String> {
         .collect())
 }
 
+/// Look up an account's created_at timestamp by id (single-row lookup, avoids
+/// scanning the full accounts collection just to read one field).
+pub async fn get_account_created_at(pool: &SqlitePool, id: &str) -> Result<Option<String>, String> {
+    sqlx::query_scalar("SELECT created_at FROM accounts WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 pub async fn update_account(
     pool: &SqlitePool,
     id: &str,
@@ -1494,6 +1519,27 @@ mod tests {
         let symbols: Vec<&str> = holdings.iter().map(|h| h.symbol.as_str()).collect();
         assert!(symbols.contains(&"AAPL"));
         assert!(symbols.contains(&"MSFT"));
+    }
+
+    #[tokio::test]
+    async fn get_holding_symbol_and_currency_returns_matching_row() {
+        let pool = open_test_db().await;
+        let inserted = insert_holding(&pool, make_input("AAPL"))
+            .await
+            .expect("insert");
+        let result = get_holding_symbol_and_currency(&pool, inserted.id.0.as_str())
+            .await
+            .expect("lookup");
+        assert_eq!(result, Some(("AAPL".to_string(), "CAD".to_string())));
+    }
+
+    #[tokio::test]
+    async fn get_holding_symbol_and_currency_returns_none_for_missing_id() {
+        let pool = open_test_db().await;
+        let result = get_holding_symbol_and_currency(&pool, "does-not-exist")
+            .await
+            .expect("lookup");
+        assert_eq!(result, None);
     }
 
     #[tokio::test]
@@ -1998,6 +2044,34 @@ mod tests {
         let tfsa = accounts.iter().find(|a| a.id == "acc-1").unwrap();
         assert_eq!(tfsa.institution, Some("Questrade".to_string()));
         assert_eq!(tfsa.account_type, "tfsa");
+    }
+
+    #[tokio::test]
+    async fn get_account_created_at_returns_matching_timestamp() {
+        let pool = open_test_db().await;
+        insert_account(&pool, "acc-1", "My TFSA", "tfsa", Some("Questrade"))
+            .await
+            .expect("insert");
+        let accounts = get_accounts(&pool).await.expect("get accounts");
+        let expected = accounts
+            .iter()
+            .find(|a| a.id == "acc-1")
+            .unwrap()
+            .created_at
+            .clone();
+        let result = get_account_created_at(&pool, "acc-1")
+            .await
+            .expect("lookup");
+        assert_eq!(result, Some(expected));
+    }
+
+    #[tokio::test]
+    async fn get_account_created_at_returns_none_for_missing_id() {
+        let pool = open_test_db().await;
+        let result = get_account_created_at(&pool, "does-not-exist")
+            .await
+            .expect("lookup");
+        assert_eq!(result, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Issue #579 reported that `add_dividend` and `update_account` loaded whole collections (`get_all_holdings` / `get_accounts`) to read one field. That N+1 pattern had already been replaced with targeted single-row queries incidentally in commit 17995350, but the raw SQL was written inline in the command files instead of going through `db.rs`, which this codebase's conventions require.
- Adds `db::get_holding_symbol_and_currency` and `db::get_account_created_at` as single-row lookups and switches both commands to use them.
- Fixes a real correctness bug found along the way: `add_dividend` silently proceeded with an empty symbol/currency when `holding_id` didn't match any holding, instead of returning an error. It now returns `AppError::NotFound`.
- `update_account`'s not-found case previously converted through the bare `String -> AppError` impl, which maps to `Validation`; it now returns `AppError::NotFound` directly, consistent with the rest of the not-found handling in this codebase.

## Test plan
- [x] `cargo test --locked` in `src-tauri/` — 229 passed, including 4 new tests: `get_holding_symbol_and_currency_returns_matching_row`, `get_holding_symbol_and_currency_returns_none_for_missing_id`, `get_account_created_at_returns_matching_timestamp`, `get_account_created_at_returns_none_for_missing_id`
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full pre-push pipeline (lint, typecheck, frontend build, backend build, frontend tests, backend tests, clippy) — all green

Closes #579