### PR TITLE
fix: validate target_weight/dividend fields, trust fresh zero prices

### DIFF
--- a/src-tauri/src/commands/dividends.rs
+++ b/src-tauri/src/commands/dividends.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{Dividend, DividendId, DividendInput, PaginatedResult};
 
-use super::DbState;
+use super::{validate_dividend_fields, DbState};
 
 /// Deprecated: use `get_dividends_paginated` instead.
 #[tauri::command]
@@ -39,6 +39,11 @@ pub async fn add_dividend(
     db: State<'_, DbState>,
     dividend: DividendInput,
 ) -> Result<Dividend, AppError> {
+    validate_dividend_fields(
+        dividend.amount_per_unit,
+        &dividend.ex_date,
+        &dividend.pay_date,
+    )?;
     let pool = &db.0;
     let (symbol, holding_currency) =
         db::get_holding_symbol_and_currency(pool, dividend.holding_id.0.as_str())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -205,7 +205,7 @@ pub(crate) const WEIGHT_EPSILON: f64 = 0.001;
 /// silently persist and produce nonsensical rebalance suggestions.
 pub(crate) fn validate_target_weight(target_weight: Option<f64>) -> Result<(), AppError> {
     if let Some(weight) = target_weight {
-        if !weight.is_finite() || weight < 0.0 || weight > 100.0 {
+        if !weight.is_finite() || !(0.0..=100.0).contains(&weight) {
             return Err(AppError::Validation(
                 "targetWeight must be a finite number between 0 and 100".to_string(),
             ));

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -200,6 +200,39 @@ pub(crate) fn validate_holding_fields(
 
 pub(crate) const WEIGHT_EPSILON: f64 = 0.001;
 
+/// Validates an optional target weight: when present, must be a finite
+/// percentage in [0, 100]. A negative or out-of-range value would otherwise
+/// silently persist and produce nonsensical rebalance suggestions.
+pub(crate) fn validate_target_weight(target_weight: Option<f64>) -> Result<(), AppError> {
+    if let Some(weight) = target_weight {
+        if !weight.is_finite() || weight < 0.0 || weight > 100.0 {
+            return Err(AppError::Validation(
+                "targetWeight must be a finite number between 0 and 100".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validates dividend input fields shared by `add_dividend`.
+pub(crate) fn validate_dividend_fields(
+    amount_per_unit: f64,
+    ex_date: &str,
+    pay_date: &str,
+) -> Result<(), AppError> {
+    if !amount_per_unit.is_finite() || amount_per_unit <= 0.0 {
+        return Err(AppError::Validation(
+            "amountPerUnit must be a finite number greater than 0".to_string(),
+        ));
+    }
+    if !ex_date.trim().is_empty() && !pay_date.trim().is_empty() && pay_date < ex_date {
+        return Err(AppError::Validation(
+            "payDate must not be before exDate".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::csv::{build_holdings_csv, parse_import_rows};

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -8,8 +8,8 @@ use crate::portfolio::build_portfolio_snapshot;
 use crate::types::{Holding, HoldingId, HoldingInput, PortfolioSnapshot};
 
 use super::{
-    get_base_currency, validate_holding_fields, DbState, HttpClient, RealizedGainsCacheState,
-    WEIGHT_EPSILON,
+    get_base_currency, validate_holding_fields, validate_target_weight, DbState, HttpClient,
+    RealizedGainsCacheState, WEIGHT_EPSILON,
 };
 
 #[tauri::command]
@@ -109,6 +109,7 @@ pub async fn add_holding(
     holding: HoldingInput,
 ) -> Result<Holding, AppError> {
     validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
+    validate_target_weight(holding.target_weight)?;
     let pool = &db.0;
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
@@ -130,6 +131,7 @@ pub async fn add_holding(
 #[tauri::command]
 pub async fn update_holding(db: State<'_, DbState>, holding: Holding) -> Result<Holding, AppError> {
     validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
+    validate_target_weight(holding.target_weight)?;
     let pool = &db.0;
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {

--- a/src-tauri/src/commands_tests.rs
+++ b/src-tauri/src/commands_tests.rs
@@ -103,6 +103,103 @@ mod tests {
         assert!(validate_holding(&holding_input("AAPL")).is_ok());
     }
 
+    // ── target weight validation (#613) ───────────────────────────────────────
+
+    #[test]
+    fn target_weight_rejects_negative() {
+        assert!(crate::commands::validate_target_weight(Some(-5.0)).is_err());
+    }
+
+    #[test]
+    fn target_weight_rejects_above_100() {
+        assert!(crate::commands::validate_target_weight(Some(100.5)).is_err());
+    }
+
+    #[test]
+    fn target_weight_rejects_nan() {
+        assert!(crate::commands::validate_target_weight(Some(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn target_weight_rejects_infinite() {
+        assert!(crate::commands::validate_target_weight(Some(f64::INFINITY)).is_err());
+    }
+
+    #[test]
+    fn target_weight_accepts_none() {
+        assert!(crate::commands::validate_target_weight(None).is_ok());
+    }
+
+    #[test]
+    fn target_weight_accepts_zero() {
+        assert!(crate::commands::validate_target_weight(Some(0.0)).is_ok());
+    }
+
+    #[test]
+    fn target_weight_accepts_100() {
+        assert!(crate::commands::validate_target_weight(Some(100.0)).is_ok());
+    }
+
+    #[test]
+    fn target_weight_accepts_valid_mid_range() {
+        assert!(crate::commands::validate_target_weight(Some(25.5)).is_ok());
+    }
+
+    // ── dividend validation (#617) ────────────────────────────────────────────
+
+    #[test]
+    fn dividend_rejects_zero_amount() {
+        assert!(
+            crate::commands::validate_dividend_fields(0.0, "2024-03-15", "2024-04-25").is_err()
+        );
+    }
+
+    #[test]
+    fn dividend_rejects_negative_amount() {
+        assert!(
+            crate::commands::validate_dividend_fields(-1.38, "2024-03-15", "2024-04-25").is_err()
+        );
+    }
+
+    #[test]
+    fn dividend_rejects_nan_amount() {
+        assert!(
+            crate::commands::validate_dividend_fields(f64::NAN, "2024-03-15", "2024-04-25")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn dividend_rejects_infinite_amount() {
+        assert!(crate::commands::validate_dividend_fields(
+            f64::INFINITY,
+            "2024-03-15",
+            "2024-04-25"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn dividend_rejects_pay_date_before_ex_date() {
+        assert!(
+            crate::commands::validate_dividend_fields(1.38, "2024-04-25", "2024-03-15").is_err()
+        );
+    }
+
+    #[test]
+    fn dividend_accepts_pay_date_equal_to_ex_date() {
+        assert!(
+            crate::commands::validate_dividend_fields(1.38, "2024-03-15", "2024-03-15").is_ok()
+        );
+    }
+
+    #[test]
+    fn dividend_accepts_valid_inputs() {
+        assert!(
+            crate::commands::validate_dividend_fields(1.38, "2024-03-15", "2024-04-25").is_ok()
+        );
+    }
+
     // ── alert validation ──────────────────────────────────────────────────────
 
     fn validate_alert(input: &PriceAlertInput) -> Result<(), String> {

--- a/src-tauri/src/portfolio.rs
+++ b/src-tauri/src/portfolio.rs
@@ -7,6 +7,20 @@ use crate::types::{FxRate, Holding, HoldingWithPrice, PortfolioSnapshot, PriceDa
 /// Price is considered stale after 24 h — covers overnight/weekend gaps when markets are closed.
 const PRICE_STALE_SECS: i64 = 24 * 3600;
 
+/// Returns true if `updated_at` (an RFC 3339 timestamp) is older than `PRICE_STALE_SECS`,
+/// or unparseable.
+fn is_price_stale(updated_at: &str) -> bool {
+    DateTime::parse_from_rfc3339(updated_at)
+        .ok()
+        .map(|t| {
+            Utc::now()
+                .signed_duration_since(t.with_timezone(&Utc))
+                .num_seconds()
+                > PRICE_STALE_SECS
+        })
+        .unwrap_or(true) // if timestamp unparseable, treat as stale
+}
+
 /// Build a `PortfolioSnapshot` from raw holdings, cached prices, and FX rates.
 ///
 /// All monetary values in the snapshot are expressed in `base_currency`.
@@ -57,21 +71,24 @@ pub fn build_portfolio_snapshot(
             (1.0f64, 0.0f64, false)
         } else {
             match price_map.get(&holding.symbol) {
-                // A cached price of 0.0 or negative is invalid (e.g. a bad API
-                // response written to the cache) — treat it the same as a
-                // cache miss rather than using it in market_value_cad/gain_loss.
                 Some(p) if p.price > 0.0 => {
-                    let stale = DateTime::parse_from_rfc3339(&p.updated_at)
-                        .ok()
-                        .map(|t| {
-                            Utc::now()
-                                .signed_duration_since(t.with_timezone(&Utc))
-                                .num_seconds()
-                                > PRICE_STALE_SECS
-                        })
-                        .unwrap_or(true); // if timestamp unparseable, treat as stale
+                    let stale = is_price_stale(&p.updated_at);
                     (p.price, p.change_percent, stale)
                 }
+                // A cached price of exactly 0.0 is ambiguous: it may be a
+                // genuinely worthless security (penny stock, delisted share,
+                // warrant) or a bad API response. Trust it while fresh; once
+                // stale (> 24h old), it's far more likely bad data, so fall
+                // back to cost_basis the same as a cache miss.
+                Some(p) if p.price == 0.0 => {
+                    let stale = is_price_stale(&p.updated_at);
+                    if stale {
+                        (holding.cost_basis, 0.0, true)
+                    } else {
+                        (0.0, p.change_percent, false)
+                    }
+                }
+                // Negative prices are never legitimate — treat as a cache miss.
                 _ => (holding.cost_basis, 0.0, true),
             }
         };
@@ -621,20 +638,55 @@ mod tests {
     }
 
     #[test]
-    fn build_portfolio_snapshot_cached_zero_price_falls_back_to_cost_basis() {
-        // Regression guard for #609: a cached price of 0.0 (e.g. a bad API
-        // response written to the cache) must be treated as if no price
-        // exists at all — fall back to cost_basis rather than using 0.0,
-        // which would otherwise wipe out market_value_cad and produce a
-        // bogus -100% gain_loss_percent.
+    fn build_portfolio_snapshot_fresh_zero_price_is_treated_as_legitimate() {
+        // Regression guard for #618: a fresh cached price of exactly 0.0 may be
+        // a genuinely worthless security (penny stock, delisted, warrant), not
+        // just a bad API response. While fresh (< 24h old), it must be trusted
+        // and used as-is rather than silently replaced with cost_basis.
+        let holding = make_holding("WORTHLESS", AssetType::Stock, 10.0, 50.0, "USD");
+        let prices = vec![PriceData {
+            symbol: "WORTHLESS".to_string(),
+            price: 0.0,
+            currency: "USD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "USD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!((snapshot.holdings[0].current_price - 0.0).abs() < 0.001);
+        assert!((snapshot.holdings[0].market_value_cad - 0.0).abs() < 0.001);
+        assert!(!snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_stale_zero_price_falls_back_to_cost_basis() {
+        // Regression guard for #609/#618: a cached price of 0.0 that is also
+        // stale (> 24h old) is almost certainly a bad API response rather than
+        // a real price — fall back to cost_basis rather than using 0.0, which
+        // would otherwise wipe out market_value_cad and produce a bogus -100%
+        // gain_loss_percent.
         let holding = make_holding("BADPRICE", AssetType::Stock, 10.0, 50.0, "USD");
+        let two_days_ago = (Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
         let prices = vec![PriceData {
             symbol: "BADPRICE".to_string(),
             price: 0.0,
             currency: "USD".to_string(),
             change: 0.0,
             change_percent: 0.0,
-            updated_at: Utc::now().to_rfc3339(),
+            updated_at: two_days_ago,
             open: None,
             previous_close: None,
             volume: None,


### PR DESCRIPTION
## Summary
- `add_holding`/`update_holding` now reject a `targetWeight` outside `[0, 100]` or non-finite, via a new `validate_target_weight` helper — a negative target weight previously persisted silently and produced nonsensical rebalance suggestions.
- `add_dividend` now rejects a non-finite/non-positive `amountPerUnit`, and a `payDate` earlier than `exDate`, via a new `validate_dividend_fields` helper.
- `build_portfolio_snapshot` now trusts a cached price of exactly `0.0` while fresh (< 24h old), since it may represent a genuinely worthless security (penny stock, delisted share, warrant) rather than bad API data. It only falls back to `cost_basis` once that `0.0` price goes stale. Negative cached prices are still always treated as invalid, regardless of age.

Closes #613
Closes #617
Closes #618

## Test plan
- [x] Added unit tests for `validate_target_weight` (negative, >100, NaN, infinite, None, 0, 100, mid-range) in `commands_tests.rs`
- [x] Added unit tests for `validate_dividend_fields` (zero/negative/NaN/infinite amount, pay_date before ex_date, equal dates, valid inputs) in `commands_tests.rs`
- [x] Updated/added `build_portfolio_snapshot` tests in `portfolio.rs`: fresh `0.0` price is now used as-is (not flagged stale); stale `0.0` price still falls back to `cost_basis`; existing negative-price regression test unchanged
- [x] `cargo test --locked` in `src-tauri/` — 269 passed, 0 failed
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt` — clean