### PR TITLE
fix: validate MCP write tools and neutralize tab/CR CSV injection

### DIFF
--- a/portfolio-mcp/src/db.rs
+++ b/portfolio-mcp/src/db.rs
@@ -186,6 +186,35 @@ pub async fn insert_holding(pool: &SqlitePool, input: HoldingInput) -> anyhow::R
     })
 }
 
+/// Sum of `target_weight` across all non-deleted holdings, optionally excluding
+/// one holding (used when validating an update to that holding).
+pub async fn sum_target_weights(
+    pool: &SqlitePool,
+    exclude_id: Option<&str>,
+) -> anyhow::Result<f64> {
+    use sqlx::Row;
+    let sum: f64 = match exclude_id {
+        Some(id) => {
+            sqlx::query(
+                "SELECT COALESCE(SUM(target_weight), 0.0) FROM holdings WHERE id != $1 AND deleted_at IS NULL",
+            )
+            .bind(id)
+            .fetch_one(pool)
+            .await?
+            .get::<f64, _>(0)
+        }
+        None => {
+            sqlx::query(
+                "SELECT COALESCE(SUM(target_weight), 0.0) FROM holdings WHERE deleted_at IS NULL",
+            )
+            .fetch_one(pool)
+            .await?
+            .get::<f64, _>(0)
+        }
+    };
+    Ok(sum)
+}
+
 pub async fn delete_holding(pool: &SqlitePool, id: &HoldingId) -> anyhow::Result<bool> {
     let result = sqlx::query(
         "UPDATE holdings SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL",

--- a/portfolio-mcp/src/main.rs
+++ b/portfolio-mcp/src/main.rs
@@ -3,6 +3,7 @@ mod snapshot;
 mod stress;
 mod tools;
 mod types;
+mod validation;
 
 use anyhow::Result;
 use rmcp::{transport::stdio, ServiceExt};

--- a/portfolio-mcp/src/tools/alerts.rs
+++ b/portfolio-mcp/src/tools/alerts.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 use crate::{
     db,
     types::{AlertDirection, AlertId, PriceAlert, PriceAlertInput},
+    validation,
 };
 
 use super::PortfolioMcpServer;
@@ -52,6 +53,9 @@ pub async fn add_alert(pool: &SqlitePool, params: AddAlertParams) -> Result<Pric
         .direction
         .parse::<AlertDirection>()
         .map_err(|e| McpError::invalid_params(e, None))?;
+
+    validation::validate_non_empty("symbol", &params.symbol)?;
+    validation::validate_alert_threshold(params.threshold)?;
 
     let input = PriceAlertInput {
         symbol: params.symbol,

--- a/portfolio-mcp/src/tools/config.rs
+++ b/portfolio-mcp/src/tools/config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
 use crate::db;
+use crate::validation;
 
 use super::PortfolioMcpServer;
 
@@ -59,13 +60,20 @@ pub async fn set_config(
     pool: &SqlitePool,
     params: SetConfigParams,
 ) -> Result<SetConfigResult, McpError> {
-    db::set_config(pool, &params.key, &params.value)
+    validation::validate_config_key(&params.key)?;
+    let value = if params.key == "cost_basis_method" {
+        params.value.to_lowercase()
+    } else {
+        params.value
+    };
+
+    db::set_config(pool, &params.key, &value)
         .await
         .map_err(PortfolioMcpServer::tool_error)?;
 
     Ok(SetConfigResult {
         key: params.key,
-        value: params.value,
+        value,
         ok: true,
     })
 }

--- a/portfolio-mcp/src/tools/holdings.rs
+++ b/portfolio-mcp/src/tools/holdings.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 use crate::{
     db,
     types::{AccountType, AssetType, Holding, HoldingId, HoldingInput},
+    validation,
 };
 
 use super::PortfolioMcpServer;
@@ -68,6 +69,19 @@ pub async fn add_holding(pool: &SqlitePool, params: AddHoldingParams) -> Result<
         .parse::<AccountType>()
         .map_err(|e| McpError::invalid_params(e, None))?;
 
+    validation::validate_non_empty("symbol", &params.symbol)?;
+    validation::validate_non_empty("name", &params.name)?;
+    let currency =
+        validation::validate_holding_fields(params.quantity, params.cost_basis, &params.currency)?;
+    validation::validate_target_weight(params.target_weight)?;
+
+    if let Some(target_weight) = params.target_weight {
+        let existing_sum = db::sum_target_weights(pool, None)
+            .await
+            .map_err(PortfolioMcpServer::tool_error)?;
+        validation::validate_target_weight_budget(Some(target_weight), existing_sum)?;
+    }
+
     let input = HoldingInput {
         symbol: params.symbol,
         name: params.name,
@@ -76,7 +90,7 @@ pub async fn add_holding(pool: &SqlitePool, params: AddHoldingParams) -> Result<
         account_id: params.account_id,
         quantity: params.quantity,
         cost_basis: params.cost_basis,
-        currency: params.currency,
+        currency,
         exchange: params.exchange,
         target_weight: params.target_weight,
         indicated_annual_dividend: params.indicated_annual_dividend,

--- a/portfolio-mcp/src/tools/transactions.rs
+++ b/portfolio-mcp/src/tools/transactions.rs
@@ -5,6 +5,7 @@ use sqlx::SqlitePool;
 use crate::{
     db,
     types::{HoldingId, Transaction, TransactionId, TransactionInput, TransactionType},
+    validation,
 };
 
 use super::PortfolioMcpServer;
@@ -48,6 +49,9 @@ pub async fn add_transaction(
         .transaction_type
         .parse::<TransactionType>()
         .map_err(|e| McpError::invalid_params(e, None))?;
+
+    validation::validate_non_empty("holdingId", &params.holding_id)?;
+    validation::validate_transaction_fields(params.quantity, params.price)?;
 
     let input = TransactionInput {
         holding_id: HoldingId(params.holding_id),

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -1,0 +1,249 @@
+//! Input validation for MCP write tools.
+//!
+//! The MCP server writes directly to the SQLite database, bypassing the
+//! Tauri command layer entirely. These checks mirror the validation enforced
+//! by the corresponding Tauri commands (see `src-tauri/src/commands/mod.rs`,
+//! `commands/alerts.rs`, `commands/transactions.rs`, and `commands/config.rs`)
+//! so the MCP layer cannot be used to write data the desktop app itself would
+//! reject.
+
+use rmcp::Error as McpError;
+
+/// Mirrors `validate_holding_fields` in `src-tauri/src/commands/mod.rs`.
+/// Returns the normalized (uppercase, trimmed) currency code.
+pub fn validate_holding_fields(
+    quantity: f64,
+    cost_basis: f64,
+    currency: &str,
+) -> Result<String, McpError> {
+    if quantity <= 0.0 || !quantity.is_finite() {
+        return Err(McpError::invalid_params(
+            "quantity must be a positive finite number",
+            None,
+        ));
+    }
+    if cost_basis < 0.0 || !cost_basis.is_finite() {
+        return Err(McpError::invalid_params(
+            "costBasis must be a non-negative finite number",
+            None,
+        ));
+    }
+    let currency = currency.trim().to_uppercase();
+    if currency.len() != 3 || !currency.chars().all(|c| c.is_ascii_alphabetic()) {
+        return Err(McpError::invalid_params(
+            "currency must be a 3-letter ISO currency code",
+            None,
+        ));
+    }
+    Ok(currency)
+}
+
+/// Rejects a blank/whitespace-only required string field.
+pub fn validate_non_empty(field: &str, value: &str) -> Result<(), McpError> {
+    if value.trim().is_empty() {
+        return Err(McpError::invalid_params(
+            format!("{field} must not be empty"),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Mirrors the `target_weight` bounds check applied by the CSV import layer
+/// (`src-tauri/src/csv.rs`) and implicitly required by `add_holding`/`update_holding`.
+pub fn validate_target_weight(target_weight: Option<f64>) -> Result<(), McpError> {
+    if let Some(weight) = target_weight {
+        if !weight.is_finite() || !(0.0..=100.0).contains(&weight) {
+            return Err(McpError::invalid_params(
+                "targetWeight must be a finite number between 0 and 100",
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Mirrors the portfolio-wide target-weight guard in `commands/portfolio.rs`:
+/// the sum of all target weights (excluding the holding being edited) plus the
+/// new value must not exceed 100%.
+pub fn validate_target_weight_budget(
+    target_weight: Option<f64>,
+    existing_sum: f64,
+) -> Result<(), McpError> {
+    const WEIGHT_EPSILON: f64 = 0.001;
+    if let Some(weight) = target_weight {
+        if weight > 0.0 && existing_sum + weight > 100.0 + WEIGHT_EPSILON {
+            return Err(McpError::invalid_params(
+                format!(
+                    "Total target weight would exceed 100% (currently {existing_sum:.1}%). \
+                     Adjust existing allocations before adding this holding."
+                ),
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Mirrors the checks in `src-tauri/src/commands/transactions.rs::add_transaction`.
+pub fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), McpError> {
+    if quantity <= 0.0 || !quantity.is_finite() {
+        return Err(McpError::invalid_params(
+            "quantity must be a positive finite number",
+            None,
+        ));
+    }
+    if price < 0.0 || !price.is_finite() {
+        return Err(McpError::invalid_params(
+            "price must be a non-negative finite number",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Mirrors the check in `src-tauri/src/commands/alerts.rs::add_alert`.
+pub fn validate_alert_threshold(threshold: f64) -> Result<(), McpError> {
+    if !threshold.is_finite() || threshold <= 0.0 {
+        return Err(McpError::invalid_params(
+            "threshold must be a positive finite number",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Config keys the Tauri `set_config_cmd` allowlist accepts
+/// (`src-tauri/src/commands/config.rs::ALLOWED_CONFIG_KEYS`). Kept in sync
+/// manually since the MCP server does not depend on the `src-tauri` crate.
+pub const ALLOWED_CONFIG_KEYS: &[&str] = &[
+    "base_currency",
+    "app_language",
+    "app_theme",
+    "auto_refresh_interval_ms",
+    "auto_refresh_market_hours_only",
+    "cost_basis_method",
+    "notifications_enabled",
+];
+
+/// Mirrors the allowlist check in `src-tauri/src/commands/config.rs::set_config_cmd`.
+pub fn validate_config_key(key: &str) -> Result<(), McpError> {
+    if !ALLOWED_CONFIG_KEYS.contains(&key) {
+        return Err(McpError::invalid_params(
+            format!("Unknown config key: {key}"),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_holding_fields_rejects_nan_quantity() {
+        let err = validate_holding_fields(f64::NAN, 100.0, "USD");
+        assert!(err.is_err(), "NaN quantity must be rejected");
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_infinite_cost_basis() {
+        let err = validate_holding_fields(1.0, f64::INFINITY, "USD");
+        assert!(err.is_err(), "infinite cost_basis must be rejected");
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_non_positive_quantity() {
+        assert!(validate_holding_fields(0.0, 100.0, "USD").is_err());
+        assert!(validate_holding_fields(-5.0, 100.0, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_negative_cost_basis() {
+        assert!(validate_holding_fields(1.0, -1.0, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_malformed_currency() {
+        assert!(validate_holding_fields(1.0, 100.0, "US").is_err());
+        assert!(validate_holding_fields(1.0, 100.0, "USDD").is_err());
+        assert!(validate_holding_fields(1.0, 100.0, "U5D").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_normalizes_currency_case_and_whitespace() {
+        let currency = validate_holding_fields(1.0, 100.0, " usd ").expect("valid input");
+        assert_eq!(currency, "USD");
+    }
+
+    #[test]
+    fn validate_holding_fields_accepts_valid_input() {
+        assert!(validate_holding_fields(10.0, 150.25, "CAD").is_ok());
+    }
+
+    #[test]
+    fn validate_non_empty_rejects_blank_and_whitespace() {
+        assert!(validate_non_empty("symbol", "").is_err());
+        assert!(validate_non_empty("symbol", "   ").is_err());
+        assert!(validate_non_empty("symbol", "AAPL").is_ok());
+    }
+
+    #[test]
+    fn validate_target_weight_rejects_out_of_range_and_nan() {
+        assert!(validate_target_weight(Some(-1.0)).is_err());
+        assert!(validate_target_weight(Some(100.001)).is_err());
+        assert!(validate_target_weight(Some(f64::NAN)).is_err());
+        assert!(validate_target_weight(Some(50.0)).is_ok());
+        assert!(validate_target_weight(None).is_ok());
+    }
+
+    #[test]
+    fn validate_target_weight_budget_rejects_when_total_exceeds_100() {
+        assert!(validate_target_weight_budget(Some(50.0), 60.0).is_err());
+        assert!(validate_target_weight_budget(Some(40.0), 60.0).is_ok());
+        // Non-positive weights don't consume budget and are always allowed here.
+        assert!(validate_target_weight_budget(Some(0.0), 99.0).is_ok());
+        assert!(validate_target_weight_budget(None, 99.0).is_ok());
+    }
+
+    #[test]
+    fn validate_transaction_fields_rejects_nan_and_non_positive_quantity() {
+        assert!(validate_transaction_fields(f64::NAN, 10.0).is_err());
+        assert!(validate_transaction_fields(0.0, 10.0).is_err());
+        assert!(validate_transaction_fields(-1.0, 10.0).is_err());
+    }
+
+    #[test]
+    fn validate_transaction_fields_rejects_negative_or_infinite_price() {
+        assert!(validate_transaction_fields(1.0, -1.0).is_err());
+        assert!(validate_transaction_fields(1.0, f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn validate_transaction_fields_accepts_valid_input() {
+        assert!(validate_transaction_fields(5.0, 0.0).is_ok());
+        assert!(validate_transaction_fields(5.0, 120.5).is_ok());
+    }
+
+    #[test]
+    fn validate_alert_threshold_rejects_nan_and_non_positive() {
+        assert!(validate_alert_threshold(f64::NAN).is_err());
+        assert!(validate_alert_threshold(0.0).is_err());
+        assert!(validate_alert_threshold(-10.0).is_err());
+        assert!(validate_alert_threshold(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn validate_alert_threshold_accepts_positive_finite() {
+        assert!(validate_alert_threshold(150.0).is_ok());
+    }
+
+    #[test]
+    fn validate_config_key_rejects_unknown_keys() {
+        assert!(validate_config_key("base_currency").is_ok());
+        assert!(validate_config_key("cost_basis_method").is_ok());
+        assert!(validate_config_key("some_arbitrary_key").is_err());
+        assert!(validate_config_key("").is_err());
+    }
+}

--- a/src-tauri/src/csv.rs
+++ b/src-tauri/src/csv.rs
@@ -23,11 +23,14 @@ pub struct ParsedImportRow {
 }
 
 /// Neutralize CSV/spreadsheet formula injection: values starting with `=`, `+`,
-/// `-`, or `@` are interpreted as formulas by Excel/LibreOffice/Google Sheets
-/// when the exported file is opened. Prefixing with a single quote forces the
-/// cell to be treated as literal text instead of being evaluated.
+/// `-`, `@`, tab, or carriage return are interpreted as formulas by
+/// Excel/LibreOffice/Google Sheets when the exported file is opened (tab/CR
+/// prefixes are stripped or otherwise treated as leading whitespace by some
+/// parsers, exposing a `=`/`+`/`-`/`@` character beneath them). Prefixing with
+/// a single quote forces the cell to be treated as literal text instead of
+/// being evaluated.
 fn neutralize_formula_injection(s: &str) -> String {
-    if s.starts_with(['=', '+', '-', '@']) {
+    if s.starts_with(['=', '+', '-', '@', '\t', '\r']) {
         format!("'{}", s)
     } else {
         s.to_string()
@@ -526,6 +529,62 @@ mod tests {
         assert_eq!(&record[1], "'+SUM(1,1)");
         assert_eq!(&record[7], "'-2+3");
         assert_eq!(&record[10], "'@SUM");
+    }
+
+    #[test]
+    fn build_holdings_csv_neutralizes_tab_prefixed_formula_injection() {
+        let mut holding = make_holding("AAPL", AssetType::Stock, 5.0, 120.0, "USD");
+        holding.name = "\t=DANGEROUS".to_string();
+
+        let csv = build_holdings_csv(&[holding]).expect("build csv");
+        let mut reader = ReaderBuilder::new().from_reader(csv.as_bytes());
+        let record = reader
+            .records()
+            .next()
+            .expect("data row")
+            .expect("valid csv row");
+
+        assert_eq!(&record[1], "'\t=DANGEROUS");
+    }
+
+    #[test]
+    fn build_holdings_csv_neutralizes_cr_prefixed_formula_injection() {
+        let mut holding = make_holding("AAPL", AssetType::Stock, 5.0, 120.0, "USD");
+        holding.name = "\r=DANGEROUS".to_string();
+
+        let csv = build_holdings_csv(&[holding]).expect("build csv");
+        let mut reader = ReaderBuilder::new().from_reader(csv.as_bytes());
+        let record = reader
+            .records()
+            .next()
+            .expect("data row")
+            .expect("valid csv row");
+
+        assert_eq!(&record[1], "'\r=DANGEROUS");
+    }
+
+    #[test]
+    fn build_holdings_csv_neutralizes_tab_and_cr_across_all_string_fields() {
+        let mut holding = make_holding("\tAAPL", AssetType::Stock, 5.0, 120.0, "\rUSD");
+        holding.name = "\t=SUM(A1)".to_string();
+        holding.exchange = "\rNASDAQ".to_string();
+        holding.indicated_annual_dividend_currency = Some("\tUSD".to_string());
+        holding.maturity_date = Some("\r2030-01-01".to_string());
+
+        let csv = build_holdings_csv(&[holding]).expect("build csv");
+        let mut reader = ReaderBuilder::new().from_reader(csv.as_bytes());
+        let record = reader
+            .records()
+            .next()
+            .expect("data row")
+            .expect("valid csv row");
+
+        assert_eq!(&record[0], "'\tAAPL");
+        assert_eq!(&record[1], "'\t=SUM(A1)");
+        assert_eq!(&record[6], "'\rUSD");
+        assert_eq!(&record[7], "'\rNASDAQ");
+        assert_eq!(&record[10], "'\tUSD");
+        assert_eq!(&record[12], "'\r2030-01-01");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **#612 (HIGH)**: `portfolio-mcp` write tools (`add_holding`, `add_transaction`, `add_alert`, `set_config`) wrote directly to SQLite, bypassing every validation guard the Tauri command layer enforces. A misconfigured or compromised MCP client could write invalid/arbitrary data (NaN/infinite quantities, malformed currencies, unbounded target weights, arbitrary config keys). Added `portfolio-mcp/src/validation.rs`, mirroring the checks in `src-tauri/src/commands/{mod,alerts,transactions,config}.rs`, and wired it into each write handler. Also added `db::sum_target_weights` to the MCP crate so `add_holding` enforces the same "target weights can't exceed 100%" budget the desktop app enforces.
- **#616**: CSV export's formula-injection guard only prefixed values starting with `=`, `+`, `-`, `@`. Some spreadsheet parsers treat a leading tab or carriage return as whitespace and evaluate the formula underneath, so those payloads weren't neutralized. Extended `neutralize_formula_injection` in `src-tauri/src/csv.rs` to also catch leading `\t`/`\r`. (Audited all string fields in the export — symbol, name, currency, exchange, dividend currency, dividend frequency, maturity date — all already route through the sanitizer; only the character set needed extending.)

## Test plan
- [x] `cargo test -p portfolio-mcp --locked` — 16 new validation tests pass (NaN/infinite/negative rejection, currency format, target-weight budget, config allowlist)
- [x] `cargo test -p portfolio-tracker --locked` — 253 tests pass, including 3 new CSV injection tests (tab-prefixed, CR-prefixed, and all-string-fields coverage)
- [x] `cargo clippy -p portfolio-mcp -p portfolio-tracker --all-targets` — no new warnings
- [x] Full pre-push pipeline (lint, typecheck, frontend build, backend build, 274 frontend tests, 253 backend tests, clippy) passed