### PR TITLE
fix: alert validation and delete/reset ID validation (#647, #648)

### DIFF
--- a/portfolio-mcp/src/tools/alerts.rs
+++ b/portfolio-mcp/src/tools/alerts.rs
@@ -56,6 +56,8 @@ pub async fn add_alert(pool: &SqlitePool, params: AddAlertParams) -> Result<Pric
 
     validation::validate_non_empty("symbol", &params.symbol)?;
     validation::validate_alert_threshold(params.threshold)?;
+    validation::validate_alert_currency(&params.currency)?;
+    validation::validate_alert_note(&params.note)?;
 
     let input = PriceAlertInput {
         symbol: params.symbol,

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -155,6 +155,33 @@ pub fn validate_alert_threshold(threshold: f64) -> Result<(), McpError> {
     Ok(())
 }
 
+/// Max length for a price alert's free-text note, to prevent abuse.
+/// Mirrors `MAX_ALERT_NOTE_LEN` in `src-tauri/src/commands/mod.rs`.
+pub const MAX_ALERT_NOTE_LEN: usize = 500;
+
+/// Mirrors the currency check in `src-tauri/src/commands/mod.rs::validate_alert_fields`.
+pub fn validate_alert_currency(currency: &str) -> Result<(), McpError> {
+    let currency = currency.trim();
+    if !(2..=3).contains(&currency.len()) || !currency.chars().all(|c| c.is_ascii_uppercase()) {
+        return Err(McpError::invalid_params(
+            "currency must be 2-3 uppercase letters",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Mirrors the note-length check in `src-tauri/src/commands/mod.rs::validate_alert_fields`.
+pub fn validate_alert_note(note: &str) -> Result<(), McpError> {
+    if note.chars().count() > MAX_ALERT_NOTE_LEN {
+        return Err(McpError::invalid_params(
+            format!("note must be at most {MAX_ALERT_NOTE_LEN} characters"),
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Config keys the Tauri `set_config_cmd` allowlist accepts
 /// (`src-tauri/src/commands/config.rs::ALLOWED_CONFIG_KEYS`). Kept in sync
 /// manually since the MCP server does not depend on the `src-tauri` crate.
@@ -279,6 +306,34 @@ mod tests {
     #[test]
     fn validate_alert_threshold_accepts_positive_finite() {
         assert!(validate_alert_threshold(150.0).is_ok());
+    }
+
+    #[test]
+    fn validate_alert_currency_rejects_malformed() {
+        assert!(validate_alert_currency("").is_err());
+        assert!(validate_alert_currency("A").is_err());
+        assert!(validate_alert_currency("ABCD").is_err());
+        assert!(validate_alert_currency("usd").is_err());
+        assert!(validate_alert_currency("U5D").is_err());
+    }
+
+    #[test]
+    fn validate_alert_currency_accepts_valid() {
+        assert!(validate_alert_currency("CAD").is_ok());
+        assert!(validate_alert_currency("US").is_ok());
+    }
+
+    #[test]
+    fn validate_alert_note_rejects_over_max_length() {
+        let note = "a".repeat(MAX_ALERT_NOTE_LEN + 1);
+        assert!(validate_alert_note(&note).is_err());
+    }
+
+    #[test]
+    fn validate_alert_note_accepts_within_max_length() {
+        let note = "a".repeat(MAX_ALERT_NOTE_LEN);
+        assert!(validate_alert_note(&note).is_ok());
+        assert!(validate_alert_note("").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -3,7 +3,7 @@ use crate::error::AppError;
 use crate::types::{Account, CreateAccountRequest};
 use chrono::Utc;
 
-use super::DbState;
+use super::{validate_id, DbState};
 
 const VALID_ACCOUNT_TYPES: &[&str] =
     &["tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", "other"];
@@ -93,6 +93,7 @@ pub async fn delete_account(
     state: tauri::State<'_, DbState>,
     id: String,
 ) -> Result<bool, AppError> {
+    validate_id("account ID", &id)?;
     let pool = &state.0;
     db::delete_account(pool, &id).await?;
     Ok(true)

--- a/src-tauri/src/commands/alerts.rs
+++ b/src-tauri/src/commands/alerts.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{AlertId, PaginatedResult, PriceAlert, PriceAlertInput};
 
-use super::{validate_alert_fields, validate_pagination, DbState};
+use super::{validate_alert_fields, validate_id, validate_pagination, DbState};
 
 /// Deprecated: use `get_alerts_paginated` instead.
 #[tauri::command]
@@ -32,19 +32,21 @@ pub async fn add_alert(
     db: State<'_, DbState>,
     alert: PriceAlertInput,
 ) -> Result<PriceAlert, AppError> {
-    validate_alert_fields(alert.threshold)?;
+    validate_alert_fields(&alert.symbol, alert.threshold, &alert.currency, &alert.note)?;
     let pool = &db.0;
     db::insert_alert(pool, alert).await.map_err(AppError::from)
 }
 
 #[tauri::command]
 pub async fn delete_alert(db: State<'_, DbState>, id: AlertId) -> Result<bool, AppError> {
+    validate_id("alert ID", &id.0)?;
     let pool = &db.0;
     db::delete_alert(pool, &id).await.map_err(AppError::from)
 }
 
 #[tauri::command]
 pub async fn reset_alert(db: State<'_, DbState>, id: AlertId) -> Result<bool, AppError> {
+    validate_id("alert ID", &id.0)?;
     let pool = &db.0;
     db::reset_alert(pool, &id).await.map_err(AppError::from)
 }

--- a/src-tauri/src/commands/dividends.rs
+++ b/src-tauri/src/commands/dividends.rs
@@ -4,7 +4,7 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{Dividend, DividendId, DividendInput, PaginatedResult};
 
-use super::{validate_dividend_fields, validate_pagination, DbState};
+use super::{validate_dividend_fields, validate_id, validate_pagination, DbState};
 
 /// Deprecated: use `get_dividends_paginated` instead.
 #[tauri::command]
@@ -59,6 +59,7 @@ pub async fn add_dividend(
 
 #[tauri::command]
 pub async fn delete_dividend(db: State<'_, DbState>, id: DividendId) -> Result<bool, AppError> {
+    validate_id("dividend ID", &id.0)?;
     let pool = &db.0;
     db::delete_dividend(pool, &id).await.map_err(AppError::from)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -297,12 +297,46 @@ pub(crate) fn validate_holding_dividend_fields(
     Ok(())
 }
 
-/// Validates a price alert's threshold. Shared by `add_alert`.
-pub(crate) fn validate_alert_fields(threshold: f64) -> Result<(), AppError> {
+/// Max length for a price alert's free-text note, to prevent abuse.
+pub(crate) const MAX_ALERT_NOTE_LEN: usize = 500;
+
+/// Validates a price alert's symbol, threshold, currency, and note. Shared by
+/// `add_alert`. Mirrors the checks in `portfolio-mcp/src/validation.rs`.
+pub(crate) fn validate_alert_fields(
+    symbol: &str,
+    threshold: f64,
+    currency: &str,
+    note: &str,
+) -> Result<(), AppError> {
+    if symbol.trim().is_empty() {
+        return Err(AppError::Validation("symbol must not be empty".to_string()));
+    }
     if !threshold.is_finite() || threshold <= 0.0 {
         return Err(AppError::Validation(
             "threshold must be a positive finite number".to_string(),
         ));
+    }
+    let currency = currency.trim();
+    if !(2..=3).contains(&currency.len()) || !currency.chars().all(|c| c.is_ascii_uppercase()) {
+        return Err(AppError::Validation(
+            "currency must be 2-3 uppercase letters".to_string(),
+        ));
+    }
+    if note.chars().count() > MAX_ALERT_NOTE_LEN {
+        return Err(AppError::Validation(format!(
+            "note must be at most {MAX_ALERT_NOTE_LEN} characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Validates that an ID string is non-empty and a syntactically valid UUID.
+/// All IDs in this app are UUID v4 strings generated via `uuid::Uuid::new_v4()`;
+/// a malformed ID would otherwise silently no-op in SQLite (0 rows affected)
+/// instead of surfacing a clear error.
+pub(crate) fn validate_id(field: &str, id: &str) -> Result<(), AppError> {
+    if id.trim().is_empty() || uuid::Uuid::parse_str(id.trim()).is_err() {
+        return Err(AppError::Validation(format!("Invalid {field}")));
     }
     Ok(())
 }

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -8,7 +8,7 @@ use crate::portfolio::build_portfolio_snapshot;
 use crate::types::{Holding, HoldingId, HoldingInput, PortfolioSnapshot};
 
 use super::{
-    get_base_currency, validate_holding_dividend_fields, validate_holding_fields,
+    get_base_currency, validate_holding_dividend_fields, validate_holding_fields, validate_id,
     validate_pagination, validate_target_weight, DbState, HttpClient, RealizedGainsCacheState,
     WEIGHT_EPSILON,
 };
@@ -156,6 +156,7 @@ pub async fn update_holding(db: State<'_, DbState>, holding: Holding) -> Result<
 
 #[tauri::command]
 pub async fn delete_holding(db: State<'_, DbState>, id: HoldingId) -> Result<bool, AppError> {
+    validate_id("holding ID", &id.0)?;
     let pool = &db.0;
     db::delete_holding(pool, &id).await.map_err(AppError::from)
 }

--- a/src-tauri/src/commands/transactions.rs
+++ b/src-tauri/src/commands/transactions.rs
@@ -4,7 +4,9 @@ use crate::db;
 use crate::error::AppError;
 use crate::types::{HoldingId, PaginatedResult, Transaction, TransactionId, TransactionInput};
 
-use super::{validate_pagination, validate_transaction_fields, DbState, RealizedGainsCacheState};
+use super::{
+    validate_id, validate_pagination, validate_transaction_fields, DbState, RealizedGainsCacheState,
+};
 
 #[tauri::command]
 pub async fn add_transaction(
@@ -62,6 +64,7 @@ pub async fn delete_transaction(
     gains_cache: State<'_, RealizedGainsCacheState>,
     id: TransactionId,
 ) -> Result<bool, AppError> {
+    validate_id("transaction ID", &id.0)?;
     let pool = &db.0;
     let result = db::delete_transaction(pool, &id)
         .await

--- a/src-tauri/src/commands_tests.rs
+++ b/src-tauri/src/commands_tests.rs
@@ -316,7 +316,12 @@ mod tests {
     // ── alert validation (exercises the real add_alert validator) ─────────────
 
     fn validate_alert(input: &PriceAlertInput) -> Result<(), crate::error::AppError> {
-        crate::commands::validate_alert_fields(input.threshold)
+        crate::commands::validate_alert_fields(
+            &input.symbol,
+            input.threshold,
+            &input.currency,
+            &input.note,
+        )
     }
 
     #[test]
@@ -379,6 +384,126 @@ mod tests {
             note: String::new(),
         };
         assert!(validate_alert(&input).is_ok());
+    }
+
+    // ── alert validation: symbol/currency/note (#647) ──────────────────────────
+
+    #[test]
+    fn add_alert_rejects_empty_symbol() {
+        let mut input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        input.symbol = "".to_string();
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
+    fn add_alert_rejects_whitespace_only_symbol() {
+        let mut input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        input.symbol = "   ".to_string();
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
+    fn add_alert_rejects_malformed_currency() {
+        let mut input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        input.currency = "".to_string();
+        assert!(validate_alert(&input).is_err());
+
+        input.currency = "A".to_string(); // too short
+        assert!(validate_alert(&input).is_err());
+
+        input.currency = "ABCD".to_string(); // too long
+        assert!(validate_alert(&input).is_err());
+
+        input.currency = "usd".to_string(); // lowercase
+        assert!(validate_alert(&input).is_err());
+
+        input.currency = "U5D".to_string(); // non-alpha
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
+    fn add_alert_accepts_two_and_three_letter_currency() {
+        let mut input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: String::new(),
+        };
+        assert!(validate_alert(&input).is_ok());
+
+        input.currency = "US".to_string();
+        assert!(validate_alert(&input).is_ok());
+    }
+
+    #[test]
+    fn add_alert_rejects_note_over_max_length() {
+        let input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: "a".repeat(501),
+        };
+        assert!(validate_alert(&input).is_err());
+    }
+
+    #[test]
+    fn add_alert_accepts_note_at_max_length() {
+        let input = PriceAlertInput {
+            symbol: "AAPL".to_string(),
+            direction: AlertDirection::Above,
+            threshold: 200.0,
+            currency: "CAD".to_string(),
+            note: "a".repeat(500),
+        };
+        assert!(validate_alert(&input).is_ok());
+    }
+
+    // ── ID validation for delete/reset commands (#648) ─────────────────────────
+
+    fn validate_id(field: &str, id: &str) -> Result<(), crate::error::AppError> {
+        crate::commands::validate_id(field, id)
+    }
+
+    #[test]
+    fn validate_id_rejects_empty_string() {
+        assert!(validate_id("holding ID", "").is_err());
+    }
+
+    #[test]
+    fn validate_id_rejects_whitespace_only_string() {
+        assert!(validate_id("holding ID", "   ").is_err());
+    }
+
+    #[test]
+    fn validate_id_rejects_non_uuid_string() {
+        assert!(validate_id("holding ID", "not-a-uuid").is_err());
+        assert!(validate_id("holding ID", "12345").is_err());
+    }
+
+    #[test]
+    fn validate_id_accepts_valid_uuid() {
+        let id = uuid::Uuid::new_v4().to_string();
+        assert!(validate_id("holding ID", &id).is_ok());
     }
 
     // ── page size validation (exercises the real *_paginated validator) ───────


### PR DESCRIPTION
## Summary
- `add_alert` (Tauri) now validates `symbol` (non-empty), `currency` (2–3 uppercase letters), and `note` (max 500 chars), in addition to the existing threshold check. Mirrored the same checks into the `portfolio-mcp` write tool (`validate_alert_currency` / `validate_alert_note` in `portfolio-mcp/src/validation.rs`) so the MCP layer can't be used to bypass validation the Tauri layer enforces.
- Added a shared `validate_id` helper (`src-tauri/src/commands/mod.rs`) that rejects empty/malformed ID strings before they reach SQLite. All entity IDs in this app are UUID v4 strings, so a malformed ID is now a clear `AppError::Validation` instead of a silent 0-rows-affected no-op. Wired into `delete_alert`, `reset_alert`, `delete_account`, `delete_transaction`, `delete_dividend`, `delete_holding`.

## Test plan
- [x] `cargo build` in `src-tauri/` — compiles clean
- [x] `cargo test` (workspace: `portfolio-tracker` + `portfolio-mcp`) — 279 + 30 tests pass, including new cases for empty/malformed symbol, currency, note length, and ID validation
- [x] `NODE_ENV=development npm test -- --run` in `frontend/` — 314 tests pass (no frontend changes; verifying no regression)
- [x] `cargo fmt --check` and `cargo clippy` clean (ran automatically via pre-push hook)

Closes #647
Closes #648