### PR TITLE
fix: backend operational fixes (#639, #641, #642, #643, #644)

### DIFF
--- a/portfolio-core/src/snapshot.rs
+++ b/portfolio-core/src/snapshot.rs
@@ -140,7 +140,12 @@ pub fn build_portfolio_snapshot(
                     created_at = %holding.created_at,
                     "Corrupted created_at; holding excluded from daily PnL"
                 );
-                price_is_stale = true;
+                // Cash holdings never have a fetched price, so they must
+                // always report price_is_stale = false (#639) — a corrupted
+                // created_at only affects daily PnL exclusion, not pricing.
+                if !is_cash {
+                    price_is_stale = true;
+                }
                 ""
             }
         };
@@ -976,6 +981,31 @@ mod tests {
         );
         assert!(snapshot.holdings[0].market_value_cad.is_finite());
         assert!(snapshot.holdings[0].price_is_stale);
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_cash_holding_with_corrupted_created_at_stays_non_stale() {
+        // Regression guard for #639: a corrupted/too-short created_at falls back
+        // to the "exclude from daily PnL" branch, which used to unconditionally
+        // set price_is_stale = true — even for cash holdings, which never have
+        // a fetched price and must always report price_is_stale = false.
+        let mut holding = make_holding("CAD-CASH", AssetType::Cash, 500.0, 1.0, "CAD");
+        holding.created_at = "bad".to_string(); // shorter than 10 chars
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &[],
+            &[],
+            "CAD",
+            "2024-01-01T00:00:00Z".to_string(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            !snapshot.holdings[0].price_is_stale,
+            "cash holdings must always report price_is_stale = false"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -3,17 +3,27 @@ use tauri::Manager;
 
 use crate::error::AppError;
 
-use super::DbState;
+use super::{BackupLockState, DbState};
 
 /// SQLite magic bytes: first 16 bytes of a valid SQLite database file.
 const SQLITE_MAGIC: &[u8] = b"SQLite format 3\0";
+
+/// Error returned when backup/restore is invoked while another instance of
+/// either is already running — both operate on the same live DB file.
+const LOCK_CONFLICT_MESSAGE: &str = "Backup or restore already in progress";
 
 #[tauri::command]
 pub async fn backup_database(
     app: tauri::AppHandle,
     state: tauri::State<'_, DbState>,
+    lock_state: tauri::State<'_, BackupLockState>,
     destination_path: String,
 ) -> Result<String, AppError> {
+    let _guard = lock_state
+        .0
+        .try_lock()
+        .map_err(|_| AppError::Conflict(LOCK_CONFLICT_MESSAGE.to_string()))?;
+
     // Flush WAL to ensure the file on disk is complete before we copy it.
     {
         let pool = &state.0;
@@ -87,7 +97,7 @@ pub async fn backup_database(
         }
     }
 
-    std::fs::copy(&source, &dest).map_err(|e| format!("Failed to copy database: {e}"))?;
+    atomic_copy(&source, &dest)?;
 
     Ok(dest.to_string_lossy().into_owned())
 }
@@ -96,8 +106,14 @@ pub async fn backup_database(
 pub async fn restore_database(
     app: tauri::AppHandle,
     state: tauri::State<'_, DbState>,
+    lock_state: tauri::State<'_, BackupLockState>,
     source_path: String,
 ) -> Result<String, AppError> {
+    let _guard = lock_state
+        .0
+        .try_lock()
+        .map_err(|_| AppError::Conflict(LOCK_CONFLICT_MESSAGE.to_string()))?;
+
     // Verify the source file is a valid SQLite database.
     let src = std::fs::canonicalize(&source_path)
         .map_err(|e| format!("Cannot resolve backup path: {e}"))?;
@@ -177,6 +193,41 @@ pub async fn restore_database(
     .await?;
 
     Ok("Database restored. Please restart the app to apply changes.".to_string())
+}
+
+/// Copies `source` to `dest` without ever exposing a partially-written file
+/// at `dest`. Stages the copy into a temp file in the same directory as
+/// `dest`, then atomically renames it into place — a same-directory rename
+/// is atomic, so `dest` is always either its prior contents or the complete
+/// new copy, never a half-written file from a failed or interrupted copy.
+///
+/// Fixes the check-then-write gap in #643: the old code checked whether
+/// `dest` existed while resolving the path, then separately wrote to it with
+/// `std::fs::copy`, leaving a window where a crash or error mid-copy could
+/// leave `dest` truncated or corrupted.
+fn atomic_copy(source: &std::path::Path, dest: &std::path::Path) -> Result<(), AppError> {
+    let mut tmp_name = dest
+        .file_name()
+        .ok_or("Destination path has no filename")?
+        .to_os_string();
+    tmp_name.push(".tmp");
+    let tmp_dest = dest.with_file_name(tmp_name);
+
+    if let Err(e) = std::fs::copy(source, &tmp_dest) {
+        let _ = std::fs::remove_file(&tmp_dest);
+        return Err(AppError::Validation(format!(
+            "Failed to copy database: {e}"
+        )));
+    }
+
+    if let Err(e) = std::fs::rename(&tmp_dest, dest) {
+        let _ = std::fs::remove_file(&tmp_dest);
+        return Err(AppError::Validation(format!(
+            "Failed to finalize backup: {e}"
+        )));
+    }
+
+    Ok(())
 }
 
 /// Quiesces `pool`, atomically replaces `dest` with `backup_src` on disk, and
@@ -351,6 +402,81 @@ mod tests {
             .expect("select marker");
         pool.close().await;
         row.map(|r| r.get::<String, _>(0))
+    }
+
+    #[test]
+    fn atomic_copy_replaces_dest_contents() {
+        let scratch = ScratchDir::new("atomic-copy-happy-path");
+        let source_path = scratch.path("source.db");
+        let dest_path = scratch.path("dest.db");
+
+        std::fs::write(&source_path, b"new contents").expect("write source");
+        std::fs::write(&dest_path, b"old contents").expect("write dest");
+
+        atomic_copy(&source_path, &dest_path).expect("atomic_copy should succeed");
+
+        let contents = std::fs::read(&dest_path).expect("read dest");
+        assert_eq!(contents, b"new contents");
+        assert!(
+            !scratch.path("dest.db.tmp").exists(),
+            "temp staging file should be cleaned up (consumed by rename) after success"
+        );
+    }
+
+    #[test]
+    fn atomic_copy_never_touches_existing_dest_when_source_is_missing() {
+        // Regression guard for #643: if the copy step fails, `dest` must be
+        // left byte-for-byte untouched rather than partially overwritten.
+        let scratch = ScratchDir::new("atomic-copy-missing-source");
+        let source_path = scratch.path("does-not-exist.db");
+        let dest_path = scratch.path("dest.db");
+
+        std::fs::write(&dest_path, b"original contents").expect("write dest");
+
+        let result = atomic_copy(&source_path, &dest_path);
+
+        assert!(result.is_err(), "copy from a missing source must fail");
+        let contents = std::fs::read(&dest_path).expect("read dest");
+        assert_eq!(
+            contents, b"original contents",
+            "dest must remain untouched when the copy step fails"
+        );
+        assert!(
+            !scratch.path("dest.db.tmp").exists(),
+            "failed temp staging file should be cleaned up rather than left behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn backup_lock_state_rejects_concurrent_acquisition() {
+        // Regression guard for #642: a second backup/restore attempt while one
+        // is already running must fail fast instead of racing on the DB file.
+        let lock_state = BackupLockState::new();
+        let _first_guard = lock_state
+            .0
+            .try_lock()
+            .expect("first lock acquisition should succeed");
+
+        assert!(
+            lock_state.0.try_lock().is_err(),
+            "a second concurrent lock acquisition must fail while the first is held"
+        );
+    }
+
+    #[tokio::test]
+    async fn backup_lock_state_allows_acquisition_after_release() {
+        let lock_state = BackupLockState::new();
+        {
+            let _guard = lock_state
+                .0
+                .try_lock()
+                .expect("first lock acquisition should succeed");
+        }
+
+        assert!(
+            lock_state.0.try_lock().is_ok(),
+            "lock should be acquirable again once the prior guard is dropped"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -5,11 +5,32 @@ use crate::error::AppError;
 
 use super::{DbState, RealizedGainsCacheState};
 
+/// Config keys readable/writable via `get_config_cmd`/`set_config_cmd`. Shared
+/// by both commands so a key can never be read without also being writable
+/// (or vice versa) — add new config keys here before wiring up a new setting.
+const ALLOWED_CONFIG_KEYS: &[&str] = &[
+    "base_currency",
+    "app_language",
+    "app_theme",
+    "auto_refresh_interval_ms",
+    "auto_refresh_market_hours_only",
+    "cost_basis_method",
+    "notifications_enabled",
+];
+
+fn validate_config_key(key: &str) -> Result<(), AppError> {
+    if !ALLOWED_CONFIG_KEYS.contains(&key) {
+        return Err(AppError::Validation(format!("Unknown config key: {key}")));
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn get_config_cmd(
     db: State<'_, DbState>,
     key: String,
 ) -> Result<Option<String>, AppError> {
+    validate_config_key(&key)?;
     let pool = &db.0;
     db::get_config(pool, &key).await.map_err(AppError::from)
 }
@@ -21,18 +42,7 @@ pub async fn set_config_cmd(
     key: String,
     value: String,
 ) -> Result<(), AppError> {
-    const ALLOWED_CONFIG_KEYS: &[&str] = &[
-        "base_currency",
-        "app_language",
-        "app_theme",
-        "auto_refresh_interval_ms",
-        "auto_refresh_market_hours_only",
-        "cost_basis_method",
-        "notifications_enabled",
-    ];
-    if !ALLOWED_CONFIG_KEYS.contains(&key.as_str()) {
-        return Err(AppError::Validation(format!("Unknown config key: {key}")));
-    }
+    validate_config_key(&key)?;
     let pool = &db.0;
     let value = if key == "cost_basis_method" {
         value.to_lowercase()
@@ -48,4 +58,39 @@ pub async fn set_config_cmd(
         gains_cache.invalidate();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_config_key_accepts_every_allowed_key() {
+        for key in ALLOWED_CONFIG_KEYS {
+            assert!(
+                validate_config_key(key).is_ok(),
+                "{key} should be a valid config key"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_config_key_rejects_unknown_key() {
+        // Regression guard for #644: get_config_cmd previously had no
+        // allowlist at all, so any key name — including internal/sensitive
+        // ones — could be queried.
+        let result = validate_config_key("some_internal_secret");
+        assert!(result.is_err(), "unknown config key must be rejected");
+        match result {
+            Err(AppError::Validation(msg)) => {
+                assert!(msg.contains("some_internal_secret"));
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_config_key_rejects_empty_key() {
+        assert!(validate_config_key("").is_err());
+    }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -142,6 +142,17 @@ impl RateLimiterState {
     }
 }
 
+/// Guards `backup_database`/`restore_database` against running concurrently —
+/// either against each other or against a second invocation of themselves —
+/// since both operate on the same live DB file on disk.
+pub struct BackupLockState(pub tokio::sync::Mutex<()>);
+
+impl BackupLockState {
+    pub fn new() -> Self {
+        BackupLockState(tokio::sync::Mutex::new(()))
+    }
+}
+
 pub(crate) async fn get_base_currency(pool: &SqlitePool) -> String {
     db::get_config(pool, "base_currency")
         .await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,11 +76,19 @@ mod ts_binding_tests {
     }
 }
 
-use commands::{DbState, HttpClient, RateLimiterState, RealizedGainsCacheState, SearchCacheState};
+use commands::{
+    BackupLockState, DbState, HttpClient, RateLimiterState, RealizedGainsCacheState,
+    SearchCacheState,
+};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use std::str::FromStr;
+use std::time::Duration;
 use tauri::Manager;
 use tracing_subscriber::prelude::*;
+
+/// Upper bound on how long app shutdown waits for the DB pool to drain before
+/// giving up — prevents the app hanging on quit if a connection is stuck.
+const POOL_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Holds the sender half of the WAL checkpoint shutdown channel.
 /// Managed as Tauri app state so the window-destroyed event can signal the background task.
@@ -172,6 +180,7 @@ pub fn run() {
             app.manage(SearchCacheState::new());
             app.manage(RealizedGainsCacheState::new());
             app.manage(RateLimiterState::new());
+            app.manage(BackupLockState::new());
             // Store the WAL shutdown sender so on_window_event can signal the task to exit.
             app.manage(WalShutdown(shutdown_tx));
 
@@ -182,6 +191,23 @@ pub fn run() {
                 // Signal the WAL checkpoint background task to shut down cleanly.
                 if let Some(state) = _window.try_state::<WalShutdown>() {
                     let _ = state.0.send(true);
+                }
+                // Drain and close the DB pool so no connection is left dangling
+                // on quit. Bounded by a timeout so a stuck connection or slow
+                // drain can never hang app shutdown.
+                if let Some(db_state) = _window.try_state::<DbState>() {
+                    let pool = db_state.0.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if tokio::time::timeout(POOL_CLOSE_TIMEOUT, pool.close())
+                            .await
+                            .is_err()
+                        {
+                            tracing::warn!(
+                                "Timed out after {:?} waiting for DB pool to close on shutdown",
+                                POOL_CLOSE_TIMEOUT
+                            );
+                        }
+                    });
                 }
             }
         })


### PR DESCRIPTION
## Summary

- **#639** — `price_is_stale` could be flagged `true` for cash holdings when a holding's `created_at` timestamp was corrupted/too short. Cash holdings never have a fetched price and must always report `price_is_stale = false`; the fallback branch now only sets the flag for non-cash holdings.
- **#641** — App shutdown never actually closed the DB pool (only the WAL checkpoint background task was signalled to stop). Added `pool.close()` on the window-destroyed event, wrapped in a 5s `tokio::time::timeout` so a stuck connection or slow drain can never hang the app on quit; logs a warning on timeout.
- **#642** — `backup_database` and `restore_database` could race if triggered concurrently (or twice). Added a `BackupLockState(tokio::sync::Mutex<()>)` in Tauri state; both commands now `try_lock()` non-blocking and return `AppError::Conflict("Backup or restore already in progress")` if the other is already running.
- **#643** — `backup_database` wrote directly to the destination path with `std::fs::copy`, leaving a window where a failed/interrupted copy could leave a truncated or corrupted file at the destination. Extracted an `atomic_copy` helper that stages the copy into a `.tmp` file in the same directory and atomically renames it into place, mirroring the pattern already used by `restore_database`.
- **#644** — `get_config_cmd` had no allowlist, so any key name could be queried. Extracted the existing `set_config_cmd` allowlist into a shared `ALLOWED_CONFIG_KEYS` constant and a `validate_config_key` helper, now enforced by both commands so a key can never be read without also being writable.

## Test plan

- [x] `cargo build` (workspace) — compiles cleanly
- [x] `cargo test --workspace` — 337 tests pass (42 portfolio-mcp, 26 portfolio-core, 269 src-tauri), including new regression tests:
  - `build_portfolio_snapshot_cash_holding_with_corrupted_created_at_stays_non_stale`
  - `atomic_copy_replaces_dest_contents`, `atomic_copy_never_touches_existing_dest_when_source_is_missing`
  - `backup_lock_state_rejects_concurrent_acquisition`, `backup_lock_state_allows_acquisition_after_release`
  - `validate_config_key_accepts_every_allowed_key`, `validate_config_key_rejects_unknown_key`, `validate_config_key_rejects_empty_key`
- [x] `NODE_ENV=development npm test -- --run` (frontend) — 314 tests pass
- [x] `cargo clippy` — clean (ran automatically via pre-push hook)
- [x] Pre-commit/pre-push hooks (lint, typecheck, format, build, tests, clippy) all passed

Closes #639
Closes #641
Closes #642
Closes #643
Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)