### PR TITLE
fix: clamp stress shocks at zero, normalize Tauri IPC errors, fix decoy validator tests

### DIFF
--- a/frontend/components/AccountsModal.tsx
+++ b/frontend/components/AccountsModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { tauriInvoke } from '../lib/tauri';
+import { tauriInvoke, getErrorMessage } from '../lib/tauri';
 import { Pencil, Trash2, X, Plus } from 'lucide-react';
 import { ACCOUNT_TYPE_CONFIG } from '../lib/constants';
 import type {
@@ -90,7 +90,7 @@ export function AccountsModal({ isOpen, onClose, portfolio }: AccountsModalProps
       const result = await tauriInvoke<Account[]>('get_accounts');
       setAccounts(result);
     } catch (e) {
-      setError(String(e));
+      setError(getErrorMessage(e));
     } finally {
       setLoading(false);
     }
@@ -147,7 +147,7 @@ export function AccountsModal({ isOpen, onClose, portfolio }: AccountsModalProps
       setForm(EMPTY_FORM);
       setEditingId(null);
     } catch (e) {
-      setError(String(e));
+      setError(getErrorMessage(e));
     } finally {
       setSaving(false);
     }
@@ -160,7 +160,7 @@ export function AccountsModal({ isOpen, onClose, portfolio }: AccountsModalProps
       await tauriInvoke('delete_account', { id });
       await loadAccounts();
     } catch (e) {
-      setError(String(e));
+      setError(getErrorMessage(e));
     } finally {
       setDeletingId(null);
     }

--- a/frontend/components/AddTransactionModal.tsx
+++ b/frontend/components/AddTransactionModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { tauriInvoke, isTauri } from '../lib/tauri';
+import { tauriInvoke, isTauri, getErrorMessage } from '../lib/tauri';
 import { useToast } from './ui/Toast';
 import type { Holding, Transaction, TransactionInput } from '../types/portfolio';
 
@@ -72,7 +72,7 @@ export function AddTransactionModal({ holding, isOpen, onClose, onSaved }: Props
       onSaved();
       onClose();
     } catch (err) {
-      setError(String(err));
+      setError(getErrorMessage(err));
     } finally {
       setSaving(false);
     }

--- a/frontend/components/Alerts.tsx
+++ b/frontend/components/Alerts.tsx
@@ -14,7 +14,7 @@ import { EmptyState } from './ui/EmptyState';
 import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 import { usePortfolio } from '../hooks/usePortfolio';
 
 const MOCK_ALERTS: PriceAlert[] = [
@@ -240,7 +240,7 @@ export function Alerts() {
         setAlerts(MOCK_ALERTS);
       }
     } catch (err) {
-      showToast(`Failed to load alerts: ${String(err)}`, 'error');
+      showToast(`Failed to load alerts: ${getErrorMessage(err)}`, 'error');
     } finally {
       setLoading(false);
     }
@@ -272,7 +272,7 @@ export function Alerts() {
         setShowForm(false);
         showToast(`Alert created for ${input.symbol}`, 'success');
       } catch (err) {
-        showToast(`Failed to create alert: ${String(err)}`, 'error');
+        showToast(`Failed to create alert: ${getErrorMessage(err)}`, 'error');
       }
     },
     [showToast]
@@ -287,7 +287,7 @@ export function Alerts() {
         setAlerts((prev) => prev.filter((a) => a.id !== id));
         showToast('Alert deleted', 'success');
       } catch (err) {
-        showToast(`Failed to delete alert: ${String(err)}`, 'error');
+        showToast(`Failed to delete alert: ${getErrorMessage(err)}`, 'error');
       }
     },
     [showToast]
@@ -301,7 +301,7 @@ export function Alerts() {
         }
         setAlerts((prev) => prev.map((a) => (a.id === id ? { ...a, triggered: false } : a)));
       } catch (err) {
-        showToast(`Failed to reset alert: ${String(err)}`, 'error');
+        showToast(`Failed to reset alert: ${getErrorMessage(err)}`, 'error');
       }
     },
     [showToast]

--- a/frontend/components/Analytics.tsx
+++ b/frontend/components/Analytics.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RefreshCw, ArrowUpDown } from 'lucide-react';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 import {
   PieChart,
   Pie,
@@ -217,7 +217,7 @@ export function Analytics() {
         });
       }
     } catch (err) {
-      setError(String(err));
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/components/Dividends.tsx
+++ b/frontend/components/Dividends.tsx
@@ -16,7 +16,7 @@ import { EmptyState } from './ui/EmptyState';
 import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 import { useToast } from './ui/Toast';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 import { SUPPORTED_CURRENCIES } from '../lib/constants';
 
 interface AddDividendFormProps {
@@ -201,7 +201,7 @@ export function Dividends() {
         setHoldings(MOCK_HOLDINGS);
       }
     } catch (err) {
-      showToast(`Failed to load dividends: ${String(err)}`, 'error');
+      showToast(`Failed to load dividends: ${getErrorMessage(err)}`, 'error');
     } finally {
       setLoading(false);
     }
@@ -230,7 +230,7 @@ export function Dividends() {
         setShowForm(false);
         showToast('Dividend recorded', 'success');
       } catch (err) {
-        showToast(`Failed to record dividend: ${String(err)}`, 'error');
+        showToast(`Failed to record dividend: ${getErrorMessage(err)}`, 'error');
       }
     },
     [holdings, showToast]
@@ -245,7 +245,7 @@ export function Dividends() {
         setDividends((prev) => prev.filter((d) => d.id !== id));
         showToast('Dividend deleted', 'success');
       } catch (err) {
-        showToast(`Failed to delete: ${String(err)}`, 'error');
+        showToast(`Failed to delete: ${getErrorMessage(err)}`, 'error');
       }
     },
     [showToast]

--- a/frontend/components/Holdings.tsx
+++ b/frontend/components/Holdings.tsx
@@ -39,7 +39,7 @@ import type {
   HoldingWithPrice,
   PriceData,
 } from '../types/portfolio';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 
 type SortKey = keyof Pick<
   HoldingWithPrice,
@@ -327,7 +327,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
       showToast(`Deleted ${ids.length} holdings`, 'info');
       setSelected(new Set());
     } catch (e) {
-      showToast(String(e), 'error');
+      showToast(getErrorMessage(e), 'error');
     } finally {
       setBulkDeleting(false);
       setIsDeleting(false);
@@ -345,7 +345,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
         showToast('Holding added', 'success');
       }
     } catch (e) {
-      showToast(String(e), 'error');
+      showToast(getErrorMessage(e), 'error');
     }
     setEditing(undefined);
   }
@@ -364,7 +364,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
       await deleteHolding(id);
       showToast('Holding deleted', 'info');
     } catch (e) {
-      showToast(String(e), 'error');
+      showToast(getErrorMessage(e), 'error');
     } finally {
       setDeletingId(null);
       setIsDeleting(false);
@@ -395,7 +395,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
       URL.revokeObjectURL(url);
       showToast('Holdings exported', 'success');
     } catch (e) {
-      showToast(String(e), 'error');
+      showToast(getErrorMessage(e), 'error');
     }
   }, [exportHoldingsCsv, showToast]);
 

--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Download, Upload } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { getVersion } from '@tauri-apps/api/app';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 import { useConfig } from '../hooks/useConfig';
 import { useTheme, type ThemeMode } from '../hooks/useTheme';
 import { useLanguage, SUPPORTED_LANGUAGES } from '../hooks/useLanguage';
@@ -211,7 +211,7 @@ function DataManagementSection() {
       });
       setBackupStatus({ kind: 'success', path: savedPath });
     } catch (err) {
-      setBackupStatus({ kind: 'error', message: String(err) });
+      setBackupStatus({ kind: 'error', message: getErrorMessage(err) });
     }
   };
 
@@ -241,7 +241,7 @@ function DataManagementSection() {
       const message = await tauriInvoke<string>('restore_database', { sourcePath: filePath });
       setRestoreStatus({ kind: 'success', message });
     } catch (err) {
-      setRestoreStatus({ kind: 'error', message: String(err) });
+      setRestoreStatus({ kind: 'error', message: getErrorMessage(err) });
     }
   };
 

--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Trash2 } from 'lucide-react';
-import { isTauri, tauriInvoke } from '../lib/tauri';
+import { isTauri, tauriInvoke, getErrorMessage } from '../lib/tauri';
 import { usePortfolio } from '../hooks/usePortfolio';
 import { AddTransactionModal } from './AddTransactionModal';
 import { EmptyState } from './ui/EmptyState';
@@ -112,7 +112,7 @@ export function TransactionHistory() {
         setTransactions([]);
       }
     } catch (err) {
-      setError(String(err));
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }
@@ -172,7 +172,7 @@ export function TransactionHistory() {
       setTransactions((prev) => prev.filter((tx) => tx.id !== id));
       showToast('Transaction deleted', 'info');
     } catch (err) {
-      showToast(String(err), 'error');
+      showToast(getErrorMessage(err), 'error');
     } finally {
       setDeletingId(null);
       setPendingDelete(null);

--- a/frontend/components/__tests__/AddTransactionModal.test.tsx
+++ b/frontend/components/__tests__/AddTransactionModal.test.tsx
@@ -8,6 +8,7 @@ const mockTauriInvoke = vi.fn();
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => true,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: (...args: unknown[]) => mockTauriInvoke(...args),
 }));
 

--- a/frontend/components/__tests__/Alerts.test.tsx
+++ b/frontend/components/__tests__/Alerts.test.tsx
@@ -10,6 +10,7 @@ const mockDeleteAlert = vi.fn();
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: (cmd: string, ...args: unknown[]) => {
     if (cmd === 'delete_alert') return mockDeleteAlert(cmd, ...args);
     return Promise.resolve(null);

--- a/frontend/components/__tests__/Analytics.test.tsx
+++ b/frontend/components/__tests__/Analytics.test.tsx
@@ -21,6 +21,7 @@ const mockAnalytics: PortfolioAnalytics = {
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => true,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: () => Promise.resolve(mockAnalytics),
 }));
 

--- a/frontend/components/__tests__/Dividends.test.tsx
+++ b/frontend/components/__tests__/Dividends.test.tsx
@@ -8,6 +8,7 @@ import i18next from '../../lib/i18n';
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: (_cmd: string) => Promise.resolve([]),
 }));
 

--- a/frontend/components/__tests__/Performance.test.tsx
+++ b/frontend/components/__tests__/Performance.test.tsx
@@ -7,6 +7,7 @@ import { MOCK_SNAPSHOT } from '../../lib/mockData';
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: vi.fn().mockResolvedValue([]),
 }));
 

--- a/frontend/components/__tests__/Rebalance.test.tsx
+++ b/frontend/components/__tests__/Rebalance.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: vi.fn().mockResolvedValue([]),
 }));
 

--- a/frontend/components/__tests__/Settings.test.tsx
+++ b/frontend/components/__tests__/Settings.test.tsx
@@ -31,6 +31,7 @@ let mockIsTauri = false;
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => mockIsTauri,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: (cmd: string, ...args: unknown[]) => {
     if (cmd === 'set_config_cmd') return mockSetConfigCmd(cmd, ...args);
     if (cmd === 'get_config_cmd') return mockGetConfigCmd(cmd, ...args);

--- a/frontend/components/__tests__/TransactionHistory.test.tsx
+++ b/frontend/components/__tests__/TransactionHistory.test.tsx
@@ -105,6 +105,7 @@ const mockHoldings = [
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => true,
+  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: vi.fn((cmd: string) => {
     if (cmd === 'get_transactions_paginated')
       return Promise.resolve({

--- a/frontend/lib/__tests__/tauri.test.ts
+++ b/frontend/lib/__tests__/tauri.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('getErrorMessage', () => {
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns the message from a real Error instance', async () => {
+    const { getErrorMessage } = await import('../tauri');
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns a plain string rejection unchanged', async () => {
+    const { getErrorMessage } = await import('../tauri');
+    expect(getErrorMessage('database is locked')).toBe('database is locked');
+  });
+
+  it('extracts message from a Tauri AppError-shaped object', async () => {
+    const { getErrorMessage } = await import('../tauri');
+    expect(
+      getErrorMessage({ type: 'Validation', message: 'quantity must be a positive finite number' })
+    ).toBe('quantity must be a positive finite number');
+  });
+
+  it('falls back to JSON.stringify for shapes without a message field', async () => {
+    const { getErrorMessage } = await import('../tauri');
+    expect(getErrorMessage({ code: 42 })).toBe('{"code":42}');
+  });
+});
+
+describe('tauriInvoke error normalization', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@tauri-apps/api/core');
+  });
+
+  it('rejects with a real Error instance carrying the backend message when the command rejects with a plain object', async () => {
+    vi.doMock('@tauri-apps/api/core', () => ({
+      invoke: vi.fn().mockRejectedValue({ type: 'NotFound', message: 'holding not found' }),
+    }));
+
+    const { tauriInvoke } = await import('../tauri');
+
+    await expect(tauriInvoke('get_portfolio')).rejects.toBeInstanceOf(Error);
+    await expect(tauriInvoke('get_portfolio')).rejects.toThrow('holding not found');
+  });
+
+  it('rejects with a real Error instance when the command rejects with a plain string', async () => {
+    vi.doMock('@tauri-apps/api/core', () => ({
+      invoke: vi.fn().mockRejectedValue('quantity must be a positive finite number'),
+    }));
+
+    const { tauriInvoke } = await import('../tauri');
+
+    await expect(tauriInvoke('add_holding')).rejects.toBeInstanceOf(Error);
+    await expect(tauriInvoke('add_holding')).rejects.toThrow(
+      'quantity must be a positive finite number'
+    );
+  });
+
+  it('resolves normally when the command succeeds', async () => {
+    vi.doMock('@tauri-apps/api/core', () => ({
+      invoke: vi.fn().mockResolvedValue({ totalValue: 100 }),
+    }));
+
+    const { tauriInvoke } = await import('../tauri');
+
+    await expect(tauriInvoke('get_portfolio')).resolves.toEqual({ totalValue: 100 });
+  });
+});

--- a/frontend/lib/tauri.ts
+++ b/frontend/lib/tauri.ts
@@ -3,7 +3,38 @@
 export const isTauri = (): boolean =>
   typeof window !== 'undefined' && ('__TAURI__' in window || '__TAURI_INTERNALS__' in window);
 
+/**
+ * Extracts a human-readable message from an unknown thrown/rejected value.
+ * Tauri IPC rejections are plain strings or plain `{ type, message }` objects
+ * (see AppError's serde representation), never `Error` instances.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
 export async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   const { invoke } = await import('@tauri-apps/api/core');
-  return invoke<T>(cmd, args);
+  try {
+    return await invoke<T>(cmd, args);
+  } catch (e) {
+    throw new Error(getErrorMessage(e));
+  }
 }

--- a/portfolio-mcp/src/stress.rs
+++ b/portfolio-mcp/src/stress.rs
@@ -36,7 +36,9 @@ pub fn run_stress_test(snapshot: &PortfolioSnapshot, scenario: &StressScenario) 
         };
 
         let current_value = holding.market_value_cad;
-        let stressed_value = current_value * (1.0 + asset_shock) * (1.0 + fx_shock);
+        // A holding can lose at most its full value — floor at 0 so shocks
+        // beyond -100% (e.g. a -200% scenario) don't drive it negative.
+        let stressed_value = (current_value * (1.0 + asset_shock) * (1.0 + fx_shock)).max(0.0);
         let impact = stressed_value - current_value;
         let shock_applied = (1.0 + asset_shock) * (1.0 + fx_shock) - 1.0;
 
@@ -53,6 +55,7 @@ pub fn run_stress_test(snapshot: &PortfolioSnapshot, scenario: &StressScenario) 
         total_stressed += stressed_value;
     }
 
+    let total_stressed = total_stressed.max(0.0);
     let current_value = snapshot.total_value;
     let total_impact = total_stressed - current_value;
     let total_impact_percent = if current_value != 0.0 {
@@ -68,5 +71,111 @@ pub fn run_stress_test(snapshot: &PortfolioSnapshot, scenario: &StressScenario) 
         total_impact,
         total_impact_percent,
         holding_breakdown: holding_results,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portfolio_core::types::{AccountType, AssetType, Holding, HoldingId, HoldingWithPrice};
+    use std::collections::HashMap;
+
+    fn make_holding(
+        symbol: &str,
+        asset_type: AssetType,
+        currency: &str,
+        value: f64,
+    ) -> HoldingWithPrice {
+        HoldingWithPrice {
+            holding: Holding {
+                id: HoldingId(symbol.to_string()),
+                symbol: symbol.to_string(),
+                name: symbol.to_string(),
+                asset_type: asset_type.clone(),
+                account: if matches!(asset_type, AssetType::Cash) {
+                    AccountType::Cash
+                } else {
+                    AccountType::Taxable
+                },
+                account_id: None,
+                account_name: None,
+                quantity: 1.0,
+                cost_basis: value,
+                currency: currency.to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+            current_price: value,
+            current_price_cad: value,
+            market_value_cad: value,
+            cost_value_cad: value,
+            gain_loss: 0.0,
+            gain_loss_percent: 0.0,
+            weight: 1.0,
+            target_value: 0.0,
+            target_delta_value: 0.0,
+            target_delta_percent: 0.0,
+            daily_change_percent: 0.0,
+            fx_stale: false,
+            price_is_stale: false,
+        }
+    }
+
+    fn make_snapshot(holdings: Vec<HoldingWithPrice>) -> PortfolioSnapshot {
+        let total = holdings.iter().map(|h| h.market_value_cad).sum();
+        PortfolioSnapshot {
+            holdings,
+            total_value: total,
+            total_cost: total,
+            total_gain_loss: 0.0,
+            total_gain_loss_percent: 0.0,
+            daily_pnl: 0.0,
+            last_updated: "2024-01-01T00:00:00Z".to_string(),
+            base_currency: "CAD".to_string(),
+            total_target_weight: 0.0,
+            target_cash_delta: 0.0,
+            realized_gains: 0.0,
+            annual_dividend_income: 0.0,
+            requires_cost_basis_selection: false,
+        }
+    }
+
+    #[test]
+    fn extreme_negative_shock_floors_holding_and_portfolio_at_zero() {
+        // Regression guard for #635: a shock beyond -100% (e.g. -200%) must not
+        // drive the stressed value negative. A holding can go to $0 but not below.
+        let value = 10_000.0;
+        let snapshot = make_snapshot(vec![make_holding("BTC", AssetType::Crypto, "CAD", value)]);
+        let mut shocks = HashMap::new();
+        shocks.insert("crypto".to_string(), -2.0); // -200% shock
+        let scenario = StressScenario {
+            name: "Beyond total wipeout".to_string(),
+            shocks,
+        };
+
+        let result = run_stress_test(&snapshot, &scenario);
+
+        assert!(
+            result.stressed_value >= 0.0,
+            "portfolio stressed_value should not be negative, got {}",
+            result.stressed_value
+        );
+        assert!(
+            (result.stressed_value - 0.0).abs() < 0.001,
+            "expected stressed_value floored at 0, got {}",
+            result.stressed_value
+        );
+        assert!(
+            result.holding_breakdown[0].stressed_value >= 0.0,
+            "holding stressed_value should not be negative, got {}",
+            result.holding_breakdown[0].stressed_value
+        );
+        assert!((result.total_impact - (-value)).abs() < 0.001);
     }
 }

--- a/src-tauri/src/commands/alerts.rs
+++ b/src-tauri/src/commands/alerts.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{AlertId, PaginatedResult, PriceAlert, PriceAlertInput};
 
-use super::DbState;
+use super::{validate_alert_fields, validate_pagination, DbState};
 
 /// Deprecated: use `get_alerts_paginated` instead.
 #[tauri::command]
@@ -20,14 +20,7 @@ pub async fn get_alerts_paginated(
     page: i64,
     page_size: i64,
 ) -> Result<PaginatedResult<PriceAlert>, AppError> {
-    if page < 1 {
-        return Err(AppError::Validation("page must be >= 1".to_string()));
-    }
-    if !(1..=500).contains(&page_size) {
-        return Err(AppError::Validation(
-            "page_size must be between 1 and 500".to_string(),
-        ));
-    }
+    validate_pagination(page, page_size)?;
     let pool = &db.0;
     db::get_alerts_paginated(pool, page, page_size)
         .await
@@ -39,11 +32,7 @@ pub async fn add_alert(
     db: State<'_, DbState>,
     alert: PriceAlertInput,
 ) -> Result<PriceAlert, AppError> {
-    if !alert.threshold.is_finite() || alert.threshold <= 0.0 {
-        return Err(AppError::Validation(
-            "threshold must be a positive finite number".to_string(),
-        ));
-    }
+    validate_alert_fields(alert.threshold)?;
     let pool = &db.0;
     db::insert_alert(pool, alert).await.map_err(AppError::from)
 }

--- a/src-tauri/src/commands/dividends.rs
+++ b/src-tauri/src/commands/dividends.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{Dividend, DividendId, DividendInput, PaginatedResult};
 
-use super::{validate_dividend_fields, DbState};
+use super::{validate_dividend_fields, validate_pagination, DbState};
 
 /// Deprecated: use `get_dividends_paginated` instead.
 #[tauri::command]
@@ -20,14 +20,7 @@ pub async fn get_dividends_paginated(
     page: i64,
     page_size: i64,
 ) -> Result<PaginatedResult<Dividend>, AppError> {
-    if page < 1 {
-        return Err(AppError::Validation("page must be >= 1".to_string()));
-    }
-    if !(1..=500).contains(&page_size) {
-        return Err(AppError::Validation(
-            "page_size must be between 1 and 500".to_string(),
-        ));
-    }
+    validate_pagination(page, page_size)?;
     let pool = &db.0;
     db::get_dividends_paginated(pool, page, page_size)
         .await

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -286,6 +286,29 @@ pub(crate) fn validate_holding_dividend_fields(
     Ok(())
 }
 
+/// Validates a price alert's threshold. Shared by `add_alert`.
+pub(crate) fn validate_alert_fields(threshold: f64) -> Result<(), AppError> {
+    if !threshold.is_finite() || threshold <= 0.0 {
+        return Err(AppError::Validation(
+            "threshold must be a positive finite number".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Validates 1-indexed pagination parameters. Shared by every `*_paginated` command.
+pub(crate) fn validate_pagination(page: i64, page_size: i64) -> Result<(), AppError> {
+    if page < 1 {
+        return Err(AppError::Validation("page must be >= 1".to_string()));
+    }
+    if !(1..=500).contains(&page_size) {
+        return Err(AppError::Validation(
+            "page_size must be between 1 and 500".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::csv::{build_holdings_csv, parse_import_rows};

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -9,7 +9,8 @@ use crate::types::{Holding, HoldingId, HoldingInput, PortfolioSnapshot};
 
 use super::{
     get_base_currency, validate_holding_dividend_fields, validate_holding_fields,
-    validate_target_weight, DbState, HttpClient, RealizedGainsCacheState, WEIGHT_EPSILON,
+    validate_pagination, validate_target_weight, DbState, HttpClient, RealizedGainsCacheState,
+    WEIGHT_EPSILON,
 };
 
 #[tauri::command]
@@ -89,14 +90,7 @@ pub async fn get_holdings_paginated(
     page: i64,
     page_size: i64,
 ) -> Result<crate::types::PaginatedResult<Holding>, AppError> {
-    if page < 1 {
-        return Err(AppError::Validation("page must be >= 1".to_string()));
-    }
-    if !(1..=500).contains(&page_size) {
-        return Err(AppError::Validation(
-            "page_size must be between 1 and 500".to_string(),
-        ));
-    }
+    validate_pagination(page, page_size)?;
     let pool = &db.0;
     db::get_holdings_paginated(pool, page, page_size)
         .await

--- a/src-tauri/src/commands/transactions.rs
+++ b/src-tauri/src/commands/transactions.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{HoldingId, PaginatedResult, Transaction, TransactionId, TransactionInput};
 
-use super::{validate_transaction_fields, DbState, RealizedGainsCacheState};
+use super::{validate_pagination, validate_transaction_fields, DbState, RealizedGainsCacheState};
 
 #[tauri::command]
 pub async fn add_transaction(
@@ -44,14 +44,7 @@ pub async fn get_transactions_paginated(
     page: i64,
     page_size: i64,
 ) -> Result<PaginatedResult<Transaction>, AppError> {
-    if page < 1 {
-        return Err(AppError::Validation("page must be >= 1".to_string()));
-    }
-    if !(1..=500).contains(&page_size) {
-        return Err(AppError::Validation(
-            "page_size must be between 1 and 500".to_string(),
-        ));
-    }
+    validate_pagination(page, page_size)?;
     let pool = &db.0;
     db::get_transactions_paginated(
         pool,

--- a/src-tauri/src/commands_tests.rs
+++ b/src-tauri/src/commands_tests.rs
@@ -34,20 +34,10 @@ mod tests {
         }
     }
 
-    // ── holding validation (mirrors add_holding logic) ────────────────────────
+    // ── holding validation (exercises the real add_holding validator) ─────────
 
-    fn validate_holding(input: &HoldingInput) -> Result<(), String> {
-        if input.quantity <= 0.0 || !input.quantity.is_finite() {
-            return Err("quantity must be a positive finite number".to_string());
-        }
-        if input.cost_basis < 0.0 || !input.cost_basis.is_finite() {
-            return Err("costBasis must be a non-negative finite number".to_string());
-        }
-        let currency = input.currency.trim().to_uppercase();
-        if currency.len() != 3 || !currency.chars().all(|c| c.is_ascii_alphabetic()) {
-            return Err("currency must be a 3-letter ISO currency code".to_string());
-        }
-        Ok(())
+    fn validate_holding(input: &HoldingInput) -> Result<String, crate::error::AppError> {
+        crate::commands::validate_holding_fields(input.quantity, input.cost_basis, &input.currency)
     }
 
     #[test]
@@ -68,6 +58,14 @@ mod tests {
     fn add_holding_rejects_nan_quantity() {
         let mut h = holding_input("RY");
         h.quantity = f64::NAN;
+        assert!(validate_holding(&h).is_err());
+    }
+
+    #[test]
+    fn add_holding_rejects_infinite_quantity() {
+        // Uncovered path: infinite quantity must be rejected the same as NaN.
+        let mut h = holding_input("RY");
+        h.quantity = f64::INFINITY;
         assert!(validate_holding(&h).is_err());
     }
 
@@ -101,6 +99,16 @@ mod tests {
     #[test]
     fn add_holding_accepts_valid_inputs() {
         assert!(validate_holding(&holding_input("AAPL")).is_ok());
+    }
+
+    #[test]
+    fn add_holding_normalizes_lowercase_currency_to_uppercase() {
+        // Uncovered path: the real validator's Ok value is the normalized
+        // currency — the deleted decoy discarded this, so a bug in the
+        // normalization itself would never have been caught.
+        let mut h = holding_input("RY");
+        h.currency = "  usd ".to_string();
+        assert_eq!(validate_holding(&h).unwrap(), "USD");
     }
 
     // ── target weight validation (#613) ───────────────────────────────────────
@@ -305,13 +313,10 @@ mod tests {
         assert!(crate::commands::validate_holding_dividend_fields(None, None, None).is_ok());
     }
 
-    // ── alert validation ──────────────────────────────────────────────────────
+    // ── alert validation (exercises the real add_alert validator) ─────────────
 
-    fn validate_alert(input: &PriceAlertInput) -> Result<(), String> {
-        if !input.threshold.is_finite() || input.threshold <= 0.0 {
-            return Err("threshold must be a positive finite number".to_string());
-        }
-        Ok(())
+    fn validate_alert(input: &PriceAlertInput) -> Result<(), crate::error::AppError> {
+        crate::commands::validate_alert_fields(input.threshold)
     }
 
     #[test]
@@ -339,6 +344,32 @@ mod tests {
     }
 
     #[test]
+    fn add_alert_rejects_nan_threshold() {
+        // Uncovered path: the decoy's `is_finite()` check was never exercised
+        // against NaN, only against the <= 0.0 branch.
+        let input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: f64::NAN,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
+    fn add_alert_rejects_infinite_threshold() {
+        let input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: f64::INFINITY,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
     fn add_alert_accepts_valid_threshold() {
         let input = PriceAlertInput {
             symbol: "AAPL".to_string(),
@@ -350,16 +381,10 @@ mod tests {
         assert!(validate_alert(&input).is_ok());
     }
 
-    // ── page size validation ──────────────────────────────────────────────────
+    // ── page size validation (exercises the real *_paginated validator) ───────
 
-    fn validate_pagination(page: i64, page_size: i64) -> Result<(), String> {
-        if page < 1 {
-            return Err("page must be >= 1".to_string());
-        }
-        if !(1..=500).contains(&page_size) {
-            return Err("page_size must be between 1 and 500".to_string());
-        }
-        Ok(())
+    fn validate_pagination(page: i64, page_size: i64) -> Result<(), crate::error::AppError> {
+        crate::commands::validate_pagination(page, page_size)
     }
 
     #[test]
@@ -368,8 +393,20 @@ mod tests {
     }
 
     #[test]
+    fn pagination_rejects_negative_page() {
+        // Uncovered path: the decoy's `page < 1` branch was only ever
+        // exercised with page == 0, not with a negative page number.
+        assert!(validate_pagination(-5, 50).is_err());
+    }
+
+    #[test]
     fn pagination_rejects_page_size_zero() {
         assert!(validate_pagination(1, 0).is_err());
+    }
+
+    #[test]
+    fn pagination_rejects_negative_page_size() {
+        assert!(validate_pagination(1, -1).is_err());
     }
 
     #[test]

--- a/src-tauri/src/stress.rs
+++ b/src-tauri/src/stress.rs
@@ -37,7 +37,9 @@ pub fn run_stress_test(snapshot: &PortfolioSnapshot, scenario: &StressScenario) 
         };
 
         let current_value = holding.market_value_cad;
-        let stressed_value = current_value * (1.0 + asset_shock) * (1.0 + fx_shock);
+        // A holding can lose at most its full value — floor at 0 so shocks
+        // beyond -100% (e.g. a -200% scenario) don't drive it negative.
+        let stressed_value = (current_value * (1.0 + asset_shock) * (1.0 + fx_shock)).max(0.0);
         let impact = stressed_value - current_value;
 
         // Combined shock for display
@@ -56,6 +58,7 @@ pub fn run_stress_test(snapshot: &PortfolioSnapshot, scenario: &StressScenario) 
         total_stressed += stressed_value;
     }
 
+    let total_stressed = total_stressed.max(0.0);
     let current_value = snapshot.total_value;
     let total_impact = total_stressed - current_value;
     let total_impact_percent = if current_value != 0.0 {
@@ -438,6 +441,40 @@ mod tests {
                 h.symbol
             );
         }
+    }
+
+    #[test]
+    fn extreme_negative_shock_floors_holding_and_portfolio_at_zero() {
+        // Regression guard for #635: a shock beyond -100% (e.g. -200%) must not
+        // drive the stressed value negative. A holding can go to $0 but not below.
+        let value = 10_000.0;
+        let snapshot = make_snapshot(vec![make_holding("BTC", AssetType::Crypto, "CAD", value)]);
+        let mut shocks = HashMap::new();
+        shocks.insert("crypto".to_string(), -2.0); // -200% shock
+        let scenario = StressScenario {
+            name: "Beyond total wipeout".to_string(),
+            shocks,
+        };
+
+        let result = run_stress_test(&snapshot, &scenario);
+
+        assert!(
+            result.stressed_value >= 0.0,
+            "portfolio stressed_value should not be negative, got {}",
+            result.stressed_value
+        );
+        assert!(
+            (result.stressed_value - 0.0).abs() < 0.001,
+            "expected stressed_value floored at 0, got {}",
+            result.stressed_value
+        );
+        assert!(
+            result.holding_breakdown[0].stressed_value >= 0.0,
+            "holding stressed_value should not be negative, got {}",
+            result.holding_breakdown[0].stressed_value
+        );
+        // Total loss is capped at the original value, not 2x the value.
+        assert!((result.total_impact - (-value)).abs() < 0.001);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three high-priority fixes, one branch:

- **#635** — Stress-test shocks beyond -100% (e.g. a -200% crash scenario) could drive holding and portfolio values negative. Both stress engines (`src-tauri/src/stress.rs` and the duplicate copy in `portfolio-mcp/src/stress.rs`) now floor the per-holding and portfolio-total stressed value at `0.0`.
- **#636** — `tauriInvoke()` propagated raw Tauri IPC rejections (plain strings or `{ type, message }` objects) instead of `Error` instances, so `catch (e)` handlers reading `e.message` or interpolating `e` printed `"[object Object]"` or `undefined`. `tauriInvoke` now normalizes every rejection into a real `Error` via a new `getErrorMessage()` helper (exported from `frontend/lib/tauri.ts`), and the component catch handlers that were doing a bare `String(err)` now call `getErrorMessage(err)` instead.
- **#637** — Three tests in `src-tauri/src/commands_tests.rs` exercised local decoy copies of validation logic instead of the real command-layer validators, so a bug in production code would never be caught. Extracted `validate_alert_fields` and `validate_pagination` into `commands/mod.rs` (this also dedupes four copy-pasted inline pagination checks across `alerts.rs`/`dividends.rs`/`portfolio.rs`/`transactions.rs`), wired the real command handlers to call them, and pointed the tests at `crate::commands::validate_holding_fields` / `validate_alert_fields` / `validate_pagination`. Added coverage for previously-untested paths (infinite quantity, currency-case normalization, NaN/infinite threshold, negative page/page_size).

## Test plan
- [x] `cargo test --locked` in `src-tauri/` — 262 passed
- [x] `cargo test --locked` in `portfolio-core/` — 34 passed
- [x] `cargo test --locked` in `portfolio-mcp/` — 26 passed
- [x] `NODE_ENV=development npm test` (frontend) — 314 passed
- [x] `tsc --noEmit` — clean
- [x] Pre-push hook (lint, format, frontend+backend build, full test suites, clippy) — all green

Closes #635
Closes #636
Closes #637