### PR TITLE
test: verify UTF-8 percent-encoding for Japanese symbols (#581 duplicate of #323)

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -145,6 +145,13 @@ mod tests {
     }
 
     #[test]
+    fn percent_encode_japanese_kanji() {
+        // 日本 (U+65E5 U+672C) → UTF-8 bytes E6 97 A5 E6 9C AC
+        let encoded = super::search_symbols_yahoo_encode("日本");
+        assert_eq!(encoded, "%E6%97%A5%E6%9C%AC");
+    }
+
+    #[test]
     fn percent_encode_space_becomes_plus() {
         let encoded = super::search_symbols_yahoo_encode("Apple Inc");
         assert_eq!(encoded, "Apple+Inc");


### PR DESCRIPTION
## Summary

Issue #581 describes the search-query URL encoder treating multi-byte Unicode characters as single bytes (`c as u32` scalar encoding), causing Japanese symbol searches to return zero results.

That bug already existed and was already fixed — in #323 (commit f34c090), which replaced the char-scalar encoder with a byte-level UTF-8 encoder (`search_symbols_yahoo_encode` in [search.rs](src-tauri/src/search.rs), using `query.bytes().fold(...)`). A regression test (`percent_encode_multibyte_unicode`) already asserts `café` → `caf%C3%A9`.

#581 appears to be a re-filed duplicate of #323, most likely opened against a description of the pre-fix code rather than current `main`.

## Change

- Adds `percent_encode_japanese_kanji`, asserting `日本` → `%E6%97%A5%E6%9C%AC`, to satisfy #581's acceptance criteria explicitly (the issue calls out Japanese kanji and `é` as required test cases; `é` was already covered).
- No production code change — the encoding logic is already correct.

## Test plan

- [x] `cargo test --locked` in `src-tauri/` — all 233 backend tests pass, including the new kanji case and the existing `café` case
- [x] Pre-push hook (lint, typecheck, format, build, frontend+backend tests, clippy) passed

Closes #581