### PR TITLE
fix: validate transaction quantity/price and holding dividend fields

### DIFF
--- a/portfolio-mcp/src/tools/holdings.rs
+++ b/portfolio-mcp/src/tools/holdings.rs
@@ -74,6 +74,11 @@ pub async fn add_holding(pool: &SqlitePool, params: AddHoldingParams) -> Result<
     let currency =
         validation::validate_holding_fields(params.quantity, params.cost_basis, &params.currency)?;
     validation::validate_target_weight(params.target_weight)?;
+    validation::validate_holding_dividend_fields(
+        params.indicated_annual_dividend,
+        params.dividend_frequency.as_deref(),
+        params.maturity_date.as_deref(),
+    )?;
 
     if let Some(target_weight) = params.target_weight {
         let existing_sum = db::sum_target_weights(pool, None)

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -85,6 +85,48 @@ pub fn validate_target_weight_budget(
     Ok(())
 }
 
+/// Dividend frequencies accepted by the CSV import layer (`src-tauri/src/csv.rs`),
+/// mirrored here so the MCP `add_holding` tool applies the same set.
+pub const VALID_DIVIDEND_FREQUENCIES: &[&str] =
+    &["monthly", "quarterly", "semi-annual", "annual", "irregular"];
+
+/// Mirrors `validate_holding_dividend_fields` in `src-tauri/src/commands/mod.rs`.
+pub fn validate_holding_dividend_fields(
+    indicated_annual_dividend: Option<f64>,
+    dividend_frequency: Option<&str>,
+    maturity_date: Option<&str>,
+) -> Result<(), McpError> {
+    if let Some(amount) = indicated_annual_dividend {
+        if !amount.is_finite() || amount < 0.0 {
+            return Err(McpError::invalid_params(
+                "indicatedAnnualDividend must be a non-negative finite number",
+                None,
+            ));
+        }
+    }
+    if let Some(freq) = dividend_frequency {
+        let normalized = freq.trim().to_lowercase();
+        if !VALID_DIVIDEND_FREQUENCIES.contains(&normalized.as_str()) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "dividendFrequency must be one of: {}",
+                    VALID_DIVIDEND_FREQUENCIES.join(", ")
+                ),
+                None,
+            ));
+        }
+    }
+    if let Some(date) = maturity_date {
+        if chrono::NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").is_err() {
+            return Err(McpError::invalid_params(
+                "maturityDate must be a valid ISO date (YYYY-MM-DD)",
+                None,
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Mirrors the checks in `src-tauri/src/commands/transactions.rs::add_transaction`.
 pub fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), McpError> {
     if quantity <= 0.0 || !quantity.is_finite() {
@@ -237,6 +279,56 @@ mod tests {
     #[test]
     fn validate_alert_threshold_accepts_positive_finite() {
         assert!(validate_alert_threshold(150.0).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_nan_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(f64::NAN), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_infinite_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(f64::INFINITY), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_negative_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(-1.0), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_zero_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(0.0), None, None).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_unknown_dividend_frequency() {
+        assert!(validate_holding_dividend_fields(None, Some("biannual"), None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_known_dividend_frequencies() {
+        for freq in ["monthly", "quarterly", "semi-annual", "annual", "irregular"] {
+            assert!(
+                validate_holding_dividend_fields(None, Some(freq), None).is_ok(),
+                "expected {freq} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_non_iso_maturity_date() {
+        assert!(validate_holding_dividend_fields(None, None, Some("01/30/2030")).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_iso_maturity_date() {
+        assert!(validate_holding_dividend_fields(None, None, Some("2030-01-01")).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_all_none() {
+        assert!(validate_holding_dividend_fields(None, None, None).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -233,6 +233,59 @@ pub(crate) fn validate_dividend_fields(
     Ok(())
 }
 
+/// Validates transaction quantity/price. Mirrors `validate_transaction_fields`
+/// in `portfolio-mcp/src/validation.rs`.
+pub(crate) fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), AppError> {
+    if quantity <= 0.0 || !quantity.is_finite() {
+        return Err(AppError::Validation(
+            "Transaction quantity must be a positive finite number".to_string(),
+        ));
+    }
+    if price < 0.0 || !price.is_finite() {
+        return Err(AppError::Validation(
+            "Transaction price must be a non-negative finite number".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Dividend frequencies accepted by the CSV import layer (`src-tauri/src/csv.rs`).
+pub(crate) const VALID_DIVIDEND_FREQUENCIES: &[&str] =
+    &["monthly", "quarterly", "semi-annual", "annual", "irregular"];
+
+/// Validates the optional dividend/maturity fields shared by `add_holding`/`update_holding`.
+/// Mirrors the checks the CSV import layer applies in `src-tauri/src/csv.rs`.
+pub(crate) fn validate_holding_dividend_fields(
+    indicated_annual_dividend: Option<f64>,
+    dividend_frequency: Option<&str>,
+    maturity_date: Option<&str>,
+) -> Result<(), AppError> {
+    if let Some(amount) = indicated_annual_dividend {
+        if !amount.is_finite() || amount < 0.0 {
+            return Err(AppError::Validation(
+                "indicatedAnnualDividend must be a non-negative finite number".to_string(),
+            ));
+        }
+    }
+    if let Some(freq) = dividend_frequency {
+        let normalized = freq.trim().to_lowercase();
+        if !VALID_DIVIDEND_FREQUENCIES.contains(&normalized.as_str()) {
+            return Err(AppError::Validation(format!(
+                "dividendFrequency must be one of: {}",
+                VALID_DIVIDEND_FREQUENCIES.join(", ")
+            )));
+        }
+    }
+    if let Some(date) = maturity_date {
+        if chrono::NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").is_err() {
+            return Err(AppError::Validation(
+                "maturityDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::csv::{build_holdings_csv, parse_import_rows};

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -8,8 +8,8 @@ use crate::portfolio::build_portfolio_snapshot;
 use crate::types::{Holding, HoldingId, HoldingInput, PortfolioSnapshot};
 
 use super::{
-    get_base_currency, validate_holding_fields, validate_target_weight, DbState, HttpClient,
-    RealizedGainsCacheState, WEIGHT_EPSILON,
+    get_base_currency, validate_holding_dividend_fields, validate_holding_fields,
+    validate_target_weight, DbState, HttpClient, RealizedGainsCacheState, WEIGHT_EPSILON,
 };
 
 #[tauri::command]
@@ -110,6 +110,11 @@ pub async fn add_holding(
 ) -> Result<Holding, AppError> {
     validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
     validate_target_weight(holding.target_weight)?;
+    validate_holding_dividend_fields(
+        holding.indicated_annual_dividend,
+        holding.dividend_frequency.as_deref(),
+        holding.maturity_date.as_deref(),
+    )?;
     let pool = &db.0;
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
@@ -132,6 +137,11 @@ pub async fn add_holding(
 pub async fn update_holding(db: State<'_, DbState>, holding: Holding) -> Result<Holding, AppError> {
     validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
     validate_target_weight(holding.target_weight)?;
+    validate_holding_dividend_fields(
+        holding.indicated_annual_dividend,
+        holding.dividend_frequency.as_deref(),
+        holding.maturity_date.as_deref(),
+    )?;
     let pool = &db.0;
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {

--- a/src-tauri/src/commands/transactions.rs
+++ b/src-tauri/src/commands/transactions.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{HoldingId, PaginatedResult, Transaction, TransactionId, TransactionInput};
 
-use super::{DbState, RealizedGainsCacheState};
+use super::{validate_transaction_fields, DbState, RealizedGainsCacheState};
 
 #[tauri::command]
 pub async fn add_transaction(
@@ -12,16 +12,7 @@ pub async fn add_transaction(
     gains_cache: State<'_, RealizedGainsCacheState>,
     input: TransactionInput,
 ) -> Result<Transaction, AppError> {
-    if input.quantity <= 0.0 {
-        return Err(AppError::Validation(
-            "Transaction quantity must be positive".to_string(),
-        ));
-    }
-    if input.price < 0.0 {
-        return Err(AppError::Validation(
-            "Transaction price must be non-negative".to_string(),
-        ));
-    }
+    validate_transaction_fields(input.quantity, input.price)?;
     let pool = &db.0;
     let result = db::insert_transaction(pool, input)
         .await

--- a/src-tauri/src/commands_tests.rs
+++ b/src-tauri/src/commands_tests.rs
@@ -200,6 +200,111 @@ mod tests {
         );
     }
 
+    // ── transaction validation (#624) ─────────────────────────────────────────
+
+    #[test]
+    fn transaction_rejects_nan_quantity() {
+        assert!(crate::commands::validate_transaction_fields(f64::NAN, 10.0).is_err());
+    }
+
+    #[test]
+    fn transaction_rejects_infinite_quantity() {
+        assert!(crate::commands::validate_transaction_fields(f64::INFINITY, 10.0).is_err());
+    }
+
+    #[test]
+    fn transaction_rejects_zero_or_negative_quantity() {
+        assert!(crate::commands::validate_transaction_fields(0.0, 10.0).is_err());
+        assert!(crate::commands::validate_transaction_fields(-1.0, 10.0).is_err());
+    }
+
+    #[test]
+    fn transaction_rejects_nan_price() {
+        assert!(crate::commands::validate_transaction_fields(5.0, f64::NAN).is_err());
+    }
+
+    #[test]
+    fn transaction_rejects_infinite_price() {
+        assert!(crate::commands::validate_transaction_fields(5.0, f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn transaction_rejects_negative_price() {
+        assert!(crate::commands::validate_transaction_fields(5.0, -1.0).is_err());
+    }
+
+    #[test]
+    fn transaction_accepts_valid_inputs() {
+        assert!(crate::commands::validate_transaction_fields(5.0, 0.0).is_ok());
+        assert!(crate::commands::validate_transaction_fields(5.0, 120.5).is_ok());
+    }
+
+    // ── holding dividend/maturity validation (#626) ───────────────────────────
+
+    #[test]
+    fn holding_dividend_fields_rejects_nan_indicated_annual_dividend() {
+        assert!(
+            crate::commands::validate_holding_dividend_fields(Some(f64::NAN), None, None).is_err()
+        );
+    }
+
+    #[test]
+    fn holding_dividend_fields_rejects_infinite_indicated_annual_dividend() {
+        assert!(
+            crate::commands::validate_holding_dividend_fields(Some(f64::INFINITY), None, None)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn holding_dividend_fields_rejects_negative_indicated_annual_dividend() {
+        assert!(crate::commands::validate_holding_dividend_fields(Some(-1.0), None, None).is_err());
+    }
+
+    #[test]
+    fn holding_dividend_fields_accepts_zero_indicated_annual_dividend() {
+        assert!(crate::commands::validate_holding_dividend_fields(Some(0.0), None, None).is_ok());
+    }
+
+    #[test]
+    fn holding_dividend_fields_rejects_unknown_dividend_frequency() {
+        assert!(
+            crate::commands::validate_holding_dividend_fields(None, Some("biannual"), None)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn holding_dividend_fields_accepts_known_dividend_frequencies() {
+        for freq in ["monthly", "quarterly", "semi-annual", "annual", "irregular"] {
+            assert!(
+                crate::commands::validate_holding_dividend_fields(None, Some(freq), None).is_ok(),
+                "expected {freq} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn holding_dividend_fields_rejects_non_iso_maturity_date() {
+        assert!(
+            crate::commands::validate_holding_dividend_fields(None, None, Some("01/30/2030"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn holding_dividend_fields_accepts_iso_maturity_date() {
+        assert!(
+            crate::commands::validate_holding_dividend_fields(None, None, Some("2030-01-01"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn holding_dividend_fields_accepts_all_none() {
+        assert!(crate::commands::validate_holding_dividend_fields(None, None, None).is_ok());
+    }
+
     // ── alert validation ──────────────────────────────────────────────────────
 
     fn validate_alert(input: &PriceAlertInput) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- `add_transaction` accepted NaN/Infinity for `quantity`/`price` because the existing comparisons (`<= 0.0`, `< 0.0`) are false for NaN and let Infinity through. Extracted `validate_transaction_fields` (mirroring the check already present on the MCP side) and required both fields to be finite.
- `dividend_frequency`, `indicated_annual_dividend`, and `maturity_date` were only validated during CSV import. `add_holding`/`update_holding` (Tauri) and the MCP `add_holding` tool accepted malformed values directly. Added `validate_holding_dividend_fields` (Tauri) and its MCP mirror, enforcing the same known-frequency set and ISO date format the CSV importer already uses, wired into both write paths.

## Test plan
- [x] `cargo test --locked` (workspace: portfolio-core, portfolio-mcp, portfolio-tracker) — 313 tests passing
- [x] New unit tests added for both validators (RED verified before implementation, per TDD)
- [x] `cargo fmt --check` / `cargo clippy --workspace --all-targets` clean (no new warnings)
- [x] Full pre-push pipeline (lint, typecheck, frontend+backend build, frontend+backend tests, clippy) passed

Closes #624
Closes #626