### PR TITLE
test: close remaining #589 coverage gaps (i18n pin, account filter, French locale)

### DIFF
--- a/frontend/components/__tests__/Alerts.test.tsx
+++ b/frontend/components/__tests__/Alerts.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { Alerts } from '../Alerts';
 
 // Initialize i18n (Alerts uses useTranslation)
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 
 const mockDeleteAlert = vi.fn();
 
@@ -38,13 +38,15 @@ vi.mock('../../hooks/usePortfolio', () => ({
   }),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
   vi.clearAllMocks();
   mockDeleteAlert.mockResolvedValue(true);
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
 function renderAlerts() {

--- a/frontend/components/__tests__/Dashboard.test.tsx
+++ b/frontend/components/__tests__/Dashboard.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Dashboard } from '../Dashboard';
 import type { PortfolioSnapshot } from '../../types/portfolio';
 import { MOCK_SNAPSHOT } from '../../lib/mockData';
+import { formatCurrency } from '../../lib/format';
 
 // Initialize i18n (needed by sibling components)
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 
 // Mock ActionCenter and useActionInsights to keep tests focused on Dashboard rendering
 vi.mock('../../hooks/useActionInsights', () => ({
@@ -16,16 +17,21 @@ vi.mock('../ActionCenter', () => ({
   ActionCenter: () => null,
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
-function renderDashboard(props: { portfolio: PortfolioSnapshot | null; loading: boolean }) {
+function renderDashboard(
+  props: { portfolio: PortfolioSnapshot | null; loading: boolean },
+  initialEntries: string[] = ['/']
+) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <Dashboard {...props} />
     </MemoryRouter>
   );
@@ -80,5 +86,41 @@ describe('Dashboard component smoke tests', () => {
   it('shows allocation section', () => {
     renderDashboard({ portfolio: MOCK_SNAPSHOT as PortfolioSnapshot, loading: false });
     expect(screen.getAllByText(/allocation/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe('Dashboard account filter', () => {
+  it('recomputes the portfolio value and holdings count when an account filter is set via URL', () => {
+    const snapshot = MOCK_SNAPSHOT as PortfolioSnapshot;
+    const tfsaHoldings = snapshot.holdings.filter((h) => h.account === 'tfsa');
+    // Sanity check the fixture actually exercises the filter (not all accounts, not zero).
+    expect(tfsaHoldings.length).toBeGreaterThan(0);
+    expect(tfsaHoldings.length).toBeLessThan(snapshot.holdings.length);
+
+    const expectedTotal = tfsaHoldings.reduce((sum, h) => sum + h.marketValueCad, 0);
+
+    renderDashboard({ portfolio: snapshot, loading: false }, ['/?account=tfsa']);
+
+    // Scope to the Portfolio Value panel — the "By Account" breakdown panel can show
+    // the same TFSA subtotal, so an unscoped query would match both.
+    const portfolioValuePanel = screen.getByText(/portfolio value/i).parentElement!;
+    expect(
+      within(portfolioValuePanel).getByText(formatCurrency(expectedTotal, snapshot.baseCurrency))
+    ).toBeTruthy();
+    expect(
+      within(portfolioValuePanel).getByText(
+        `${tfsaHoldings.length} position${tfsaHoldings.length !== 1 ? 's' : ''}`
+      )
+    ).toBeTruthy();
+  });
+
+  it('shows an empty state when the filtered account has no holdings', () => {
+    const snapshot = MOCK_SNAPSHOT as PortfolioSnapshot;
+    // No holding in the fixture uses the 'fhsa' account.
+    expect(snapshot.holdings.some((h) => h.account === 'fhsa')).toBe(false);
+
+    renderDashboard({ portfolio: snapshot, loading: false }, ['/?account=fhsa']);
+
+    expect(screen.getByText(/no holdings in this account/i)).toBeTruthy();
   });
 });

--- a/frontend/components/__tests__/Dividends.test.tsx
+++ b/frontend/components/__tests__/Dividends.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { Dividends } from '../Dividends';
 
 // Initialize i18n (Dividends uses useTranslation)
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
@@ -33,12 +33,14 @@ vi.mock('../../hooks/usePortfolio', () => ({
   }),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
   vi.clearAllMocks();
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
 function renderDividends() {

--- a/frontend/components/__tests__/Holdings.test.tsx
+++ b/frontend/components/__tests__/Holdings.test.tsx
@@ -6,7 +6,7 @@ import type { HoldingWithPrice, PortfolioSnapshot } from '../../types/portfolio'
 import { MOCK_SNAPSHOT } from '../../lib/mockData';
 
 // Initialize i18n (Holdings uses useTranslation)
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 
 // Shared mock state — reassigned per test
 let mockHoldings: HoldingWithPrice[] = [];
@@ -32,13 +32,15 @@ vi.mock('../../hooks/usePortfolio', () => ({
   }),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
   mockHoldings = [];
   mockPortfolio = null;
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
 function renderHoldings() {

--- a/frontend/components/__tests__/Settings.test.tsx
+++ b/frontend/components/__tests__/Settings.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { Settings } from '../Settings';
 
 // Initialize i18n
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 
 // Mock AccountsModal to avoid deep dependency rendering
 vi.mock('../AccountsModal', () => ({
@@ -43,7 +43,7 @@ vi.mock('@tauri-apps/api/app', () => ({
   getVersion: () => mockGetVersion(),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -51,6 +51,8 @@ beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
   mockIsTauri = false;
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
 function renderSettings() {

--- a/frontend/components/__tests__/StressComponents.test.tsx
+++ b/frontend/components/__tests__/StressComponents.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
+
+// Pin language so English-text assertions don't break if the default locale changes.
+beforeEach(async () => {
+  await i18next.changeLanguage('en');
+});
 
 // ─── ResilienceSummary ────────────────────────────────────────────────────────
 import { ResilienceSummary } from '../ResilienceSummary';

--- a/frontend/components/__tests__/TransactionHistory.test.tsx
+++ b/frontend/components/__tests__/TransactionHistory.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-import '../../lib/i18n';
+import i18next from '../../lib/i18n';
 import { TransactionHistory } from '../TransactionHistory';
 
 const mockTransactions = [
@@ -144,12 +144,14 @@ vi.mock('../../hooks/usePortfolio', () => ({
   }),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
   vi.clearAllMocks();
+  // Pin language so English-text assertions don't break if the default locale changes.
+  await i18next.changeLanguage('en');
 });
 
 function renderTxHistory() {

--- a/frontend/lib/__tests__/format.test.ts
+++ b/frontend/lib/__tests__/format.test.ts
@@ -46,6 +46,10 @@ describe('formatCurrency', () => {
     it('formats using an explicit locale override, ignoring the global i18next language', () => {
       expect(formatCurrency(1234.56, 'USD', 'de')).toBe('1.234,56 USD');
     });
+
+    it('formats using French locale separators (narrow no-break space thousands, comma decimal)', () => {
+      expect(formatCurrency(1234.56, 'USD', 'fr')).toBe('1 234,56 USD');
+    });
   });
 });
 
@@ -121,6 +125,10 @@ describe('formatNumber', () => {
 
     it('formats using an explicit locale override, ignoring the global i18next language', () => {
       expect(formatNumber(1234.5, 2, 'de')).toBe('1.234,50');
+    });
+
+    it('formats using French locale separators (narrow no-break space thousands, comma decimal)', () => {
+      expect(formatNumber(1234.5, 2, 'fr')).toBe('1 234,50');
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,8 +27,8 @@ export default defineConfig({
       // measured coverage so the gate is real and green. Raise incrementally as tests are added
       // — do not lower these numbers without adding an equivalent justification.
       thresholds: {
-        lines: 50,
-        functions: 42,
+        lines: 51,
+        functions: 43,
         branches: 44,
         statements: 50,
       },


### PR DESCRIPTION
## Summary

Closes #589

Investigation showed two of the six tracked gaps (`useActionInsights`/`buildInsights` unit tests and the E2E selector/`waitForTimeout` fixes) were already fixed by a prior PR for #327. This PR closes the remaining three:

- **TS2-T1 — pin i18n language**: `Alerts.test.tsx`, `Dividends.test.tsx`, `Holdings.test.tsx`, `Settings.test.tsx`, `StressComponents.test.tsx`, `TransactionHistory.test.tsx`, and `Dashboard.test.tsx` now call `i18next.changeLanguage('en')` in `beforeEach`, so their English-text assertions won't silently break if the default locale changes.
- **TS2-T4 — Dashboard account filter**: added two tests covering the `?account=` URL param — one verifying the portfolio value/holdings count recompute for a filtered account (scoped with `within()` since the "By Account" panel can show the same subtotal), and one covering the empty state for an account with no holdings.
- **TS2-T7 — locale number formats**: added French tests next to the existing German ones in `format.test.ts`, matching the narrow no-break space (U+202F) thousands separator that `Intl.NumberFormat('fr', ...)` actually produces.

Coverage thresholds in `vitest.config.ts` raised to match measured output: `lines 50→51`, `functions 42→43` (branches/statements didn't move enough to bump the floor — gains were sub-1%). Not jumping to the 65%/80% milestones since that's not what the added tests actually achieve.

## Test plan
- [x] `npm test -- --coverage` — 262/262 tests pass, coverage gate passes at new thresholds
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Pre-push hook (lint/typecheck/format, frontend+backend build, frontend+backend tests, clippy) — all green