### PR TITLE
fix: locale/formatter fixes (#649, #650, #651, #652)

### DIFF
--- a/frontend/components/Analytics.tsx
+++ b/frontend/components/Analytics.tsx
@@ -169,10 +169,9 @@ function MetaCell({ value }: { value: string | number | undefined }) {
   );
 }
 
-function formatMarketCap(cap?: number, currency = 'USD'): string {
+function formatMarketCap(cap: number | undefined, currency = 'USD', locale = 'en'): string {
   if (cap == null) return '';
   const fmt = (value: number, suffix: string) => {
-    const locale = navigator.language || 'en';
     const formatted = new Intl.NumberFormat(locale, {
       style: 'decimal',
       minimumFractionDigits: 2,
@@ -183,12 +182,11 @@ function formatMarketCap(cap?: number, currency = 'USD'): string {
   if (cap >= 1e12) return fmt(cap / 1e12, 'T');
   if (cap >= 1e9) return fmt(cap / 1e9, 'B');
   if (cap >= 1e6) return fmt(cap / 1e6, 'M');
-  const locale = navigator.language || 'en';
   return `${new Intl.NumberFormat(locale, { style: 'decimal', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(cap)} ${currency}`;
 }
 
 export function Analytics() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const formatNumber = useFormatNumber();
   const [analytics, setAnalytics] = useState<PortfolioAnalytics | null>(null);
   const [loading, setLoading] = useState(false);
@@ -707,7 +705,11 @@ export function Analytics() {
                         }
                       />
                       <MetaCell
-                        value={meta.marketCap != null ? formatMarketCap(meta.marketCap) : undefined}
+                        value={
+                          meta.marketCap != null
+                            ? formatMarketCap(meta.marketCap, undefined, i18n.language)
+                            : undefined
+                        }
                       />
                     </tr>
                   ))}

--- a/frontend/components/Holdings.tsx
+++ b/frontend/components/Holdings.tsx
@@ -825,12 +825,12 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
               {[
                 {
                   label: 'Assigned Target',
-                  value: `${rebalanceSummary.totalTargetWeight.toFixed(1)}%`,
+                  value: `${formatNumber(rebalanceSummary.totalTargetWeight, 1)}%`,
                   tone: 'var(--text-primary)',
                 },
                 {
                   label: 'Unassigned Target',
-                  value: `${rebalanceSummary.unassignedTargetWeight.toFixed(1)}%`,
+                  value: `${formatNumber(rebalanceSummary.unassignedTargetWeight, 1)}%`,
                   tone: 'var(--text-secondary)',
                 },
                 {
@@ -972,7 +972,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                           textAlign: 'right',
                         }}
                       >
-                        {group.totalWeight.toFixed(1)}%
+                        {formatNumber(group.totalWeight, 1)}%
                       </span>
                     </button>
                     {/* Holdings rows */}
@@ -1143,7 +1143,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                       color: 'var(--text-secondary)',
                                     }}
                                   >
-                                    {h.weight.toFixed(1)}%
+                                    {formatNumber(h.weight, 1)}%
                                   </td>
                                   <td
                                     style={{
@@ -1368,7 +1368,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                                   color: 'var(--text-secondary)',
                                 }}
                               >
-                                {(group.totalWeight * 100).toFixed(2)}%
+                                {formatNumber(group.totalWeight * 100, 2)}%
                               </td>
                               <td colSpan={3} style={TD} />
                               <td
@@ -1749,7 +1749,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                               color: 'var(--text-secondary)',
                             }}
                           >
-                            {h.weight.toFixed(1)}%
+                            {formatNumber(h.weight, 1)}%
                           </td>
                         )}
                         {!hiddenColumns.has('targetWeight') && (
@@ -2108,7 +2108,7 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
                           fontSize: 13,
                         }}
                       >
-                        {totals.targetWeight > 0 ? `${totals.targetWeight.toFixed(1)}%` : '—'}
+                        {totals.targetWeight > 0 ? `${formatNumber(totals.targetWeight, 1)}%` : '—'}
                       </td>
                     )}
                     {!hiddenColumns.has('targetDeltaPercent') && (

--- a/frontend/components/Performance.tsx
+++ b/frontend/components/Performance.tsx
@@ -12,9 +12,10 @@ import {
   Cell,
 } from 'recharts';
 import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { ALL_PERF_DATA, calcStats, filterByRange } from '../lib/perfMockData';
 import type { PerfDataPoint } from '../lib/perfMockData';
-import { formatCompact, formatPercent } from '../lib/format';
+import { formatCompact, formatNumber, formatPercent } from '../lib/format';
 import { useFormatCurrency } from '../hooks/useFormatters';
 import { pnlColor } from '../lib/colors';
 import { ACCOUNT_OPTIONS, ASSET_TYPE_CONFIG } from '../lib/constants';
@@ -139,6 +140,7 @@ function CustomTooltip({
 }
 
 export function Performance({ portfolio, onRefresh }: PerformanceProps) {
+  const { i18n } = useTranslation();
   const formatCurrency = useFormatCurrency();
   const [searchParams, setSearchParams] = useSearchParams();
   const range = (searchParams.get('range') as Range) || '1Y';
@@ -408,7 +410,7 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border-subtle)" vertical={false} />
             <XAxis dataKey="date" hide />
             <YAxis
-              tickFormatter={(v) => `${v.toFixed(1)}%`}
+              tickFormatter={(v) => `${formatNumber(v, 1, i18n.language)}%`}
               tick={{ fill: 'var(--text-muted)', fontSize: 9, fontFamily: 'var(--font-mono)' }}
               axisLine={false}
               tickLine={false}
@@ -422,7 +424,10 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
                 fontSize: 11,
                 fontFamily: 'var(--font-mono)',
               }}
-              formatter={(v: unknown) => [`${Number(v).toFixed(2)}%`, 'Daily Return']}
+              formatter={(v: unknown) => [
+                `${formatNumber(Number(v), 2, i18n.language)}%`,
+                'Daily Return',
+              ]}
               labelStyle={{ color: 'var(--text-secondary)' }}
             />
             <Bar dataKey="dailyReturn" maxBarSize={8}>
@@ -462,13 +467,13 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
             },
             {
               label: 'Max Drawdown',
-              value: `-${stats.maxDrawdown.toFixed(1)}%`,
+              value: `-${formatNumber(stats.maxDrawdown, 1, i18n.language)}%`,
               sub: 'peak to trough',
               color: 'var(--color-loss)',
             },
             {
               label: 'Annualized Volatility',
-              value: `${stats.volatility.toFixed(1)}%`,
+              value: `${formatNumber(stats.volatility, 1, i18n.language)}%`,
               sub: 'std dev of daily returns',
               color: 'var(--color-warning)',
             },

--- a/frontend/components/ResilienceSummary.tsx
+++ b/frontend/components/ResilienceSummary.tsx
@@ -1,5 +1,6 @@
 // ─── Portfolio resilience summary panel for stress test ──────────────────────
 import { formatCompact } from '../lib/format';
+import { useFormatNumber } from '../hooks/useFormatters';
 import type { PortfolioSnapshot } from '../types/portfolio';
 
 const PANEL: React.CSSProperties = {
@@ -58,6 +59,8 @@ export interface ResilienceSummaryProps {
 
 // ─── ResilienceSummary component ──────────────────────────────────────────────
 export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
+  const formatNumber = useFormatNumber();
+
   if (!portfolio || portfolio.holdings.length === 0) return null;
 
   const baseCurrency = portfolio.baseCurrency;
@@ -118,7 +121,7 @@ export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
           <div style={STAT_CARD}>
             <div style={STAT_LABEL}>Largest Position</div>
             <div style={STAT_VALUE}>
-              {largestHolding ? `${(largestHolding.weight * 100).toFixed(1)}%` : '—'}
+              {largestHolding ? `${formatNumber(largestHolding.weight * 100, 1)}%` : '—'}
             </div>
             <div style={STAT_SUB}>{largestHolding ? largestHolding.symbol : '—'} of portfolio</div>
           </div>
@@ -146,7 +149,7 @@ export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
                       : 'var(--color-loss)',
               }}
             >
-              {n > 0 ? `${diversificationScore.toFixed(0)} / 100` : '—'}
+              {n > 0 ? `${formatNumber(diversificationScore, 0)} / 100` : '—'}
             </div>
             <div style={STAT_SUB}>
               {n > 0
@@ -162,7 +165,7 @@ export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
           {/* FX exposure */}
           <div style={STAT_CARD}>
             <div style={STAT_LABEL}>Foreign Currency Exposure</div>
-            <div style={STAT_VALUE}>{fxExposurePct.toFixed(1)}%</div>
+            <div style={STAT_VALUE}>{formatNumber(fxExposurePct, 1)}%</div>
             <div style={STAT_SUB}>
               {formatCompact(fxExposureValue)} in non-{baseCurrency}
             </div>
@@ -182,7 +185,7 @@ export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
                       : 'var(--text-secondary)',
               }}
             >
-              {cashPct.toFixed(1)}%
+              {formatNumber(cashPct, 1)}%
             </div>
             <div style={STAT_SUB}>{formatCompact(cashValue)} in cash positions</div>
           </div>

--- a/frontend/components/Settings.tsx
+++ b/frontend/components/Settings.tsx
@@ -594,7 +594,9 @@ export function Settings() {
           <Select
             value={language}
             onChange={(code) => {
-              void setLanguage(code);
+              // setLanguage already logs failures internally; swallow here so a
+              // rejected locale load doesn't surface as an unhandled rejection.
+              setLanguage(code).catch(() => {});
             }}
             options={languageOptions}
             style={{ minWidth: 200 }}

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -157,7 +157,7 @@ export function TopBar({
   failedSymbols = [],
   countdown = null,
 }: TopBarProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { pathname } = useLocation();
   const titleKey = ROUTE_TITLE_KEYS[pathname];
   const title = titleKey
@@ -288,7 +288,9 @@ export function TopBar({
           <AlertTriangle size={12} />
           <span>
             Offline — showing last-known portfolio
-            {portfolio?.lastUpdated ? ` (${new Date(portfolio.lastUpdated).toLocaleString()})` : ''}
+            {portfolio?.lastUpdated
+              ? ` (${new Date(portfolio.lastUpdated).toLocaleString(i18n.language)})`
+              : ''}
           </span>
           <button
             onClick={onRefresh}

--- a/frontend/components/__tests__/Analytics.test.tsx
+++ b/frontend/components/__tests__/Analytics.test.tsx
@@ -8,7 +8,7 @@ import type { PortfolioAnalytics } from '../../types/portfolio';
 import i18next from '../../lib/i18n';
 
 const mockAnalytics: PortfolioAnalytics = {
-  metadata: [{ symbol: 'AAPL', beta: 1.2, peRatio: 25.5 }],
+  metadata: [{ symbol: 'AAPL', beta: 1.2, peRatio: 25.5, marketCap: 2_500_000_000 }],
   riskMetrics: {
     weightedBeta: 1234.5,
     portfolioYield: 0.05,
@@ -58,5 +58,28 @@ describe('Analytics risk metric formatting', () => {
     await waitFor(() => expect(screen.getByText('1.234,50')).toBeTruthy());
     // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
     expect(screen.queryByText('1234.50')).toBeNull();
+  });
+
+  it('renders market cap using the i18next locale, not navigator.language', async () => {
+    const originalLanguage = Object.getOwnPropertyDescriptor(window.navigator, 'language');
+    Object.defineProperty(window.navigator, 'language', {
+      value: 'en-US',
+      configurable: true,
+    });
+
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderAnalytics();
+    screen.getByRole('button').click();
+
+    await waitFor(() => expect(screen.getByText('2,50B USD')).toBeTruthy());
+    // Guard against the pre-fix behavior (navigator.language driving the format instead of i18next).
+    expect(screen.queryByText('2.50B USD')).toBeNull();
+
+    if (originalLanguage) {
+      Object.defineProperty(window.navigator, 'language', originalLanguage);
+    }
   });
 });

--- a/frontend/components/__tests__/Holdings.test.tsx
+++ b/frontend/components/__tests__/Holdings.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Holdings } from '../Holdings';
 import type { HoldingWithPrice, PortfolioSnapshot } from '../../types/portfolio';
@@ -184,5 +184,46 @@ describe('Holdings target weight null vs explicit-0 display', () => {
     renderHoldings();
 
     expect(screen.getByText('-20.00%')).toBeTruthy();
+  });
+});
+
+describe('Holdings locale-aware weight formatting', () => {
+  it('renders the per-holding weight column with German locale separators (flat view)', async () => {
+    showAllColumns();
+    const holding = makeHolding({ weight: 20 });
+    mockHoldings = [holding];
+    mockPortfolio = { ...MOCK_SNAPSHOT, holdings: [holding] } as PortfolioSnapshot;
+
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderHoldings();
+
+    expect(screen.getByText('20,0%')).toBeTruthy();
+    // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
+    expect(screen.queryByText('20.0%')).toBeNull();
+  });
+
+  it('renders the group weight badge and total with German locale separators (grouped view)', async () => {
+    showAllColumns();
+    const holding = makeHolding({ weight: 20, account: 'taxable' });
+    mockHoldings = [holding];
+    mockPortfolio = { ...MOCK_SNAPSHOT, holdings: [holding] } as PortfolioSnapshot;
+
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderHoldings();
+    await act(async () => {
+      screen.getByTitle('Group by account').click();
+    });
+
+    // Group weight badge + per-holding weight cell both render "20,0%" in de
+    expect(screen.getAllByText('20,0%').length).toBeGreaterThanOrEqual(2);
+    // Group footer total: (group.totalWeight * 100).toFixed(2) -> "2.000,00%" in de
+    expect(screen.getByText('2.000,00%')).toBeTruthy();
+    expect(screen.queryByText('2000.00%')).toBeNull();
   });
 });

--- a/frontend/components/__tests__/Performance.test.tsx
+++ b/frontend/components/__tests__/Performance.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Performance } from '../Performance';
 import type { PortfolioSnapshot } from '../../types/portfolio';
 import { MOCK_SNAPSHOT } from '../../lib/mockData';
+
+// Initialize i18n (Performance uses useTranslation for locale-aware number formatting)
+import i18next from '../../lib/i18n';
 
 vi.mock('../../lib/tauri', () => ({
   isTauri: () => false,
@@ -17,6 +20,12 @@ beforeEach(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
   vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    await i18next.changeLanguage('en');
+  });
 });
 
 function renderPerformance(props: { portfolio: PortfolioSnapshot | null; onRefresh?: () => void }) {
@@ -74,5 +83,23 @@ describe('Performance component', () => {
     renderPerformance({ portfolio: null, onRefresh });
     // With null portfolio, renders the "No portfolio data" empty state (no action shown)
     expect(screen.getByText(/no portfolio data available/i)).toBeTruthy();
+  });
+
+  it('renders Max Drawdown and Annualized Volatility with German locale separators', async () => {
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderPerformance({ portfolio: MOCK_SNAPSHOT as PortfolioSnapshot });
+
+    const maxDrawdownValue = screen.getByText('Max Drawdown').nextElementSibling?.textContent;
+    const volatilityValue =
+      screen.getByText('Annualized Volatility').nextElementSibling?.textContent;
+
+    expect(maxDrawdownValue).toMatch(/^-\d+,\d%$/);
+    expect(volatilityValue).toMatch(/^\d+,\d%$/);
+    // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
+    expect(maxDrawdownValue).not.toMatch(/\./);
+    expect(volatilityValue).not.toMatch(/\./);
   });
 });

--- a/frontend/components/__tests__/ResilienceSummary.test.tsx
+++ b/frontend/components/__tests__/ResilienceSummary.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { ResilienceSummary } from '../ResilienceSummary';
+import type { HoldingWithPrice, PortfolioSnapshot } from '../../types/portfolio';
+
+// Initialize i18n (ResilienceSummary uses useFormatNumber, which subscribes to i18next)
+import i18next from '../../lib/i18n';
+
+function makeHolding(overrides: Partial<HoldingWithPrice> = {}): HoldingWithPrice {
+  return {
+    id: 'h1',
+    symbol: 'AAPL',
+    name: 'Apple',
+    assetType: 'stock',
+    account: 'taxable',
+    quantity: 10,
+    costBasis: 150,
+    currency: 'USD',
+    exchange: 'NASDAQ',
+    targetWeight: null,
+    weight: 12.34,
+    currentPrice: 200,
+    currentPriceCad: 280,
+    marketValueCad: 2800,
+    costValueCad: 2100,
+    gainLoss: 700,
+    gainLossPercent: 33.3,
+    targetValue: 0,
+    targetDeltaValue: 0,
+    targetDeltaPercent: 0,
+    dailyChangePercent: 0.5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    indicatedAnnualDividend: null,
+    indicatedAnnualDividendCurrency: null,
+    dividendFrequency: null,
+    maturityDate: null,
+    fxStale: false,
+    priceIsStale: false,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(holdings: HoldingWithPrice[]): PortfolioSnapshot {
+  const totalValue = holdings.reduce((s, h) => s + h.marketValueCad, 0);
+  return {
+    holdings,
+    totalValue,
+    totalCost: 0,
+    totalGainLoss: 0,
+    totalGainLossPercent: 0,
+    dailyPnl: 0,
+    lastUpdated: '2024-01-01T00:00:00Z',
+    baseCurrency: 'CAD',
+    totalTargetWeight: 0,
+    targetCashDelta: 0,
+    realizedGains: 0,
+    annualDividendIncome: 0,
+  };
+}
+
+afterEach(async () => {
+  await act(async () => {
+    await i18next.changeLanguage('en');
+  });
+});
+
+describe('ResilienceSummary locale-aware formatting', () => {
+  it('renders the largest position weight with German locale separators', async () => {
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    const holding = makeHolding({ weight: 12.34 });
+    render(<ResilienceSummary portfolio={makeSnapshot([holding])} />);
+
+    // weight * 100 = 1234 -> "1.234,0" in de-DE (period thousands, comma decimal)
+    expect(screen.getByText('1.234,0%')).toBeTruthy();
+    // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
+    expect(screen.queryByText('1234.0%')).toBeNull();
+  });
+});

--- a/frontend/components/__tests__/TopBar.test.tsx
+++ b/frontend/components/__tests__/TopBar.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TopBar } from '../TopBar';
+import type { PortfolioSnapshot } from '../../types/portfolio';
+
+// Initialize i18n (TopBar uses useTranslation)
+import i18next from '../../lib/i18n';
+
+const mockPortfolio: PortfolioSnapshot = {
+  holdings: [],
+  totalValue: 1000,
+  totalCost: 900,
+  totalGainLoss: 100,
+  totalGainLossPercent: 11.1,
+  dailyPnl: 10,
+  lastUpdated: '2024-03-05T14:30:00Z',
+  baseCurrency: 'CAD',
+  totalTargetWeight: 0,
+  targetCashDelta: 0,
+  realizedGains: 0,
+  annualDividendIncome: 0,
+};
+
+afterEach(async () => {
+  await act(async () => {
+    await i18next.changeLanguage('en');
+  });
+});
+
+function renderTopBar(overrides: Partial<React.ComponentProps<typeof TopBar>> = {}) {
+  return render(
+    <MemoryRouter>
+      <TopBar
+        portfolio={mockPortfolio}
+        loading={false}
+        isOffline={true}
+        onRefresh={vi.fn()}
+        baseCurrency="CAD"
+        onBaseCurrencyChange={vi.fn()}
+        {...overrides}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('TopBar offline banner locale-aware date formatting', () => {
+  it('formats the last-updated timestamp using the active i18next locale, not the environment default', async () => {
+    await act(async () => {
+      await i18next.changeLanguage('de');
+    });
+
+    renderTopBar();
+
+    const expectedDe = new Date(mockPortfolio.lastUpdated).toLocaleString('de');
+    const unlocalized = new Date(mockPortfolio.lastUpdated).toLocaleString();
+
+    expect(screen.getByText(new RegExp(expectedDe.replace(/[.,]/g, '\\$&')))).toBeTruthy();
+    // Guard against the pre-fix behavior (toLocaleString() with no locale arg, ignoring i18next).
+    if (expectedDe !== unlocalized) {
+      expect(screen.queryByText(new RegExp(unlocalized.replace(/[.,]/g, '\\$&')))).toBeNull();
+    }
+  });
+});

--- a/frontend/hooks/__tests__/useActionInsights.test.ts
+++ b/frontend/hooks/__tests__/useActionInsights.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import type { TFunction } from 'i18next';
 import { buildInsights } from '../useActionInsights';
 import type { HoldingWithPrice, PortfolioSnapshot } from '../../types/portfolio';
+
+// Initialize i18n (buildInsights defaults to it, and locale-formatting tests use it directly)
+import i18next from '../../lib/i18n';
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -354,5 +358,35 @@ describe('buildInsights', () => {
     expect(infoIdx).toBeGreaterThanOrEqual(0);
     expect(criticalIdx).toBeLessThan(warningIdx);
     expect(warningIdx).toBeLessThan(infoIdx);
+  });
+});
+
+describe('buildInsights localization', () => {
+  it('routes title/explanation/action text through the provided translate function', () => {
+    const holding = makeHolding({ targetWeight: 20, weight: 32, marketValueCad: 3200 });
+    const snapshot = makeSnapshot([holding]);
+    const fakeT = vi.fn((key: string) => `translated:${key}`);
+
+    const insights = buildInsights(snapshot, [holding], fakeT as unknown as TFunction, 'en');
+    const drift = insights.find((i) => i.type === 'target_drift');
+
+    expect(fakeT).toHaveBeenCalledWith('insights.targetDrift.action');
+    expect(drift!.action).toBe('translated:insights.targetDrift.action');
+    // Guard against the pre-fix behavior (hardcoded English strings, ignoring the translate fn).
+    expect(drift!.action).not.toBe('Review Rebalance');
+  });
+
+  it('formats interpolated numbers in title/explanation using the provided locale', () => {
+    const holding = makeHolding({ targetWeight: 20, weight: 32, marketValueCad: 3200 });
+    const snapshot = makeSnapshot([holding]);
+
+    const insights = buildInsights(snapshot, [holding], i18next.t.bind(i18next), 'de');
+    const drift = insights.find((i) => i.type === 'target_drift');
+
+    expect(drift!.title).toContain('12,0');
+    expect(drift!.explanation).toContain('32,0');
+    expect(drift!.explanation).toContain('20,0');
+    // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
+    expect(drift!.title).not.toMatch(/12\.0/);
   });
 });

--- a/frontend/hooks/__tests__/useLanguage.test.ts
+++ b/frontend/hooks/__tests__/useLanguage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
 beforeEach(() => {
@@ -73,5 +73,31 @@ describe('useLanguage (non-Tauri path)', () => {
       expect(lang.name).toBeTruthy();
       expect(lang.nativeName).toBeTruthy();
     }
+  });
+
+  it('setLanguage logs and rejects when i18next.changeLanguage fails, without persisting the change', async () => {
+    const { useLanguage } = await import('../../hooks/useLanguage');
+    const { default: i18next } = await import('../../lib/i18n');
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const changeLanguageSpy = vi
+      .spyOn(i18next, 'changeLanguage')
+      .mockRejectedValueOnce(new Error('locale bundle failed to load'));
+
+    const { result } = renderHook(() => useLanguage());
+    await waitFor(() => expect(result.current.language).toBeDefined());
+
+    await expect(
+      act(async () => {
+        await result.current.setLanguage('de');
+      })
+    ).rejects.toThrow('locale bundle failed to load');
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    // Guard against the pre-fix behavior (silent failure — localStorage still updated despite the rejection).
+    expect(localStorage.getItem('app_language')).toBeNull();
+
+    changeLanguageSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/frontend/hooks/useActionInsights.ts
+++ b/frontend/hooks/useActionInsights.ts
@@ -1,4 +1,8 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
+import i18next from '../lib/i18n';
+import { formatNumber } from '../lib/format';
 import type {
   ActionInsight,
   HoldingWithPrice,
@@ -18,7 +22,9 @@ const SEVERITY_RANK: Record<InsightSeverity, number> = {
 
 export function buildInsights(
   snapshot: PortfolioSnapshot,
-  holdings: HoldingWithPrice[]
+  holdings: HoldingWithPrice[],
+  t: TFunction = i18next.t,
+  locale: string = i18next.language
 ): ActionInsight[] {
   if (holdings.length === 0 || snapshot.totalValue <= 0) return [];
 
@@ -33,6 +39,7 @@ export function buildInsights(
     if (drift <= 5) continue;
 
     const severity: InsightSeverity = drift > 10 ? 'critical' : 'warning';
+    // Plain (non-localized) decimal strings for metrics — parsed via parseFloat() during sorting.
     const driftPct = drift.toFixed(1);
     const actualPct = holding.weight.toFixed(1);
     const targetPct = holding.targetWeight.toFixed(1);
@@ -44,14 +51,21 @@ export function buildInsights(
       type: 'target_drift',
       severity,
       direction: insightDirection,
-      title: `${holding.symbol} is ${direction} by ${driftPct}%`,
-      explanation: `Current weight ${actualPct}% vs target ${targetPct}%. Consider rebalancing.`,
+      title: t('insights.targetDrift.title', {
+        symbol: holding.symbol,
+        direction: t(`insights.targetDrift.${direction}`),
+        pct: formatNumber(drift, 1, locale),
+      }),
+      explanation: t('insights.targetDrift.explanation', {
+        actual: formatNumber(holding.weight, 1, locale),
+        target: formatNumber(holding.targetWeight, 1, locale),
+      }),
       metrics: {
         current: actualPct,
         target: targetPct,
         drift: driftPct,
       },
-      action: 'Review Rebalance',
+      action: t('insights.targetDrift.action'),
       linkTo: '/rebalance',
     });
   }
@@ -68,12 +82,15 @@ export function buildInsights(
       type: 'concentration_risk',
       severity,
       direction: 'sell' as InsightDirection,
-      title: `${holding.symbol} dominates the portfolio`,
-      explanation: `${holding.symbol} represents ${weightPct.toFixed(1)}% of portfolio — consider diversifying.`,
+      title: t('insights.concentrationRisk.title', { symbol: holding.symbol }),
+      explanation: t('insights.concentrationRisk.explanation', {
+        symbol: holding.symbol,
+        weight: formatNumber(weightPct, 1, locale),
+      }),
       metrics: {
         weight: weightPct.toFixed(1),
       },
-      action: 'View Holdings',
+      action: t('insights.concentrationRisk.action'),
       linkTo: '/holdings',
     });
   }
@@ -89,12 +106,14 @@ export function buildInsights(
       type: 'idle_cash',
       severity: 'info',
       direction: 'buy' as InsightDirection,
-      title: 'High cash allocation',
-      explanation: `Cash represents ${cashPct.toFixed(1)}% of portfolio — consider deploying.`,
+      title: t('insights.idleCash.title'),
+      explanation: t('insights.idleCash.explanation', {
+        pct: formatNumber(cashPct, 1, locale),
+      }),
       metrics: {
         cashPct: cashPct.toFixed(1),
       },
-      action: 'View Holdings',
+      action: t('insights.idleCash.action'),
       linkTo: '/holdings',
     });
   }
@@ -107,13 +126,16 @@ export function buildInsights(
       type: 'missing_targets',
       severity: 'info',
       direction: 'review' as InsightDirection,
-      title: 'Target weights not set',
-      explanation: `${withoutTarget.length} of ${holdings.length} holdings have no target weight. Set targets to enable rebalancing recommendations.`,
+      title: t('insights.missingTargets.title'),
+      explanation: t('insights.missingTargets.explanation', {
+        missing: withoutTarget.length,
+        total: holdings.length,
+      }),
       metrics: {
         missing: withoutTarget.length,
         total: holdings.length,
       },
-      action: 'Set Targets',
+      action: t('insights.missingTargets.action'),
       linkTo: '/rebalance',
     });
   }
@@ -135,8 +157,9 @@ export function useActionInsights(
   snapshot: PortfolioSnapshot | null,
   holdings: HoldingWithPrice[]
 ): ActionInsight[] {
+  const { t, i18n } = useTranslation();
   return useMemo(() => {
     if (!snapshot) return [];
-    return buildInsights(snapshot, holdings);
-  }, [snapshot, holdings]);
+    return buildInsights(snapshot, holdings, t, i18n.language);
+  }, [snapshot, holdings, t, i18n.language]);
 }

--- a/frontend/hooks/useLanguage.ts
+++ b/frontend/hooks/useLanguage.ts
@@ -37,8 +37,16 @@ export function useLanguage() {
   }, []);
 
   const setLanguage = async (code: string) => {
+    const previous = language;
     setLanguageState(code);
-    await i18next.changeLanguage(code);
+    try {
+      await i18next.changeLanguage(code);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to change language:', error);
+      setLanguageState(previous);
+      throw error;
+    }
     // Mirror to localStorage even in Tauri mode: i18n.ts's synchronous
     // pre-render init only has access to localStorage, not the async Tauri
     // config store, so this cache is what prevents a language flash on the

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -303,5 +303,20 @@
   "transactions.columns.quantity": "Quantity",
   "transactions.columns.price": "Price",
   "transactions.columns.total": "Total Value",
-  "transactions.columns.actions": "Actions"
+  "transactions.columns.actions": "Actions",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/es/translation.json
+++ b/frontend/locales/es/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/fr/translation.json
+++ b/frontend/locales/fr/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/ja/translation.json
+++ b/frontend/locales/ja/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/pl/translation.json
+++ b/frontend/locales/pl/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/pt/translation.json
+++ b/frontend/locales/pt/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }

--- a/frontend/locales/zh/translation.json
+++ b/frontend/locales/zh/translation.json
@@ -282,5 +282,20 @@
   "help.term.dividend": "Dividend",
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
-  "help.def.yield": "Annual dividend payment as a percentage of the current share price."
+  "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
+
+  "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
+  "insights.targetDrift.overweight": "overweight",
+  "insights.targetDrift.underweight": "underweight",
+  "insights.targetDrift.explanation": "Current weight {{actual}}% vs target {{target}}%. Consider rebalancing.",
+  "insights.targetDrift.action": "Review Rebalance",
+  "insights.concentrationRisk.title": "{{symbol}} dominates the portfolio",
+  "insights.concentrationRisk.explanation": "{{symbol}} represents {{weight}}% of portfolio — consider diversifying.",
+  "insights.concentrationRisk.action": "View Holdings",
+  "insights.idleCash.title": "High cash allocation",
+  "insights.idleCash.explanation": "Cash represents {{pct}}% of portfolio — consider deploying.",
+  "insights.idleCash.action": "View Holdings",
+  "insights.missingTargets.title": "Target weights not set",
+  "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
+  "insights.missingTargets.action": "Set Targets"
 }


### PR DESCRIPTION
## Summary
- Analytics.tsx's `formatMarketCap` used `navigator.language` instead of the active i18next locale for `Intl.NumberFormat` — fixed to use `i18n.language`.
- Replaced raw `toFixed()` calls with locale-aware formatting (`formatNumber`/`useFormatNumber`) in ResilienceSummary, Performance, and Holdings; fixed TopBar's unlocalized `toLocaleString()` on the offline-banner timestamp.
- `useActionInsights`'s `buildInsights` built title/explanation strings with hardcoded English text and raw `toFixed()`. It now accepts a translate function and locale, routes all user-facing strings through new `insights.*` i18next keys, and formats interpolated numbers per-locale. New keys were added to all 8 locale files (non-English stubbed with the English copy as a placeholder for translators).
- `useLanguage.setLanguage` silently swallowed `i18next.changeLanguage()` failures. It now logs the error, reverts the optimistic language state, and rethrows so the rejection is surfaced to the caller (Settings.tsx's caller updated accordingly).

## Test plan
- [x] `NODE_ENV=development npm run typecheck` — no errors
- [x] `NODE_ENV=development npm test -- --run` — 323/323 frontend tests pass, including new locale-aware regression tests for each fix
- [x] `NODE_ENV=development npx eslint frontend --max-warnings 0` — clean
- [x] Pre-push hooks (lint, typecheck, format, frontend build, backend build, frontend tests, backend tests, clippy) — all passed

Closes #649
Closes #650
Closes #651
Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)