### PR TITLE
fix: distinguish explicit 0% target weight from unset in frontend

### DIFF
--- a/frontend/components/Holdings.tsx
+++ b/frontend/components/Holdings.tsx
@@ -28,6 +28,7 @@ import {
   formatNumber,
   formatPercent,
   formatShortDate,
+  formatTargetWeight,
 } from '../lib/format';
 import { pnlColor } from '../lib/colors';
 import { ACCOUNT_OPTIONS, ACCOUNT_TYPE_CONFIG } from '../lib/constants';
@@ -1150,14 +1151,17 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                       textAlign: 'right',
                                       fontFamily: 'var(--font-mono)',
                                       color:
-                                        (h.targetWeight ?? 0) > 0
-                                          ? 'var(--text-primary)'
-                                          : 'var(--text-muted)',
+                                        h.targetWeight === 0
+                                          ? 'var(--color-loss)'
+                                          : h.targetWeight != null
+                                            ? 'var(--text-primary)'
+                                            : 'var(--text-muted)',
                                     }}
+                                    title={
+                                      h.targetWeight === 0 ? 'Marked for full exit' : undefined
+                                    }
                                   >
-                                    {(h.targetWeight ?? 0) > 0
-                                      ? `${(h.targetWeight ?? 0).toFixed(1)}%`
-                                      : '—'}
+                                    {formatTargetWeight(h.targetWeight)}
                                   </td>
                                   <td
                                     style={{
@@ -1167,7 +1171,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                       color: pnlColor(h.targetDeltaPercent),
                                     }}
                                   >
-                                    {(h.targetWeight ?? 0) > 0 || h.assetType === 'cash'
+                                    {h.targetWeight != null || h.assetType === 'cash'
                                       ? formatPercent(h.targetDeltaPercent)
                                       : '—'}
                                   </td>
@@ -1180,7 +1184,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                       fontWeight: 600,
                                     }}
                                   >
-                                    {(h.targetWeight ?? 0) > 0 || h.assetType === 'cash'
+                                    {h.targetWeight != null || h.assetType === 'cash'
                                       ? `${h.targetDeltaValue >= 0 ? '+' : ''}${formatCurrency(h.targetDeltaValue, baseCurrency)}`
                                       : '—'}
                                   </td>
@@ -1755,14 +1759,15 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               textAlign: 'right',
                               fontFamily: 'var(--font-mono)',
                               color:
-                                (h.targetWeight ?? 0) > 0
-                                  ? 'var(--text-primary)'
-                                  : 'var(--text-muted)',
+                                h.targetWeight === 0
+                                  ? 'var(--color-loss)'
+                                  : h.targetWeight != null
+                                    ? 'var(--text-primary)'
+                                    : 'var(--text-muted)',
                             }}
+                            title={h.targetWeight === 0 ? 'Marked for full exit' : undefined}
                           >
-                            {(h.targetWeight ?? 0) > 0
-                              ? `${(h.targetWeight ?? 0).toFixed(1)}%`
-                              : '—'}
+                            {formatTargetWeight(h.targetWeight)}
                           </td>
                         )}
                         {!hiddenColumns.has('targetDeltaPercent') && (
@@ -1774,7 +1779,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               color: pnlColor(h.targetDeltaPercent),
                             }}
                           >
-                            {(h.targetWeight ?? 0) > 0 || h.assetType === 'cash'
+                            {h.targetWeight != null || h.assetType === 'cash'
                               ? formatPercent(h.targetDeltaPercent)
                               : '—'}
                           </td>
@@ -1789,7 +1794,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               fontWeight: 600,
                             }}
                           >
-                            {(h.targetWeight ?? 0) > 0 || h.assetType === 'cash'
+                            {h.targetWeight != null || h.assetType === 'cash'
                               ? `${h.targetDeltaValue >= 0 ? '+' : ''}${formatCurrency(h.targetDeltaValue, baseCurrency)}`
                               : '—'}
                           </td>

--- a/frontend/components/ImportHoldingsModal.tsx
+++ b/frontend/components/ImportHoldingsModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { ImportResult, PreviewImportResult, PreviewRow } from '../types/portfolio';
 import { ASSET_TYPE_CONFIG } from '../lib/constants';
 import { useFormatNumber } from '../hooks/useFormatters';
+import { formatTargetWeight } from '../lib/format';
 import { Badge } from './ui/Badge';
 
 interface Props {
@@ -170,7 +171,7 @@ function PreviewTable({ rows }: { rows: PreviewRow[] }) {
                 {formatNumber(r.costBasis, 2)}
               </td>
               <td style={{ ...TD, ...MONO, color: 'var(--text-secondary)', textAlign: 'right' }}>
-                {formatNumber(r.targetWeight, 1)}%
+                {formatTargetWeight(r.targetWeight)}
               </td>
               <td style={TD}>{statusCell(r)}</td>
             </tr>

--- a/frontend/components/__tests__/Holdings.test.tsx
+++ b/frontend/components/__tests__/Holdings.test.tsx
@@ -39,9 +39,50 @@ beforeEach(async () => {
   delete (window as any).__TAURI__;
   mockHoldings = [];
   mockPortfolio = null;
+  localStorage.clear();
   // Pin language so English-text assertions don't break if the default locale changes.
   await i18next.changeLanguage('en');
 });
+
+function makeHolding(overrides: Partial<HoldingWithPrice> = {}): HoldingWithPrice {
+  return {
+    id: 'h1',
+    symbol: 'AAPL',
+    name: 'Apple',
+    assetType: 'stock',
+    account: 'taxable',
+    quantity: 10,
+    costBasis: 150,
+    currency: 'USD',
+    exchange: 'NASDAQ',
+    targetWeight: null,
+    weight: 20,
+    currentPrice: 200,
+    currentPriceCad: 280,
+    marketValueCad: 2800,
+    costValueCad: 2100,
+    gainLoss: 700,
+    gainLossPercent: 33.3,
+    targetValue: 0,
+    targetDeltaValue: -2800,
+    targetDeltaPercent: -20,
+    dailyChangePercent: 0.5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    indicatedAnnualDividend: null,
+    indicatedAnnualDividendCurrency: null,
+    dividendFrequency: null,
+    maturityDate: null,
+    fxStale: false,
+    priceIsStale: false,
+    ...overrides,
+  };
+}
+
+/** Shows every column, including targetWeight/targetDeltaPercent/targetDeltaValue which are hidden by default. */
+function showAllColumns() {
+  localStorage.setItem('app-config', JSON.stringify({ holdings_hidden_columns: '[]' }));
+}
 
 function renderHoldings() {
   return render(
@@ -105,5 +146,43 @@ describe('Holdings component smoke tests', () => {
     mockPortfolio = MOCK_SNAPSHOT as PortfolioSnapshot;
     renderHoldings();
     expect(screen.queryByText(/no positions/i)).toBeNull();
+  });
+});
+
+describe('Holdings target weight null vs explicit-0 display', () => {
+  it('shows "—" for a holding with no target weight set (null)', () => {
+    showAllColumns();
+    const holding = makeHolding({ targetWeight: null });
+    mockHoldings = [holding];
+    mockPortfolio = { ...MOCK_SNAPSHOT, holdings: [holding] } as PortfolioSnapshot;
+    renderHoldings();
+
+    // No explicit-zero tooltip should be present for a null target.
+    expect(screen.queryByTitle('Marked for full exit')).toBeNull();
+  });
+
+  it('shows "0.0%" with a distinct tooltip for a holding explicitly targeted at 0%', () => {
+    showAllColumns();
+    const holding = makeHolding({ targetWeight: 0 });
+    mockHoldings = [holding];
+    mockPortfolio = { ...MOCK_SNAPSHOT, holdings: [holding] } as PortfolioSnapshot;
+    renderHoldings();
+
+    const targetCell = screen.getByTitle('Marked for full exit');
+    expect(targetCell.textContent).toBe('0.0%');
+  });
+
+  it('shows rebalance delta values for an explicit 0% target (not "—")', () => {
+    showAllColumns();
+    const holding = makeHolding({
+      targetWeight: 0,
+      targetDeltaPercent: -20,
+      targetDeltaValue: -2800,
+    });
+    mockHoldings = [holding];
+    mockPortfolio = { ...MOCK_SNAPSHOT, holdings: [holding] } as PortfolioSnapshot;
+    renderHoldings();
+
+    expect(screen.getByText('-20.00%')).toBeTruthy();
   });
 });

--- a/frontend/components/__tests__/ImportHoldingsModal.test.tsx
+++ b/frontend/components/__tests__/ImportHoldingsModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ImportHoldingsModal } from '../ImportHoldingsModal';
 import type { PreviewRow, PreviewImportResult } from '../../types/portfolio';
 
@@ -132,5 +132,30 @@ describe('ImportHoldingsModal', () => {
   it('shows max rows hint', () => {
     renderModal();
     expect(screen.getByText(/max 500 rows/i)).toBeTruthy();
+  });
+
+  it('renders "—" with no percent sign for a row with no target_weight', async () => {
+    const rows = [makeReadyRow({ targetWeight: null })];
+    mockOnPreview.mockResolvedValue(makePreviewResult(rows));
+    renderModal();
+
+    const file = new File(['symbol\nAAPL'], 'holdings.csv', { type: 'text/csv' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText('—')).toBeTruthy());
+    expect(screen.queryByText('—%')).toBeNull();
+  });
+
+  it('renders "0.0%" for a row with an explicit zero target_weight', async () => {
+    const rows = [makeReadyRow({ targetWeight: 0 })];
+    mockOnPreview.mockResolvedValue(makePreviewResult(rows));
+    renderModal();
+
+    const file = new File(['symbol\nAAPL'], 'holdings.csv', { type: 'text/csv' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText('0.0%')).toBeTruthy());
   });
 });

--- a/frontend/hooks/__tests__/usePortfolio.test.ts
+++ b/frontend/hooks/__tests__/usePortfolio.test.ts
@@ -131,6 +131,52 @@ describe('usePortfolio hook (mock/browser path)', () => {
     expect(importResult!.totalRows).toBe(1);
   });
 
+  it('previewImportCsv preserves an explicit target_weight of 0 (not null)', async () => {
+    const { usePortfolio, PortfolioProvider } = await import('../../hooks/usePortfolio');
+    const { createElement } = await import('react');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(PortfolioProvider, null, children);
+
+    const { result } = renderHook(() => usePortfolio(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false), { timeout: 2000 });
+
+    const csvContent = [
+      'symbol,name,type,account,quantity,cost_basis,currency,exchange,target_weight',
+      'GOOG,Alphabet Inc.,stock,taxable,5,120,USD,NASDAQ,0',
+    ].join('\n');
+
+    let preview: Awaited<ReturnType<typeof result.current.previewImportCsv>>;
+    await act(async () => {
+      preview = await result.current.previewImportCsv(csvContent);
+    });
+
+    expect(preview!.rows[0]!.targetWeight).toBe(0);
+  });
+
+  it('previewImportCsv maps a blank target_weight cell to null', async () => {
+    const { usePortfolio, PortfolioProvider } = await import('../../hooks/usePortfolio');
+    const { createElement } = await import('react');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(PortfolioProvider, null, children);
+
+    const { result } = renderHook(() => usePortfolio(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false), { timeout: 2000 });
+
+    const csvContent = [
+      'symbol,name,type,account,quantity,cost_basis,currency,exchange,target_weight',
+      'GOOG,Alphabet Inc.,stock,taxable,5,120,USD,NASDAQ,',
+    ].join('\n');
+
+    let preview: Awaited<ReturnType<typeof result.current.previewImportCsv>>;
+    await act(async () => {
+      preview = await result.current.previewImportCsv(csvContent);
+    });
+
+    expect(preview!.rows[0]!.targetWeight).toBeNull();
+  });
+
   it('exports CSV with correct headers when holdings exist', async () => {
     const { usePortfolio, PortfolioProvider } = await import('../../hooks/usePortfolio');
     const { createElement } = await import('react');

--- a/frontend/hooks/usePortfolio.ts
+++ b/frontend/hooks/usePortfolio.ts
@@ -75,6 +75,13 @@ function parseCSVLine(line: string, delimiter: string): string[] {
   return result;
 }
 
+/** Parses a CSV cell as a number, preserving an explicit "0" instead of coercing it to null. */
+function parseNullableNumber(cell: string | undefined): number | null {
+  if (!cell || cell.trim() === '') return null;
+  const n = Number(cell);
+  return Number.isFinite(n) ? n : null;
+}
+
 function parseMockCsv(csvContent: string): HoldingInput[] {
   const lines = csvContent
     .trim()
@@ -107,9 +114,7 @@ function parseMockCsv(csvContent: string): HoldingInput[] {
       costBasis: Number(cells[columnIndex('cost_basis')]),
       currency,
       exchange: (cells[columnIndex('exchange')] ?? '').toUpperCase(),
-      targetWeight: cells[columnIndex('target_weight')]
-        ? Number(cells[columnIndex('target_weight')]) || null
-        : null,
+      targetWeight: parseNullableNumber(cells[columnIndex('target_weight')]),
       indicatedAnnualDividend: cells[columnIndex('indicated_annual_dividend')]
         ? Number(cells[columnIndex('indicated_annual_dividend')]) || null
         : null,

--- a/frontend/lib/__tests__/format.test.ts
+++ b/frontend/lib/__tests__/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatCompact,
   formatMonthYear,
   formatShortDate,
+  formatTargetWeight,
 } from '../format';
 
 const EM_DASH = '—';
@@ -211,5 +212,23 @@ describe('formatShortDate', () => {
 
   it('formats using an explicit locale override, not the hardcoded en locale', () => {
     expect(formatShortDate('2026-01-14T12:00:00Z', 'de')).toBe('14. Jan. 2026');
+  });
+});
+
+describe('formatTargetWeight', () => {
+  it('returns em dash with no percent sign for null (no target set)', () => {
+    expect(formatTargetWeight(null)).toBe('—');
+  });
+
+  it('returns em dash with no percent sign for undefined', () => {
+    expect(formatTargetWeight(undefined)).toBe('—');
+  });
+
+  it('formats an explicit zero target as "0.0%", distinct from unset', () => {
+    expect(formatTargetWeight(0)).toBe('0.0%');
+  });
+
+  it('formats a positive target with one decimal place', () => {
+    expect(formatTargetWeight(12.5)).toBe('12.5%');
   });
 });

--- a/frontend/lib/format.ts
+++ b/frontend/lib/format.ts
@@ -30,6 +30,12 @@ export function formatPercent(decimal: number | null | undefined): string {
   return `${sign}${decimal.toFixed(2)}%`;
 }
 
+/** Formats a nullable target weight percentage. Null/undefined means "no target set" (→ "—"); 0 is an explicit target and renders as "0.0%". */
+export function formatTargetWeight(weight: number | null | undefined): string {
+  if (!isValidNumber(weight)) return INVALID_NUMBER;
+  return `${weight.toFixed(1)}%`;
+}
+
 export function formatNumber(
   n: number | null | undefined,
   decimals = 2,


### PR DESCRIPTION
## Summary
- `target_weight` is nullable in the DB — `null` means "no target set", `0.0` means "explicitly targeted at 0%, sell everything". The frontend previously collapsed both cases together with `(targetWeight ?? 0) > 0` checks, so an explicit 0% target displayed the same "—" as an unset one and its rebalance delta columns were hidden.
- Added `formatTargetWeight()` to `frontend/lib/format.ts`: returns `"—"` for null/undefined, `"0.0%"` for an explicit zero. Used by both `Holdings.tsx` and `ImportHoldingsModal.tsx`, which also fixes the import preview table rendering `"—%"` (dash + stray percent sign) for rows with no `target_weight`.
- `Holdings.tsx`: an explicit 0% target now renders `"0.0%"` in loss-red with a `"Marked for full exit"` tooltip, distinct from the muted `"—"` shown for an unset target. The `targetDeltaPercent`/`targetDeltaValue` columns now key off `targetWeight != null` instead of `> 0`, so rebalance guidance shows for an explicit 0% target too.
- `AddHoldingModal.tsx` already saved `null` vs `0` correctly on submit — confirmed by existing tests, no change needed there.
- `usePortfolio.ts`'s browser-mock CSV parser (`parseMockCsv`, used by `previewImportCsv`/`importHoldingsCsv` in browser dev mode) used `Number(cell) || null`, which coerced an explicit CSV `"0"` into `null`. Replaced with a helper that only returns `null` for a blank/invalid cell.

Closes #614
Closes #619

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 285/285 passing (added TDD coverage: `formatTargetWeight` in `format.test.ts`, null-vs-0 rendering + tooltip + delta-column visibility in `Holdings.test.tsx`, `"—"` vs `"0.0%"` preview rendering in `ImportHoldingsModal.test.tsx`, explicit-0 CSV parsing in `usePortfolio.test.ts`)
- [x] Manually verified in the browser preview: enabled the Target column on Holdings (mock data, all non-null/non-zero — no regression), and drove the Import Holdings modal with a CSV containing an explicit `target_weight=0` row and a blank row — confirmed `"0.0%"` vs plain `"—"` (no stray `%`)