### PR TITLE
fix: zero/non-finite FX & price guards, atomic DB restore (#633, #634, #638)

### DIFF
--- a/portfolio-core/src/fx.rs
+++ b/portfolio-core/src/fx.rs
@@ -16,8 +16,8 @@ pub fn convert_to_base(amount: f64, from_currency: &str, base: &str, rates: &[Fx
     // Try the direct pair first: e.g. USDCAD when converting USD → CAD
     let direct_pair = format!("{}{}", from_upper, base_upper);
     if let Some(rate) = rates.iter().find(|r| r.pair == direct_pair) {
-        if rate.rate == 0.0 {
-            tracing::warn!(pair = %rate.pair, "FX rate is zero; returning amount with fxStale=true");
+        if !rate.rate.is_finite() || rate.rate == 0.0 {
+            tracing::warn!(pair = %rate.pair, rate = rate.rate, "FX rate is zero or non-finite; returning amount with fxStale=true");
             return None;
         }
         return Some(amount * rate.rate);
@@ -27,7 +27,7 @@ pub fn convert_to_base(amount: f64, from_currency: &str, base: &str, rates: &[Fx
     // but base=CAD was previously cached as USDCAD. Invert the stored rate.
     let inverted_pair = format!("{}{}", base_upper, from_upper);
     if let Some(rate) = rates.iter().find(|r| r.pair == inverted_pair) {
-        if rate.rate != 0.0 {
+        if rate.rate.is_finite() && rate.rate != 0.0 {
             return Some(amount / rate.rate);
         }
     }
@@ -99,6 +99,28 @@ mod tests {
             result, None,
             "zero direct rate should be treated as unavailable, not a valid 0 conversion"
         );
+    }
+
+    #[test]
+    fn direct_pair_infinite_rate_returns_none() {
+        // Regression guard for #638: an infinite direct rate must be rejected too.
+        let rates = vec![make_rate("USDCAD", f64::INFINITY)];
+        let result = convert_to_base(100.0, "USD", "CAD", &rates);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn direct_pair_nan_rate_returns_none() {
+        let rates = vec![make_rate("USDCAD", f64::NAN)];
+        let result = convert_to_base(100.0, "USD", "CAD", &rates);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn inverted_pair_infinite_rate_returns_none() {
+        let rates = vec![make_rate("CADUSD", f64::INFINITY)];
+        let result = convert_to_base(100.0, "USD", "CAD", &rates);
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/portfolio-core/src/snapshot.rs
+++ b/portfolio-core/src/snapshot.rs
@@ -61,8 +61,6 @@ pub fn build_portfolio_snapshot(
         .map(|p| (p.symbol.clone(), p))
         .collect();
 
-    let fx_map: HashMap<String, &FxRate> = cached_fx.iter().map(|r| (r.pair.clone(), r)).collect();
-
     let mut holdings_with_price: Vec<HoldingWithPrice> = Vec::new();
     let mut total_value = 0.0f64;
     let mut total_cost = 0.0f64;
@@ -74,7 +72,7 @@ pub fn build_portfolio_snapshot(
             (1.0f64, 0.0f64, false)
         } else {
             match price_map.get(&holding.symbol) {
-                Some(p) if p.price > 0.0 => {
+                Some(p) if p.price > 0.0 && p.price.is_finite() => {
                     let stale = is_price_stale(&p.updated_at);
                     (p.price, p.change_percent, stale)
                 }
@@ -91,24 +89,19 @@ pub fn build_portfolio_snapshot(
                         (0.0, p.change_percent, false)
                     }
                 }
-                // Negative prices are never legitimate — treat as a cache miss.
+                // Negative, infinite, or NaN prices are never legitimate — treat as a cache miss.
                 _ => (holding.cost_basis, 0.0, true),
             }
         };
 
-        let fx_pair = format!(
-            "{}{}",
-            holding.currency.to_uppercase(),
-            base_currency.to_uppercase()
-        );
         let (fx_rate, fx_stale) = if holding.currency.eq_ignore_ascii_case(base_currency) {
             (1.0, false)
         } else {
-            match fx_map
-                .get(&fx_pair)
-                .map(|r| r.rate)
-                .or_else(|| convert_to_base(1.0, &holding.currency, base_currency, cached_fx))
-            {
+            // `convert_to_base` is the single source of truth for FX lookups:
+            // it already guards against zero and non-finite rates on both the
+            // direct and inverted pair (see #633). Do not short-circuit it
+            // with a raw fx_map lookup — that bypasses the guard entirely.
+            match convert_to_base(1.0, &holding.currency, base_currency, cached_fx) {
                 Some(rate) => (rate, false),
                 None => {
                     tracing::warn!(
@@ -770,6 +763,54 @@ mod tests {
     }
 
     #[test]
+    fn build_portfolio_snapshot_direct_zero_fx_rate_marks_stale_instead_of_zeroing_value() {
+        // Regression guard for #633: a cached direct-pair FX rate of exactly 0.0
+        // must be treated as unavailable (fx_stale = true), not multiplied in —
+        // convert_to_base already guards this, but the fast-path fx_map lookup
+        // in build_portfolio_snapshot must not bypass that guard.
+        let holding = make_holding("AAPL", AssetType::Stock, 10.0, 100.0, "USD");
+        let prices = vec![PriceData {
+            symbol: "AAPL".to_string(),
+            price: 150.0,
+            currency: "USD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+        // Direct pair USDCAD cached at exactly 0.0.
+        let fx = vec![FxRate {
+            pair: "USDCAD".to_string(),
+            rate: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &fx,
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            snapshot.holdings[0].fx_stale,
+            "a zero direct-pair FX rate must be treated as unavailable, not used as-is"
+        );
+        // market_value_cad must NOT be zeroed out — fx_rate should default to
+        // 1.0 (source-currency passthrough) when the cached rate is invalid.
+        assert!(
+            (snapshot.holdings[0].market_value_cad - 1500.0).abs() < 0.001,
+            "market_value_cad should fall back to source-currency value (1500), got {}",
+            snapshot.holdings[0].market_value_cad
+        );
+    }
+
+    #[test]
     fn build_portfolio_snapshot_missing_fx_marks_holding_as_stale() {
         // When FX rate is unavailable, fx_stale = true and rate defaults to 1.0.
         let holding = make_holding("AAPL", AssetType::Stock, 1.0, 100.0, "USD");
@@ -863,6 +904,117 @@ mod tests {
             "weights should sum to 100%, got {}",
             total_weight
         );
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_infinite_price_falls_back_to_cost_basis() {
+        // Regression guard for #638: an infinite cached price must not
+        // propagate into market_value_cad — Infinity > 0.0 is true, so the
+        // existing `> 0.0` check alone accepts it. Must fall back to cost_basis.
+        let holding = make_holding("BADFEED", AssetType::Stock, 10.0, 50.0, "CAD");
+        let prices = vec![PriceData {
+            symbol: "BADFEED".to_string(),
+            price: f64::INFINITY,
+            currency: "CAD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            (snapshot.holdings[0].current_price - 50.0).abs() < 0.001,
+            "infinite price should fall back to cost_basis, got {}",
+            snapshot.holdings[0].current_price
+        );
+        assert!(snapshot.holdings[0].market_value_cad.is_finite());
+        assert!(snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_nan_price_falls_back_to_cost_basis() {
+        // Regression guard for #638: NaN must also be rejected explicitly.
+        let holding = make_holding("BADFEED2", AssetType::Stock, 10.0, 50.0, "CAD");
+        let prices = vec![PriceData {
+            symbol: "BADFEED2".to_string(),
+            price: f64::NAN,
+            currency: "CAD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            (snapshot.holdings[0].current_price - 50.0).abs() < 0.001,
+            "NaN price should fall back to cost_basis, got {}",
+            snapshot.holdings[0].current_price
+        );
+        assert!(snapshot.holdings[0].market_value_cad.is_finite());
+        assert!(snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_infinite_fx_rate_marks_stale() {
+        // Regression guard for #638: an infinite cached FX rate must not
+        // propagate into market_value_cad.
+        let holding = make_holding("AAPL", AssetType::Stock, 10.0, 100.0, "USD");
+        let prices = vec![PriceData {
+            symbol: "AAPL".to_string(),
+            price: 150.0,
+            currency: "USD".to_string(),
+            change: 0.0,
+            change_percent: 0.0,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+        let fx = vec![FxRate {
+            pair: "USDCAD".to_string(),
+            rate: f64::INFINITY,
+            updated_at: Utc::now().to_rfc3339(),
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &fx,
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            snapshot.holdings[0].fx_stale,
+            "an infinite FX rate must be treated as unavailable"
+        );
+        assert!(snapshot.holdings[0].market_value_cad.is_finite());
     }
 
     #[test]

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -169,8 +169,12 @@ pub async fn restore_database(
     let wal_path = app_data_dir.join(format!("{}-wal", crate::config::DB_FILE_NAME));
     let shm_path = app_data_dir.join(format!("{}-shm", crate::config::DB_FILE_NAME));
     let bak_path = app_data_dir.join(format!("{}.bak", crate::config::DB_FILE_NAME));
+    let tmp_path = app_data_dir.join(format!("{}.restore_tmp", crate::config::DB_FILE_NAME));
 
-    quiesce_and_restore_file(&state.0, &src, &dest, &wal_path, &shm_path, &bak_path).await?;
+    quiesce_and_restore_file(
+        &state.0, &src, &dest, &wal_path, &shm_path, &bak_path, &tmp_path,
+    )
+    .await?;
 
     Ok("Database restored. Please restart the app to apply changes.".to_string())
 }
@@ -192,6 +196,7 @@ async fn quiesce_and_restore_file(
     wal_path: &std::path::Path,
     shm_path: &std::path::Path,
     bak_path: &std::path::Path,
+    tmp_path: &std::path::Path,
 ) -> Result<(), AppError> {
     // Flush and truncate the WAL so the live DB file on disk is fully
     // self-contained before we quiesce the pool.
@@ -211,7 +216,23 @@ async fn quiesce_and_restore_file(
             .map_err(|e| format!("Could not create safety backup before restore: {e}"))?;
     }
 
-    std::fs::copy(backup_src, dest).map_err(|e| format!("Failed to restore database: {e}"))?;
+    // Stage the backup into a temp file in the same directory as `dest` and
+    // verify its integrity BEFORE touching the live database. `dest` is only
+    // ever replaced by an atomic rename once the staged file is known-good,
+    // so a crash mid-copy or a backup that fails verification never leaves
+    // `dest` in a corrupted or partially-written state.
+    std::fs::copy(backup_src, tmp_path)
+        .map_err(|e| format!("Failed to stage restore file: {e}"))?;
+
+    if let Err(e) = verify_sqlite_integrity(tmp_path).await {
+        let _ = std::fs::remove_file(tmp_path);
+        return Err(e);
+    }
+
+    // Same-filesystem rename is atomic: `dest` is either the untouched
+    // original or the fully-staged, already-verified new file — never a
+    // partial write.
+    std::fs::rename(tmp_path, dest).map_err(|e| format!("Failed to restore database: {e}"))?;
 
     // Remove stale WAL and SHM companion files so the restored DB starts
     // clean and SQLite does not attempt to replay the old journal.
@@ -224,7 +245,7 @@ async fn quiesce_and_restore_file(
             .map_err(|e| format!("Could not remove SHM file after restore: {e}"))?;
     }
 
-    verify_sqlite_integrity(dest).await
+    Ok(())
 }
 
 /// Opens `path` read-only via a dedicated connection (not the app pool) and
@@ -340,6 +361,7 @@ mod tests {
         let wal_path = scratch.path("live.db-wal");
         let shm_path = scratch.path("live.db-shm");
         let bak_path = scratch.path("live.db.bak");
+        let tmp_path = scratch.path("live.db.restore_tmp");
 
         let backup_pool = open_file_db(&backup_path).await;
         set_marker(&backup_pool, "from-backup").await;
@@ -355,6 +377,7 @@ mod tests {
             &wal_path,
             &shm_path,
             &bak_path,
+            &tmp_path,
         )
         .await
         .expect("restore should succeed");
@@ -363,6 +386,10 @@ mod tests {
             get_marker(&dest_path).await.as_deref(),
             Some("from-backup"),
             "dest should now contain the backup's data"
+        );
+        assert!(
+            !tmp_path.exists(),
+            "temp staging file should be cleaned up (consumed by rename) after a successful restore"
         );
     }
 
@@ -374,6 +401,7 @@ mod tests {
         let wal_path = scratch.path("live.db-wal");
         let shm_path = scratch.path("live.db-shm");
         let bak_path = scratch.path("live.db.bak");
+        let tmp_path = scratch.path("live.db.restore_tmp");
 
         let backup_pool = open_file_db(&backup_path).await;
         backup_pool.close().await;
@@ -387,6 +415,7 @@ mod tests {
             &wal_path,
             &shm_path,
             &bak_path,
+            &tmp_path,
         )
         .await
         .expect("restore should succeed");
@@ -405,6 +434,7 @@ mod tests {
         let wal_path = scratch.path("live.db-wal");
         let shm_path = scratch.path("live.db-shm");
         let bak_path = scratch.path("live.db.bak");
+        let tmp_path = scratch.path("live.db.restore_tmp");
 
         let backup_pool = open_file_db(&backup_path).await;
         set_marker(&backup_pool, "from-backup").await;
@@ -420,6 +450,7 @@ mod tests {
             &wal_path,
             &shm_path,
             &bak_path,
+            &tmp_path,
         )
         .await
         .expect("restore should succeed");
@@ -432,6 +463,53 @@ mod tests {
             get_marker(&bak_path).await.as_deref(),
             Some("original-live-data"),
             "safety backup should preserve the pre-restore live data"
+        );
+    }
+
+    #[tokio::test]
+    async fn quiesce_and_restore_file_leaves_dest_intact_when_staged_file_fails_integrity_check() {
+        // Regression guard for #634: the restore must stage the backup into a
+        // temp file and verify it BEFORE touching `dest`. A backup that fails
+        // verification (corrupted, truncated, or not actually SQLite) must
+        // never be copied over the live database.
+        let scratch = ScratchDir::new("failed-integrity");
+        let backup_path = scratch.path("backup.db");
+        let dest_path = scratch.path("live.db");
+        let wal_path = scratch.path("live.db-wal");
+        let shm_path = scratch.path("live.db-shm");
+        let bak_path = scratch.path("live.db.bak");
+        let tmp_path = scratch.path("live.db.restore_tmp");
+
+        // Not a valid SQLite database — verify_sqlite_integrity must reject it.
+        std::fs::write(&backup_path, b"not a real sqlite database at all")
+            .expect("write bogus backup file");
+
+        let live_pool = open_file_db(&dest_path).await;
+        set_marker(&live_pool, "original-live-data").await;
+
+        let result = quiesce_and_restore_file(
+            &live_pool,
+            &backup_path,
+            &dest_path,
+            &wal_path,
+            &shm_path,
+            &bak_path,
+            &tmp_path,
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "restore must fail when the staged file does not pass integrity check"
+        );
+        assert_eq!(
+            get_marker(&dest_path).await.as_deref(),
+            Some("original-live-data"),
+            "dest must remain byte-for-byte untouched when verification fails before the rename"
+        );
+        assert!(
+            !tmp_path.exists(),
+            "the failed temp staging file should be cleaned up rather than left behind"
         );
     }
 


### PR DESCRIPTION
## Summary

Three critical backend bugs fixed on one branch, per issue scope.

**#633 — direct-pair FX rate of 0.0 bypassed the zero-rate guard**
`build_portfolio_snapshot` looked up direct-pair FX rates straight from a `fx_map` HashMap and only fell back to `convert_to_base` via `.or_else()` when the map lookup returned `None`. A cached rate of exactly `0.0` yields `Some(0.0)`, so `.or_else()` never ran and `convert_to_base`'s zero-rate guard (already tested and correct) was dead code on this path — the holding's value was silently multiplied by zero. Fixed by routing all FX lookups through `convert_to_base` directly and deleting the redundant fast-path.

**#634 — `restore_database` was a non-atomic overwrite with no rollback**
`quiesce_and_restore_file` copied the backup directly onto the live DB file, then ran the integrity check *after* the copy. A crash mid-copy, or a backup that failed the post-copy check, left the live database corrupted in place with no recovery path (the safety `.bak` was written but never used to roll back). Fixed by staging the backup into a temp file first, verifying its integrity there, and only atomically `rename`-ing it over the live DB on success — the live DB is now either the original or the fully-verified new file, never a partial write.

**#638 — no `is_finite`/NaN guard on cached prices or FX rates**
`price > 0.0` is `true` for `f64::INFINITY`, so a corrupted price feed returning `Infinity` was accepted as a legitimate price and propagated into `market_value_cad`/`total_value`, eventually producing `NaN` weights that break JSON serialization for the whole snapshot. Added `.is_finite()` checks alongside the existing price and FX-rate guards, falling back to cost basis / `fx_stale = true` respectively — mirroring how negative/stale-zero prices are already handled. (NaN prices already fell through correctly due to Rust's NaN comparison semantics, but explicit regression tests now cover it too.)

## Test plan

- [x] `cargo test --locked` in `portfolio-core/` — 34 passed, including new regression tests for zero/infinite direct+inverted FX rates and infinite/NaN prices
- [x] `cargo test --locked` in `src-tauri/` — 255 passed, including a new test asserting the live DB is byte-for-byte untouched when the staged restore file fails integrity check
- [x] `cargo test --locked` in `portfolio-mcp/` — 25 passed (unaffected, but re-verified since it shares `portfolio-core`)
- [x] Full pre-push suite (lint, typecheck, frontend build, frontend tests x307, backend tests, clippy) — all green
- [x] Confirmed `portfolio-mcp` and `src-tauri` both consume the shared `portfolio-core::snapshot`/`fx` modules, so this fix covers both surfaces with one change

🤖 Generated with [Claude Code](https://claude.com/claude-code)