### PR TITLE
fix: locale-aware Analytics formatting, dedupe stress-test math

### DIFF
--- a/frontend/components/Analytics.tsx
+++ b/frontend/components/Analytics.tsx
@@ -17,7 +17,8 @@ import {
 } from 'recharts';
 import { Spinner } from './ui/Spinner';
 import { EmptyState } from './ui/EmptyState';
-import { formatNumber, formatPercent } from '../lib/format';
+import { formatPercent } from '../lib/format';
+import { useFormatNumber } from '../hooks/useFormatters';
 import type { PortfolioAnalytics, SymbolMetadata } from '../types/portfolio';
 
 // Chart color palette using design tokens + extended palette for extra sectors
@@ -188,6 +189,7 @@ function formatMarketCap(cap?: number, currency = 'USD'): string {
 
 export function Analytics() {
   const { t } = useTranslation();
+  const formatNumber = useFormatNumber();
   const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -385,18 +387,19 @@ export function Analytics() {
                 label={t('analytics.portfolioBeta')}
                 value={
                   analytics.riskMetrics.weightedBeta != null
-                    ? analytics.riskMetrics.weightedBeta.toFixed(2)
+                    ? formatNumber(analytics.riskMetrics.weightedBeta, 2)
                     : 'N/A'
                 }
                 sub={t('analytics.weightedAverageBeta')}
               />
               <RiskCard
                 label={t('analytics.dividendYield')}
-                value={
+                value={`${formatNumber(
                   analytics.riskMetrics.portfolioYield > 0
-                    ? `${(analytics.riskMetrics.portfolioYield * 100).toFixed(2)}%`
-                    : '0.00%'
-                }
+                    ? analytics.riskMetrics.portfolioYield * 100
+                    : 0,
+                  2
+                )}%`}
                 sub={t('analytics.weightedPortfolioYield')}
               />
               <RiskCard
@@ -406,7 +409,7 @@ export function Analytics() {
               />
               <RiskCard
                 label={t('analytics.largestPosition')}
-                value={`${analytics.riskMetrics.largestPositionWeight.toFixed(2)}%`}
+                value={`${formatNumber(analytics.riskMetrics.largestPositionWeight, 2)}%`}
                 sub={analytics.riskMetrics.topSector ?? ''}
               />
             </div>
@@ -452,7 +455,7 @@ export function Analytics() {
                       cx="50%"
                       cy="50%"
                       outerRadius={90}
-                      label={({ name, value }) => `${name} ${(value as number).toFixed(1)}%`}
+                      label={({ name, value }) => `${name} ${formatNumber(value as number, 1)}%`}
                       labelLine={false}
                     >
                       {pieData.map((_, index) => (
@@ -461,7 +464,7 @@ export function Analytics() {
                     </Pie>
                     <Tooltip
                       formatter={(value) => [
-                        `${(value as number).toFixed(2)}%`,
+                        `${formatNumber(value as number, 2)}%`,
                         t('holdings.columns.weight'),
                       ]}
                       contentStyle={{
@@ -542,7 +545,7 @@ export function Analytics() {
                       />
                       <Tooltip
                         formatter={(value) => [
-                          `${(value as number).toFixed(2)}%`,
+                          `${formatNumber(value as number, 2)}%`,
                           t('holdings.columns.weight'),
                         ]}
                         contentStyle={{
@@ -690,9 +693,11 @@ export function Analytics() {
                       <MetaCell value={meta.sector} />
                       <MetaCell value={meta.industry} />
                       <MetaCell value={meta.country} />
-                      <MetaCell value={meta.beta != null ? meta.beta.toFixed(2) : undefined} />
                       <MetaCell
-                        value={meta.peRatio != null ? meta.peRatio.toFixed(2) : undefined}
+                        value={meta.beta != null ? formatNumber(meta.beta, 2) : undefined}
+                      />
+                      <MetaCell
+                        value={meta.peRatio != null ? formatNumber(meta.peRatio, 2) : undefined}
                       />
                       <MetaCell
                         value={

--- a/frontend/components/ScenarioComparison.tsx
+++ b/frontend/components/ScenarioComparison.tsx
@@ -1,10 +1,10 @@
 // ─── Scenario comparison table for stress test ───────────────────────────────
 import { useMemo } from 'react';
-import { fxShockKey } from '../lib/constants';
 import { formatPercent, formatCompact } from '../lib/format';
 import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
-import type { PortfolioSnapshot, StressScenario, StressScenarioInfo } from '../types/portfolio';
+import { computeStressImpact } from '../lib/scenarioMath';
+import type { PortfolioSnapshot, StressScenarioInfo } from '../types/portfolio';
 
 const PANEL: React.CSSProperties = {
   background: 'var(--bg-surface)',
@@ -31,44 +31,6 @@ const TD: React.CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
-function computeScenarioLocally(
-  snapshot: PortfolioSnapshot,
-  scenario: StressScenario
-): {
-  stressedValue: number;
-  totalImpact: number;
-  totalImpactPercent: number;
-  topImpacted: { symbol: string; impact: number }[];
-} {
-  let totalStressed = 0;
-  const breakdown: { symbol: string; impact: number }[] = [];
-
-  for (const h of snapshot.holdings) {
-    const assetShock = scenario.shocks[h.assetType] ?? 0;
-    const fxKey = fxShockKey(h.currency, snapshot.baseCurrency);
-    const fxShock =
-      h.currency.toUpperCase() === snapshot.baseCurrency.toUpperCase()
-        ? 0
-        : (scenario.shocks[fxKey] ?? 0);
-
-    const currentValue = h.marketValueCad;
-    const stressedValue = currentValue * (1 + assetShock) * (1 + fxShock);
-    const impact = stressedValue - currentValue;
-    totalStressed += stressedValue;
-    breakdown.push({ symbol: h.symbol, impact });
-  }
-
-  const currentValue = snapshot.totalValue;
-  const totalImpact = totalStressed - currentValue;
-  const totalImpactPercent = currentValue !== 0 ? (totalImpact / currentValue) * 100 : 0;
-
-  const topImpacted = [...breakdown]
-    .sort((a, b) => Math.abs(b.impact) - Math.abs(a.impact))
-    .slice(0, 2);
-
-  return { stressedValue: totalStressed, totalImpact, totalImpactPercent, topImpacted };
-}
-
 // ─── Props ────────────────────────────────────────────────────────────────────
 export interface ScenarioComparisonProps {
   portfolio: PortfolioSnapshot;
@@ -83,14 +45,18 @@ export function ScenarioComparison({ portfolio, scenarios }: ScenarioComparisonP
   const rows = useMemo(
     () =>
       scenarios.map((s) => {
-        const result = computeScenarioLocally(portfolio, s);
+        const result = computeStressImpact(portfolio, s);
+        const topImpacted = [...result.holdingBreakdown]
+          .sort((a, b) => Math.abs(b.impact) - Math.abs(a.impact))
+          .slice(0, 2)
+          .map((h) => ({ symbol: h.symbol, impact: h.impact }));
         return {
           name: s.name,
           description: s.description,
           stressedValue: result.stressedValue,
           totalImpact: result.totalImpact,
           totalImpactPercent: result.totalImpactPercent,
-          topImpacted: result.topImpacted,
+          topImpacted,
         };
       }),
     [portfolio, scenarios]

--- a/frontend/components/__tests__/Analytics.test.tsx
+++ b/frontend/components/__tests__/Analytics.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Analytics } from '../Analytics';
+import type { PortfolioAnalytics } from '../../types/portfolio';
+
+// Initialize i18n (Analytics uses useTranslation)
+import i18next from '../../lib/i18n';
+
+const mockAnalytics: PortfolioAnalytics = {
+  metadata: [{ symbol: 'AAPL', beta: 1.2, peRatio: 25.5 }],
+  riskMetrics: {
+    weightedBeta: 1234.5,
+    portfolioYield: 0.05,
+    largestPositionWeight: 12.34,
+    concentrationHhi: 1500,
+  },
+  sectorBreakdown: [],
+  countryBreakdown: [],
+};
+
+vi.mock('../../lib/tauri', () => ({
+  isTauri: () => true,
+  tauriInvoke: () => Promise.resolve(mockAnalytics),
+}));
+
+afterEach(async () => {
+  await act(async () => {
+    await i18next.changeLanguage('en');
+  });
+});
+
+function renderAnalytics() {
+  return render(
+    <MemoryRouter>
+      <Analytics />
+    </MemoryRouter>
+  );
+}
+
+describe('Analytics risk metric formatting', () => {
+  it('renders the weighted beta with locale-aware separators in English', async () => {
+    renderAnalytics();
+    screen.getByRole('button', { name: /load analytics/i }).click();
+
+    await waitFor(() => expect(screen.getByText('1,234.50')).toBeTruthy());
+  });
+
+  it('renders the weighted beta with German locale separators (comma decimal, period thousands)', async () => {
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderAnalytics();
+    screen.getByRole('button').click();
+
+    await waitFor(() => expect(screen.getByText('1.234,50')).toBeTruthy());
+    // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
+    expect(screen.queryByText('1234.50')).toBeNull();
+  });
+});

--- a/frontend/hooks/useStressTest.ts
+++ b/frontend/hooks/useStressTest.ts
@@ -1,50 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { PortfolioSnapshot, StressResult, StressScenario } from '../types/portfolio';
-import { fxShockKey } from '../lib/constants';
 import { isTauri, tauriInvoke } from '../lib/tauri';
-
-function computeLocally(snapshot: PortfolioSnapshot, scenario: StressScenario): StressResult {
-  let totalStressed = 0;
-
-  const holdingBreakdown = snapshot.holdings.map((h) => {
-    const assetShock = scenario.shocks[h.assetType] ?? 0;
-    const fxKey = fxShockKey(h.currency, snapshot.baseCurrency);
-    const fxShock =
-      h.currency.toUpperCase() === snapshot.baseCurrency.toUpperCase()
-        ? 0
-        : (scenario.shocks[fxKey] ?? 0);
-
-    const currentValue = h.marketValueCad;
-    const stressedValue = currentValue * (1 + assetShock) * (1 + fxShock);
-    const impact = stressedValue - currentValue;
-    const shockApplied = (1 + assetShock) * (1 + fxShock) - 1;
-
-    totalStressed += stressedValue;
-
-    return {
-      holdingId: h.id,
-      symbol: h.symbol,
-      name: h.name,
-      currentValue,
-      stressedValue,
-      impact,
-      shockApplied,
-    };
-  });
-
-  const currentValue = snapshot.totalValue;
-  const totalImpact = totalStressed - currentValue;
-  const totalImpactPercent = currentValue !== 0 ? (totalImpact / currentValue) * 100 : 0;
-
-  return {
-    scenario: scenario.name,
-    currentValue,
-    stressedValue: totalStressed,
-    totalImpact,
-    totalImpactPercent,
-    holdingBreakdown,
-  };
-}
+import { computeStressImpact } from '../lib/scenarioMath';
 
 export interface UseStressTestReturn {
   result: StressResult | null;
@@ -70,7 +27,7 @@ export function useStressTest(): UseStressTestReturn {
         } else {
           // Small async tick so loading state renders
           await new Promise((r) => setTimeout(r, 0));
-          setResult(computeLocally(snapshot, scenario));
+          setResult(computeStressImpact(snapshot, scenario));
         }
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));

--- a/frontend/lib/__tests__/scenarioMath.test.ts
+++ b/frontend/lib/__tests__/scenarioMath.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { computeStressImpact } from '../scenarioMath';
+import type {
+  AssetType,
+  HoldingWithPrice,
+  PortfolioSnapshot,
+  StressScenario,
+} from '../../types/portfolio';
+
+function makeHolding(
+  symbol: string,
+  assetType: AssetType,
+  currency: string,
+  value: number
+): HoldingWithPrice {
+  return {
+    id: symbol,
+    symbol,
+    name: symbol,
+    assetType,
+    account: assetType === 'cash' ? 'cash' : 'taxable',
+    quantity: 1,
+    costBasis: value,
+    currency,
+    exchange: '',
+    targetWeight: null,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    indicatedAnnualDividend: null,
+    indicatedAnnualDividendCurrency: null,
+    dividendFrequency: null,
+    maturityDate: null,
+    currentPrice: value,
+    currentPriceCad: value,
+    marketValueCad: value,
+    costValueCad: value,
+    gainLoss: 0,
+    gainLossPercent: 0,
+    weight: 1,
+    targetValue: 0,
+    targetDeltaValue: 0,
+    targetDeltaPercent: 0,
+    dailyChangePercent: 0,
+    fxStale: false,
+    priceIsStale: false,
+  };
+}
+
+function makeSnapshot(holdings: HoldingWithPrice[], baseCurrency = 'CAD'): PortfolioSnapshot {
+  const total = holdings.reduce((sum, h) => sum + h.marketValueCad, 0);
+  return {
+    holdings,
+    totalValue: total,
+    totalCost: total,
+    totalGainLoss: 0,
+    totalGainLossPercent: 0,
+    dailyPnl: 0,
+    lastUpdated: '2024-01-01T00:00:00Z',
+    baseCurrency,
+    totalTargetWeight: 0,
+    targetCashDelta: 0,
+    realizedGains: 0,
+    annualDividendIncome: 0,
+  };
+}
+
+describe('computeStressImpact', () => {
+  it('returns unchanged values for zero shocks', () => {
+    const snapshot = makeSnapshot([
+      makeHolding('AAPL', 'stock', 'USD', 10_000),
+      makeHolding('BTC', 'crypto', 'CAD', 5_000),
+    ]);
+    const scenario: StressScenario = { name: 'Zero', shocks: {} };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(Math.abs(result.totalImpact)).toBeLessThan(0.001);
+    expect(result.holdingBreakdown).toHaveLength(2);
+    for (const h of result.holdingBreakdown) {
+      expect(Math.abs(h.impact)).toBeLessThan(0.001);
+    }
+  });
+
+  it('applies a stock shock correctly', () => {
+    const value = 10_000;
+    const snapshot = makeSnapshot([makeHolding('AAPL', 'stock', 'CAD', value)]);
+    const scenario: StressScenario = { name: 'Bear', shocks: { stock: -0.2 } };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(result.stressedValue).toBeCloseTo(value * 0.8, 3);
+    expect(result.totalImpact).toBeCloseTo(-2_000, 3);
+  });
+
+  it('applies FX shock to non-base-currency holdings', () => {
+    const value = 10_000;
+    const snapshot = makeSnapshot([makeHolding('AAPL', 'stock', 'USD', value)]);
+    const scenario: StressScenario = {
+      name: 'Mixed',
+      shocks: { stock: -0.1, fx_usd_cad: 0.05 },
+    };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(result.stressedValue).toBeCloseTo(value * 0.9 * 1.05, 3);
+  });
+
+  it('ignores FX shocks for base-currency holdings', () => {
+    const value = 5_000;
+    const snapshot = makeSnapshot([makeHolding('RY.TO', 'stock', 'CAD', value)]);
+    const scenario: StressScenario = { name: 'FX only', shocks: { fx_usd_cad: 0.15 } };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(Math.abs(result.totalImpact)).toBeLessThan(0.001);
+  });
+
+  it('excludes cash from asset shocks but still applies FX shocks to it', () => {
+    const value = 10_000;
+    const snapshot = makeSnapshot([
+      makeHolding('USD-CASH', 'cash', 'USD', value),
+      makeHolding('CAD-CASH', 'cash', 'CAD', value),
+    ]);
+    const scenario: StressScenario = {
+      name: 'Cash test',
+      shocks: { cash: -0.5, fx_usd_cad: 0.1 },
+    };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    const usd = result.holdingBreakdown.find((h) => h.symbol === 'USD-CASH')!;
+    const cad = result.holdingBreakdown.find((h) => h.symbol === 'CAD-CASH')!;
+
+    expect(usd.stressedValue).toBeCloseTo(11_000, 3);
+    expect(cad.stressedValue).toBeCloseTo(value, 3);
+  });
+
+  it('does not let stressed value go negative on a total-loss shock', () => {
+    const value = 10_000;
+    const snapshot = makeSnapshot([makeHolding('BTC', 'crypto', 'CAD', value)]);
+    const scenario: StressScenario = { name: 'Crypto gone', shocks: { crypto: -1.0 } };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(result.stressedValue).toBeGreaterThanOrEqual(0);
+    expect(result.stressedValue).toBeCloseTo(0, 3);
+    expect(result.totalImpact).toBeCloseTo(-value, 3);
+  });
+
+  it('handles an empty portfolio without producing NaN', () => {
+    const snapshot = makeSnapshot([]);
+    const scenario: StressScenario = { name: 'Empty', shocks: {} };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    expect(result.totalImpact).toBe(0);
+    expect(result.totalImpactPercent).toBe(0);
+  });
+});

--- a/frontend/lib/scenarioMath.ts
+++ b/frontend/lib/scenarioMath.ts
@@ -1,0 +1,59 @@
+import { fxShockKey } from './constants';
+import type { PortfolioSnapshot, StressResult, StressScenario } from '../types/portfolio';
+
+/**
+ * TypeScript mirror of the Rust stress-test calculation in `src-tauri/src/stress.rs`
+ * (via the shared `portfolio-core` crate). Used only when no Tauri backend is available
+ * — browser dev mode and scenario-comparison previews — since those need a result
+ * synchronously without a round trip to `run_stress_test_cmd`. The desktop app always
+ * defers to the Rust implementation for its primary stress-test results.
+ *
+ * This is a deliberate parallel implementation, not incidental duplication: keep it in
+ * sync with `run_stress_test` in `src-tauri/src/stress.rs` if the shock model changes.
+ */
+export function computeStressImpact(
+  snapshot: PortfolioSnapshot,
+  scenario: StressScenario
+): StressResult {
+  let totalStressed = 0;
+
+  const holdingBreakdown = snapshot.holdings.map((h) => {
+    // Asset-level shock: cash is excluded — only FX shocks may affect cash positions.
+    const assetShock = h.assetType === 'cash' ? 0 : (scenario.shocks[h.assetType] ?? 0);
+
+    const fxShock =
+      h.currency.toUpperCase() === snapshot.baseCurrency.toUpperCase()
+        ? 0
+        : (scenario.shocks[fxShockKey(h.currency, snapshot.baseCurrency)] ?? 0);
+
+    const currentValue = h.marketValueCad;
+    const stressedValue = currentValue * (1 + assetShock) * (1 + fxShock);
+    const impact = stressedValue - currentValue;
+    const shockApplied = (1 + assetShock) * (1 + fxShock) - 1;
+
+    totalStressed += stressedValue;
+
+    return {
+      holdingId: h.id,
+      symbol: h.symbol,
+      name: h.name,
+      currentValue,
+      stressedValue,
+      impact,
+      shockApplied,
+    };
+  });
+
+  const currentValue = snapshot.totalValue;
+  const totalImpact = totalStressed - currentValue;
+  const totalImpactPercent = currentValue !== 0 ? (totalImpact / currentValue) * 100 : 0;
+
+  return {
+    scenario: scenario.name,
+    currentValue,
+    stressedValue: totalStressed,
+    totalImpact,
+    totalImpactPercent,
+    holdingBreakdown,
+  };
+}


### PR DESCRIPTION
## Summary
- Analytics.tsx risk metric cards, chart labels/tooltips, and the beta/P·E table columns called `.toFixed()` directly, which always renders with a period decimal separator regardless of locale. Replaced with the locale-aware `useFormatNumber` hook so German (and other locale) users see comma decimals.
- `ScenarioComparison.tsx` reimplemented the stress-test shock calculation that already lives in `src-tauri/src/stress.rs` (via `portfolio-core`), and had drifted from it — it applied asset-level shocks to cash holdings, which the Rust implementation deliberately excludes. Extracted the calculation into `frontend/lib/scenarioMath.ts` as a single tested TS mirror of the Rust logic, and pointed both `ScenarioComparison.tsx` and `useStressTest.ts`'s browser/mock-mode path at it, removing two separately-drifting copies.

Closes #629
Closes #628

## Test plan
- [x] `NODE_ENV=development npm run typecheck`
- [x] `NODE_ENV=development npm test -- --run` (307 passed, including new `Analytics.test.tsx` German-locale assertion and `scenarioMath.test.ts`)
- [x] `npm run lint`
- [x] Full pre-push suite (frontend build, backend build, frontend tests, `cargo test` — 254 passed, Clippy) all green