### PR TITLE
fix: make formatCurrency/formatNumber reactive to language changes

### DIFF
--- a/frontend/components/AddHoldingModal.tsx
+++ b/frontend/components/AddHoldingModal.tsx
@@ -7,7 +7,7 @@ import type {
   SymbolResult,
 } from '../types/portfolio';
 import { ACCOUNT_OPTIONS, SUPPORTED_CURRENCIES } from '../lib/constants';
-import { formatNumber } from '../lib/format';
+import { useFormatNumber } from '../hooks/useFormatters';
 import { usePortfolio } from '../hooks/usePortfolio';
 import { useToast } from './ui/Toast';
 import { Select } from './ui/Select';
@@ -132,6 +132,7 @@ function Field({
 }
 
 export function AddHoldingModal({ isOpen, onClose, onSave, editingHolding }: Props) {
+  const formatNumber = useFormatNumber();
   const { holdings } = usePortfolio();
   const { showToast } = useToast();
   const [form, setForm] = useState<FormState>(EMPTY_FORM);

--- a/frontend/components/ImportHoldingsModal.tsx
+++ b/frontend/components/ImportHoldingsModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ImportResult, PreviewImportResult, PreviewRow } from '../types/portfolio';
 import { ASSET_TYPE_CONFIG } from '../lib/constants';
-import { formatNumber } from '../lib/format';
+import { useFormatNumber } from '../hooks/useFormatters';
 import { Badge } from './ui/Badge';
 
 interface Props {
@@ -89,6 +89,7 @@ const TD: React.CSSProperties = {
 };
 
 function PreviewTable({ rows }: { rows: PreviewRow[] }) {
+  const formatNumber = useFormatNumber();
   return (
     <div style={{ border: '1px solid var(--border-primary)', overflowX: 'auto' }}>
       <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 11 }}>

--- a/frontend/components/Performance.tsx
+++ b/frontend/components/Performance.tsx
@@ -14,7 +14,8 @@ import {
 import { useSearchParams } from 'react-router-dom';
 import { ALL_PERF_DATA, calcStats, filterByRange } from '../lib/perfMockData';
 import type { PerfDataPoint } from '../lib/perfMockData';
-import { formatCurrency, formatCompact, formatPercent } from '../lib/format';
+import { formatCompact, formatPercent } from '../lib/format';
+import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
 import { ACCOUNT_OPTIONS, ASSET_TYPE_CONFIG } from '../lib/constants';
 import { Select } from './ui/Select';
@@ -114,6 +115,7 @@ function CustomTooltip({
   label?: string;
   currency: string;
 }) {
+  const formatCurrency = useFormatCurrency();
   if (!active || !payload?.length) return null;
   const val = payload[0]!.value;
   const daily = payload[0]!.payload.dailyReturn;
@@ -137,6 +139,7 @@ function CustomTooltip({
 }
 
 export function Performance({ portfolio, onRefresh }: PerformanceProps) {
+  const formatCurrency = useFormatCurrency();
   const [searchParams, setSearchParams] = useSearchParams();
   const range = (searchParams.get('range') as Range) || '1Y';
   const accountFilter = (searchParams.get('account') as 'all' | AccountType) || 'all';

--- a/frontend/components/Rebalance.tsx
+++ b/frontend/components/Rebalance.tsx
@@ -1,13 +1,15 @@
 import { useState, useCallback, useEffect } from 'react';
 import { Download, RefreshCw, Copy } from 'lucide-react';
 import { Spinner } from './ui/Spinner';
-import { formatCurrency, formatNumber, formatPercent } from '../lib/format';
+import { formatPercent } from '../lib/format';
+import { useFormatCurrency, useFormatNumber } from '../hooks/useFormatters';
 import { tauriInvoke } from '../lib/tauri';
 import type { RebalanceSuggestion } from '../types/portfolio';
 
 const DEFAULT_DRIFT_THRESHOLD = 5;
 
 function DriftBadge({ drift }: { drift: number }) {
+  const formatNumber = useFormatNumber();
   const isOver = drift > 0;
   const color = isOver ? 'var(--color-loss)' : 'var(--color-accent)';
   const label = isOver ? `+${formatNumber(drift, 2)}pp` : `${formatNumber(drift, 2)}pp`;
@@ -26,6 +28,7 @@ function DriftBadge({ drift }: { drift: number }) {
 }
 
 function TradeCell({ suggestion }: { suggestion: RebalanceSuggestion }) {
+  const formatNumber = useFormatNumber();
   const isSell = suggestion.suggestedTradeCad > 0;
   const color = isSell ? 'var(--color-loss)' : 'var(--color-gain)';
   const action = isSell ? 'Sell' : 'Buy';
@@ -78,6 +81,7 @@ function buildCsvContent(suggestions: RebalanceSuggestion[]): string {
 }
 
 export function Rebalance() {
+  const formatCurrency = useFormatCurrency();
   const [driftThreshold, setDriftThreshold] = useState(DEFAULT_DRIFT_THRESHOLD);
   const [suggestions, setSuggestions] = useState<RebalanceSuggestion[] | null>(null);
   const [loading, setLoading] = useState(false);

--- a/frontend/components/ScenarioComparison.tsx
+++ b/frontend/components/ScenarioComparison.tsx
@@ -1,7 +1,8 @@
 // ─── Scenario comparison table for stress test ───────────────────────────────
 import { useMemo } from 'react';
 import { fxShockKey } from '../lib/constants';
-import { formatCurrency, formatPercent, formatCompact } from '../lib/format';
+import { formatPercent, formatCompact } from '../lib/format';
+import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
 import type { PortfolioSnapshot, StressScenario, StressScenarioInfo } from '../types/portfolio';
 
@@ -76,6 +77,7 @@ export interface ScenarioComparisonProps {
 
 // ─── ScenarioComparison component ────────────────────────────────────────────
 export function ScenarioComparison({ portfolio, scenarios }: ScenarioComparisonProps) {
+  const formatCurrency = useFormatCurrency();
   const baseCurrency = portfolio.baseCurrency;
 
   const rows = useMemo(

--- a/frontend/components/StressResultsTable.tsx
+++ b/frontend/components/StressResultsTable.tsx
@@ -1,6 +1,7 @@
 // ─── Breakdown table for stress test results ─────────────────────────────────
 import { ASSET_TYPE_CONFIG } from '../lib/constants';
-import { formatCurrency, formatPercent } from '../lib/format';
+import { formatPercent } from '../lib/format';
+import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
 import { CollapsiblePanel } from './ui/CollapsiblePanel';
 import type { HoldingWithPrice, StressResult } from '../types/portfolio';
@@ -22,6 +23,7 @@ export interface StressResultsTableProps {
 
 // ─── StressResultsTable component ────────────────────────────────────────────
 export function StressResultsTable({ result, holdings, baseCurrency }: StressResultsTableProps) {
+  const formatCurrency = useFormatCurrency();
   const columns = [
     'Symbol',
     'Type',

--- a/frontend/components/StressTest.tsx
+++ b/frontend/components/StressTest.tsx
@@ -19,7 +19,8 @@ import {
   fxShockKey,
   ACCOUNT_OPTIONS,
 } from '../lib/constants';
-import { formatCurrency, formatPercent, formatCompact } from '../lib/format';
+import { formatPercent, formatCompact } from '../lib/format';
+import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
 import { EmptyState } from './ui/EmptyState';
 import { Select } from './ui/Select';
@@ -113,6 +114,7 @@ function applyHoldingFilters(
 
 // ─── Main component ───────────────────────────────────────────────────────────
 export function StressTest() {
+  const formatCurrency = useFormatCurrency();
   const { portfolio, holdings } = usePortfolio();
   const { result, loading, runTest } = useStressTest();
   const [searchParams, setSearchParams] = useSearchParams();

--- a/frontend/hooks/__tests__/useFormatters.test.ts
+++ b/frontend/hooks/__tests__/useFormatters.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import i18next from '../../lib/i18n';
+
+afterEach(async () => {
+  await act(async () => {
+    await i18next.changeLanguage('en');
+  });
+});
+
+describe('useFormatCurrency', () => {
+  it('reflects the active language immediately after it changes', async () => {
+    const { useFormatCurrency } = await import('../useFormatters');
+    const { result } = renderHook(() => useFormatCurrency());
+
+    expect(result.current(1234.56, 'USD')).toBe('1,234.56 USD');
+
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    await waitFor(() => expect(result.current(1234.56, 'USD')).toBe('1.234,56 USD'));
+  });
+});
+
+describe('useFormatNumber', () => {
+  it('reflects the active language immediately after it changes', async () => {
+    const { useFormatNumber } = await import('../useFormatters');
+    const { result } = renderHook(() => useFormatNumber());
+
+    expect(result.current(1234.5)).toBe('1,234.50');
+
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    await waitFor(() => expect(result.current(1234.5)).toBe('1.234,50'));
+  });
+});

--- a/frontend/hooks/useFormatters.ts
+++ b/frontend/hooks/useFormatters.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { formatCurrency, formatNumber } from '../lib/format';
+
+/** Reactive wrapper around `formatCurrency` — re-renders callers when the active language changes. */
+export function useFormatCurrency() {
+  const { i18n } = useTranslation();
+  return useCallback(
+    (amount: number | null | undefined, currency?: string) =>
+      formatCurrency(amount, currency, i18n.language),
+    [i18n.language]
+  );
+}
+
+/** Reactive wrapper around `formatNumber` — re-renders callers when the active language changes. */
+export function useFormatNumber() {
+  const { i18n } = useTranslation();
+  return useCallback(
+    (n: number | null | undefined, decimals?: number) => formatNumber(n, decimals, i18n.language),
+    [i18n.language]
+  );
+}

--- a/frontend/lib/__tests__/format.test.ts
+++ b/frontend/lib/__tests__/format.test.ts
@@ -42,6 +42,10 @@ describe('formatCurrency', () => {
     it('formats with custom currency label', () => {
       expect(formatCurrency(100, 'USD')).toBe('100.00 USD');
     });
+
+    it('formats using an explicit locale override, ignoring the global i18next language', () => {
+      expect(formatCurrency(1234.56, 'USD', 'de')).toBe('1.234,56 USD');
+    });
   });
 });
 
@@ -113,6 +117,10 @@ describe('formatNumber', () => {
 
     it('formats zero', () => {
       expect(formatNumber(0)).toBe('0.00');
+    });
+
+    it('formats using an explicit locale override, ignoring the global i18next language', () => {
+      expect(formatNumber(1234.5, 2, 'de')).toBe('1.234,50');
     });
   });
 });

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -6,9 +6,13 @@ function isValidNumber(value: number | null | undefined): value is number {
   return value != null && Number.isFinite(value) && !Number.isNaN(value);
 }
 
-export function formatCurrency(amount: number | null | undefined, currency = 'CAD'): string {
+export function formatCurrency(
+  amount: number | null | undefined,
+  currency = 'CAD',
+  localeOverride?: string
+): string {
   if (!isValidNumber(amount)) return INVALID_NUMBER;
-  const locale = i18next.language || 'en';
+  const locale = localeOverride || i18next.language || 'en';
   return (
     new Intl.NumberFormat(locale, {
       style: 'decimal',
@@ -26,9 +30,13 @@ export function formatPercent(decimal: number | null | undefined): string {
   return `${sign}${decimal.toFixed(2)}%`;
 }
 
-export function formatNumber(n: number | null | undefined, decimals = 2): string {
+export function formatNumber(
+  n: number | null | undefined,
+  decimals = 2,
+  localeOverride?: string
+): string {
   if (!isValidNumber(n)) return INVALID_NUMBER;
-  const locale = i18next.language || 'en';
+  const locale = localeOverride || i18next.language || 'en';
   return new Intl.NumberFormat(locale, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,


### PR DESCRIPTION
## Summary

- `formatCurrency`/`formatNumber` in `frontend/lib/format.ts` read `i18next.language` imperatively at call time. Components that never subscribe to language changes via `useTranslation()` don't re-render when the user switches language, so their formatted numbers stay stale until something unrelated triggers a re-render.
- Confirmed via grep that `Performance.tsx`, `StressTest.tsx`, `Rebalance.tsx`, `ScenarioComparison.tsx`, `StressResultsTable.tsx`, `ImportHoldingsModal.tsx`, and `AddHoldingModal.tsx` call `formatCurrency`/`formatNumber` but import `useTranslation` nowhere — so they never re-render on language change at all (as opposed to other components which already have `useTranslation()` and are therefore already reactive).
- Added `useFormatCurrency`/`useFormatNumber` hooks (`frontend/hooks/useFormatters.ts`) that subscribe via `useTranslation()` and pass `i18n.language` explicitly into `formatCurrency`/`formatNumber` via a new optional `localeOverride` param — additive and backward-compatible, existing callers of the plain functions are untouched.
- Wired the new hooks into the seven affected components (including their non-exported sub-components like `DriftBadge`/`TradeCell`/`PreviewTable`/`CustomTooltip` where the formatter calls actually live).

Closes #582

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 256/256 passing, including new `useFormatters.test.ts` (proves the hook's returned formatter reflects a locale change via `i18next.changeLanguage`) and two new locale-override cases in `format.test.ts`
- [x] Manual verification in the browser preview: `/stress` page and "Compare Scenarios" panel render correctly with no console errors
- [x] Pre-push hooks: lint, typecheck, frontend build, backend build, frontend tests, backend tests, clippy — all passed