### PR TITLE
fix: real app version in Settings + daily log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,6 +3365,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ts-rs",
  "uuid",
@@ -4913,6 +4914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5676,6 +5683,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -1,6 +1,7 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Download, Upload } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { getVersion } from '@tauri-apps/api/app';
 import { isTauri, tauriInvoke } from '../lib/tauri';
 import { useConfig } from '../hooks/useConfig';
 import { useTheme, type ThemeMode } from '../hooks/useTheme';
@@ -487,6 +488,14 @@ export function Settings() {
   const { theme, setTheme } = useTheme();
   const [accountsOpen, setAccountsOpen] = useState(false);
   const { language, setLanguage } = useLanguage();
+  const [appVersion, setAppVersion] = useState('...');
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    getVersion()
+      .then(setAppVersion)
+      .catch(() => {});
+  }, []);
 
   // Auto-refresh controls — read/write config directly to avoid creating a
   // second competing interval alongside the one in AppRoutes.
@@ -742,7 +751,7 @@ export function Settings() {
               color: 'var(--text-secondary)',
             }}
           >
-            0.1.0
+            {appVersion}
           </span>
         </SettingRow>
       </div>

--- a/frontend/components/__tests__/Settings.test.tsx
+++ b/frontend/components/__tests__/Settings.test.tsx
@@ -26,13 +26,21 @@ vi.mock('../../hooks/useLanguage', () => ({
 const mockSetConfigCmd = vi.fn().mockResolvedValue(undefined);
 const mockGetConfigCmd = vi.fn().mockResolvedValue(null);
 
+// Mutable so individual tests can simulate running inside the Tauri runtime.
+let mockIsTauri = false;
+
 vi.mock('../../lib/tauri', () => ({
-  isTauri: () => false,
+  isTauri: () => mockIsTauri,
   tauriInvoke: (cmd: string, ...args: unknown[]) => {
     if (cmd === 'set_config_cmd') return mockSetConfigCmd(cmd, ...args);
     if (cmd === 'get_config_cmd') return mockGetConfigCmd(cmd, ...args);
     return Promise.resolve(null);
   },
+}));
+
+const mockGetVersion = vi.fn().mockResolvedValue('1.2.3');
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: () => mockGetVersion(),
 }));
 
 beforeEach(() => {
@@ -42,6 +50,7 @@ beforeEach(() => {
   delete (window as any).__TAURI__;
   localStorage.clear();
   vi.clearAllMocks();
+  mockIsTauri = false;
 });
 
 function renderSettings() {
@@ -82,9 +91,15 @@ describe('Settings component smoke tests', () => {
     expect(screen.getByText(/fifo/i)).toBeTruthy();
   });
 
-  it('shows the version number', () => {
+  it('shows a placeholder version outside the Tauri runtime', () => {
     renderSettings();
-    expect(screen.getByText('0.1.0')).toBeTruthy();
+    expect(screen.getByText('...')).toBeTruthy();
+  });
+
+  it('shows the real app version when running in Tauri', async () => {
+    mockIsTauri = true;
+    renderSettings();
+    await waitFor(() => expect(screen.getByText('1.2.3')).toBeTruthy());
   });
 
   it('shows Manage Accounts button', () => {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 csv = "1.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+tracing-appender = "0.2"
 ts-rs = { version = "12", features = ["serde-compat"] }
 
 [dev-dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,23 +78,45 @@ use commands::{DbState, HttpClient, RateLimiterState, RealizedGainsCacheState, S
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::str::FromStr;
 use tauri::Manager;
+use tracing_subscriber::prelude::*;
 
 /// Holds the sender half of the WAL checkpoint shutdown channel.
 /// Managed as Tauri app state so the window-destroyed event can signal the background task.
 struct WalShutdown(tokio::sync::watch::Sender<bool>);
 
+/// Keeps the non-blocking file appender's background flush thread alive for the
+/// lifetime of the app. Dropping this guard stops log writes, so it's managed as
+/// Tauri app state rather than a local variable in `setup`.
+struct LogGuard(#[allow(dead_code)] tracing_appender::non_blocking::WorkerGuard);
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .try_init();
-
     let result = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(|app| {
+            let log_dir = app.path().app_log_dir()?;
+            std::fs::create_dir_all(&log_dir)?;
+            let file_appender = tracing_appender::rolling::daily(&log_dir, "portfolio-tracker.log");
+            let (non_blocking, log_guard) = tracing_appender::non_blocking(file_appender);
+
+            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+            // Dev builds also mirror logs to stderr; release builds write to the file only.
+            let stderr_layer = cfg!(debug_assertions)
+                .then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
+
+            let _ = tracing_subscriber::registry()
+                .with(env_filter)
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(non_blocking)
+                        .with_ansi(false),
+                )
+                .with(stderr_layer)
+                .try_init();
+
+            app.manage(LogGuard(log_guard));
+
             let app_data_dir = app.path().app_data_dir()?;
 
             std::fs::create_dir_all(&app_data_dir)?;


### PR DESCRIPTION
## Summary

- **#586 (Part A — frontend):** `Settings.tsx` showed a hardcoded `"0.1.0"`. Now reads the real version via `getVersion()` from `@tauri-apps/api/app` in a `useEffect`, guarded by `isTauri()`. Falls back to `"..."` while loading or in browser dev mode.
- **#586 (Part B — backend):** Wired up persistent daily-rolling file logging. Subscriber init moved from the top of `run()` into the `setup()` closure (where the `AppHandle` is available), using `app.path().app_log_dir()` + `tracing_appender::rolling::daily`. Dev builds keep a stderr layer alongside the file layer; release builds write to the file only. The `WorkerGuard` is stored as managed app state so the non-blocking writer keeps flushing for the app's lifetime. Re-added `tracing-appender` to `src-tauri/Cargo.toml`.
- **#584 (ExportPayload type):** Already fixed — `transactions`/`dividends` fields were added to the TypeScript `ExportPayload` interface back in commit `011a6fec` (closed #329). No change needed; noting here per the issue.

## Test plan
- [x] `cargo build --locked` / `cargo test --locked` in `src-tauri/` — 233 tests pass
- [x] `NODE_ENV=development npm run typecheck` — passes
- [x] `NODE_ENV=development npm test -- --run` — 258 tests pass, including two new/updated `Settings.test.tsx` cases covering the `"..."` fallback outside Tauri and the real version once `getVersion()` resolves
- [x] Pre-push hooks (lint, format, frontend+backend build, tests, clippy) all green

Closes #586