### PR TITLE
fix: dividends summary shows total cash received, not per-unit amount

### DIFF
--- a/frontend/components/Dividends.tsx
+++ b/frontend/components/Dividends.tsx
@@ -267,19 +267,20 @@ export function Dividends() {
       }));
   }, [portfolio]);
 
-  // Summary stats
+  // Summary stats: total cash received (amountPerUnit x quantity), not the raw per-unit amount
   const summary = useMemo(() => {
     const bySymbol: Record<string, { total: number; currency: string; count: number }> = {};
     for (const div of dividends) {
       if (!bySymbol[div.symbol]) {
         bySymbol[div.symbol] = { total: 0, currency: div.currency, count: 0 };
       }
+      const holding = holdings.find((h) => h.id === div.holdingId);
       const entry = bySymbol[div.symbol]!;
-      entry.total += div.amountPerUnit;
+      entry.total += div.amountPerUnit * (holding?.quantity ?? 0);
       entry.count += 1;
     }
     return bySymbol;
-  }, [dividends]);
+  }, [dividends, holdings]);
 
   if (loading) {
     return (

--- a/frontend/components/__tests__/Dividends.test.tsx
+++ b/frontend/components/__tests__/Dividends.test.tsx
@@ -104,4 +104,15 @@ describe('Dividends component smoke tests', () => {
       expect(cells.length).toBeGreaterThan(0);
     });
   });
+
+  it('shows total cash received (amountPerUnit x quantity), not the raw per-unit amount', async () => {
+    // MOCK_DIVIDENDS: TD.TO pays 0.118/share on a 150-share holding -> 17.70 CAD total.
+    // AAPL pays 0.25/share on a 50-share holding -> 12.50 USD total.
+    // The old (buggy) behavior summed amountPerUnit directly, which would render
+    // as "0.12 CAD" and "0.25 USD" instead of the correct cash totals below.
+    renderDividends();
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
+    expect(screen.getByText('17.70 CAD')).toBeTruthy();
+    expect(screen.getByText('12.50 USD')).toBeTruthy();
+  });
 });

--- a/frontend/lib/mockData.ts
+++ b/frontend/lib/mockData.ts
@@ -416,8 +416,8 @@ export function buildMockSnapshot(holdingsList: Holding[]): PortfolioSnapshot {
 export const MOCK_DIVIDENDS: Dividend[] = [
   {
     id: 'a1000000-0000-4000-8000-000000000001',
-    holdingId: 'h1',
-    symbol: 'VDY.TO',
+    holdingId: '4',
+    symbol: 'TD.TO',
     amountPerUnit: 0.118,
     currency: 'CAD',
     exDate: '2026-01-15',
@@ -426,7 +426,7 @@ export const MOCK_DIVIDENDS: Dividend[] = [
   },
   {
     id: 'a1000000-0000-4000-8000-000000000002',
-    holdingId: 'h2',
+    holdingId: '1',
     symbol: 'AAPL',
     amountPerUnit: 0.25,
     currency: 'USD',


### PR DESCRIPTION
## Summary
- The per-symbol summary tiles on the Dividends page summed `amountPerUnit` across dividend records (e.g. $1.20/share + $0.50/share = $1.70), which is neither a total nor a useful average.
- Each tile now sums `amountPerUnit x quantity` (looked up from the matching holding), giving actual total cash received per symbol. Since each symbol tile already carries a single currency (`formatCurrency(data.total, data.currency)`), this also correctly avoids mixing currencies without needing to restructure the grouping.
- Fixed `MOCK_DIVIDENDS` in `frontend/lib/mockData.ts`: its `holdingId` values (`h1`, `h2`) didn't match any id in `MOCK_HOLDINGS`, so the quantity lookup always missed in browser/dev mode. Pointed them at real mock holdings (TD.TO / AAPL) instead.

Closes #583

## Test plan
- [x] Added a regression test in `frontend/components/__tests__/Dividends.test.tsx` asserting the rendered totals reflect `amountPerUnit x quantity` (verified RED before the fix, GREEN after).
- [x] `NODE_ENV=development npm run typecheck` passes.
- [x] `NODE_ENV=development npm test` — 257 tests pass.
- [x] Full pre-push gate (lint, frontend+backend build, frontend+backend tests, clippy) passed on push.