### PR TITLE
fix: high-priority and security fixes (#669, #670, #699, #681)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ts-rs",
+ "urlencoding",
  "uuid",
 ]
 
@@ -5511,6 +5512,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/frontend/components/ResilienceSummary.tsx
+++ b/frontend/components/ResilienceSummary.tsx
@@ -121,7 +121,7 @@ export function ResilienceSummary({ portfolio }: ResilienceSummaryProps) {
           <div style={STAT_CARD}>
             <div style={STAT_LABEL}>Largest Position</div>
             <div style={STAT_VALUE}>
-              {largestHolding ? `${formatNumber(largestHolding.weight * 100, 1)}%` : '—'}
+              {largestHolding ? `${formatNumber(largestHolding.weight, 1)}%` : '—'}
             </div>
             <div style={STAT_SUB}>{largestHolding ? largestHolding.symbol : '—'} of portfolio</div>
           </div>

--- a/frontend/components/__tests__/ResilienceSummary.test.tsx
+++ b/frontend/components/__tests__/ResilienceSummary.test.tsx
@@ -74,9 +74,30 @@ describe('ResilienceSummary locale-aware formatting', () => {
     const holding = makeHolding({ weight: 12.34 });
     render(<ResilienceSummary portfolio={makeSnapshot([holding])} />);
 
-    // weight * 100 = 1234 -> "1.234,0" in de-DE (period thousands, comma decimal)
-    expect(screen.getByText('1.234,0%')).toBeTruthy();
+    // weight is already a 0-100 percentage -> "12,3" in de-DE (comma decimal, rounded to 1dp)
+    expect(screen.getByText('12,3%')).toBeTruthy();
     // Guard against the pre-fix behavior (raw toFixed() always uses '.' regardless of locale).
-    expect(screen.queryByText('1234.0%')).toBeNull();
+    expect(screen.queryByText('12.3%')).toBeNull();
+  });
+});
+
+describe('ResilienceSummary largest position percentage (#699)', () => {
+  it('displays the weight value directly, without multiplying by 100 again', () => {
+    // weight is already expressed on a 0-100 scale by the backend (see
+    // portfolio-core/src/snapshot.rs: `holding.weight = market_value / total * 100.0`),
+    // so a 45% position must render as "45.0%", not "4500.0%".
+    const holding = makeHolding({ weight: 45.0 });
+    render(<ResilienceSummary portfolio={makeSnapshot([holding])} />);
+
+    expect(screen.getByText('45.0%')).toBeTruthy();
+    expect(screen.queryByText('4500.0%')).toBeNull();
+  });
+
+  it('handles a small weight without an extra order-of-magnitude error', () => {
+    const holding = makeHolding({ weight: 3.7 });
+    render(<ResilienceSummary portfolio={makeSnapshot([holding])} />);
+
+    expect(screen.getByText('3.7%')).toBeTruthy();
+    expect(screen.queryByText('370.0%')).toBeNull();
   });
 });

--- a/frontend/lib/__tests__/scenarioMath.test.ts
+++ b/frontend/lib/__tests__/scenarioMath.test.ts
@@ -147,6 +147,40 @@ describe('computeStressImpact', () => {
     expect(result.totalImpact).toBeCloseTo(-value, 3);
   });
 
+  it('floors a holding at zero for a shock beyond -100% (#681)', () => {
+    // A -150% shock: without the `Math.max(0, ...)` floor, `value * (1 - 1.5)`
+    // works out to -5,000 — a holding can't lose more than its full value.
+    const value = 10_000;
+    const snapshot = makeSnapshot([makeHolding('BTC', 'crypto', 'CAD', value)]);
+    const scenario: StressScenario = { name: 'Beyond total loss', shocks: { crypto: -1.5 } };
+
+    const result = computeStressImpact(snapshot, scenario);
+    const btc = result.holdingBreakdown.find((h) => h.symbol === 'BTC')!;
+
+    expect(btc.stressedValue).toBe(0);
+    expect(btc.stressedValue).toBeGreaterThanOrEqual(0);
+    expect(result.stressedValue).toBeGreaterThanOrEqual(0);
+    expect(result.stressedValue).toBe(0);
+    // Impact is still capped at losing the full original value, not more.
+    expect(result.totalImpact).toBeCloseTo(-value, 3);
+  });
+
+  it('floors the portfolio total at zero when a mixed portfolio shock goes past -100%', () => {
+    const snapshot = makeSnapshot([
+      makeHolding('BTC', 'crypto', 'CAD', 5_000),
+      makeHolding('ETH', 'crypto', 'CAD', 3_000),
+    ]);
+    const scenario: StressScenario = { name: 'Crypto wipeout', shocks: { crypto: -2.0 } };
+
+    const result = computeStressImpact(snapshot, scenario);
+
+    for (const h of result.holdingBreakdown) {
+      expect(h.stressedValue).toBeGreaterThanOrEqual(0);
+    }
+    expect(result.stressedValue).toBeGreaterThanOrEqual(0);
+    expect(result.stressedValue).toBe(0);
+  });
+
   it('handles an empty portfolio without producing NaN', () => {
     const snapshot = makeSnapshot([]);
     const scenario: StressScenario = { name: 'Empty', shocks: {} };

--- a/frontend/lib/scenarioMath.ts
+++ b/frontend/lib/scenarioMath.ts
@@ -31,7 +31,9 @@ export function computeStressImpact(
         : (scenario.shocks[fxShockKey(h.currency, snapshot.baseCurrency)] ?? 0);
 
     const currentValue = h.marketValueCad;
-    const stressedValue = currentValue * (1 + assetShock) * (1 + fxShock);
+    // Floor at zero to match `portfolio-core/src/stress.rs`'s `.max(0.0)` — a
+    // combined shock below -100% must not drive a holding's value negative.
+    const stressedValue = Math.max(0, currentValue * (1 + assetShock) * (1 + fxShock));
     const impact = stressedValue - currentValue;
     const shockApplied = (1 + assetShock) * (1 + fxShock) - 1;
 
@@ -48,14 +50,18 @@ export function computeStressImpact(
     };
   });
 
+  // Mirrors the redundant-but-explicit floor on the Rust side (portfolio-core's
+  // `total_stressed.max(0.0)`) for exact parity, even though summing already
+  // non-negative per-holding values can't itself go negative.
+  const stressedValueTotal = Math.max(0, totalStressed);
   const currentValue = snapshot.totalValue;
-  const totalImpact = totalStressed - currentValue;
+  const totalImpact = stressedValueTotal - currentValue;
   const totalImpactPercent = currentValue !== 0 ? (totalImpact / currentValue) * 100 : 0;
 
   return {
     scenario: scenario.name,
     currentValue,
-    stressedValue: totalStressed,
+    stressedValue: stressedValueTotal,
     totalImpact,
     totalImpactPercent,
     holdingBreakdown,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 tracing-appender = "0.2"
 ts-rs = { version = "12", features = ["serde-compat"] }
+urlencoding = "2"
 
 [dev-dependencies]
 mockito = "1"

--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -65,7 +65,7 @@ fn compute_avco(transactions: &[Transaction]) -> Result<RealizedGainsSummary, St
                 }
 
                 lots.push(RealizedLot {
-                    sold_at: date_part(&tx.transacted_at),
+                    sold_at: date_part(&tx.transacted_at)?,
                     quantity: sold_qty,
                     proceeds,
                     cost_basis,
@@ -139,7 +139,7 @@ fn compute_fifo(transactions: &[Transaction]) -> Result<RealizedGainsSummary, St
                 total_cost_basis += lot_cost_basis;
 
                 lots.push(RealizedLot {
-                    sold_at: date_part(&tx.transacted_at),
+                    sold_at: date_part(&tx.transacted_at)?,
                     quantity: tx.quantity,
                     proceeds,
                     cost_basis: lot_cost_basis,
@@ -207,13 +207,15 @@ pub fn compute_realized_gains_grouped(
 }
 
 /// Extract the YYYY-MM-DD portion from an ISO 8601 timestamp.
-fn date_part(ts: &str) -> String {
-    // Use safe slicing: if the string is shorter than 10 chars (e.g. invalid
-    // timestamp), return the original string rather than panicking.
-    if ts.len() < 10 {
-        return ts.to_string();
-    }
-    ts[..10].to_string()
+///
+/// Uses `str::get` rather than byte-slicing: a fixed `&ts[..10]` panics if
+/// byte offset 10 doesn't land on a char boundary (possible with a malformed,
+/// non-ASCII `transacted_at` value). `get` returns `None` in that case instead
+/// of panicking, which we surface as an error.
+fn date_part(ts: &str) -> Result<String, String> {
+    ts.get(..10)
+        .map(str::to_string)
+        .ok_or_else(|| format!("Malformed transacted_at timestamp: {:?}", ts))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -438,7 +440,21 @@ mod tests {
 
     #[test]
     fn date_part_extracts_first_ten_chars() {
-        assert_eq!(date_part("2024-03-15T12:00:00Z"), "2024-03-15");
-        assert_eq!(date_part("2024-03-15"), "2024-03-15");
+        assert_eq!(date_part("2024-03-15T12:00:00Z").unwrap(), "2024-03-15");
+        assert_eq!(date_part("2024-03-15").unwrap(), "2024-03-15");
+    }
+
+    #[test]
+    fn date_part_rejects_string_shorter_than_ten_bytes() {
+        assert!(date_part("2024").is_err());
+    }
+
+    #[test]
+    fn date_part_rejects_non_char_boundary_instead_of_panicking() {
+        // 9 ASCII bytes followed by 'é' (2 UTF-8 bytes: 0xC3 0xA9) means byte
+        // offset 10 lands in the middle of 'é' — `&s[..10]` would panic here.
+        let malformed = "2024-03-1é";
+        assert_eq!(malformed.len(), 11, "sanity check: 11 bytes, 10 chars");
+        assert!(date_part(malformed).is_err());
     }
 }

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -22,7 +22,14 @@ async fn fetch_asset_profile(
     client: &reqwest::Client,
     symbol: &str,
 ) -> (String, Option<String>, Option<String>, Option<String>) {
-    let url = crate::config::YAHOO_QUOTE_SUMMARY_URL.replace("{}", symbol);
+    // Symbols originate from stored holdings, which aren't validated on insert,
+    // so guard against an unvalidated value reaching the URL (see #670).
+    if let Err(e) = crate::price::validate_symbol(symbol) {
+        tracing::warn!("Skipping asset profile fetch for invalid symbol: {}", e);
+        return (symbol.to_string(), None, None, None);
+    }
+    let encoded_symbol = urlencoding::encode(symbol);
+    let url = crate::config::YAHOO_QUOTE_SUMMARY_URL.replace("{}", &encoded_symbol);
 
     let json: Option<serde_json::Value> = async {
         let resp = client
@@ -103,7 +110,22 @@ pub(crate) async fn get_symbol_metadata_with_cache(
     let stale_symbols: Vec<String> = stale_indices.iter().map(|&i| symbols[i].clone()).collect();
 
     // ── 1. Bulk quote request for numeric fields ──────────────────────────────
-    let joined = stale_symbols.join(",");
+    // Validate and encode each symbol individually before joining so a single
+    // malformed symbol can't corrupt the query string or smuggle in extra
+    // characters (see #670); each encoded symbol is comma-safe since the
+    // allowed charset contains no commas.
+    let joined = stale_symbols
+        .iter()
+        .filter(|s| match crate::price::validate_symbol(s) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!("Skipping invalid symbol in bulk quote request: {}", e);
+                false
+            }
+        })
+        .map(|s| urlencoding::encode(s).into_owned())
+        .collect::<Vec<_>>()
+        .join(",");
     let quote_url = crate::config::YAHOO_QUOTE_URL.replace("{}", &joined);
 
     let quote_future = client

--- a/src-tauri/src/price.rs
+++ b/src-tauri/src/price.rs
@@ -4,6 +4,26 @@ use reqwest::Client;
 use crate::config::{USER_AGENT, YAHOO_CHART_URL};
 use crate::types::PriceData;
 
+/// Validate a ticker symbol before it is interpolated into a Yahoo Finance URL.
+///
+/// Restricts symbols to the character set Yahoo Finance actually uses (uppercase
+/// letters, digits, `.` for exchange suffixes like `.TO`, `-` for pairs like
+/// `BTC-USD`, `^` for indices like `^GSPC`, and `=` for futures/FX like `CL=F`
+/// or `EURUSD=X`), rejecting anything else — including path-traversal sequences
+/// like `../../etc/passwd` — before it ever reaches a URL.
+pub(crate) fn validate_symbol(symbol: &str) -> Result<(), String> {
+    let valid = !symbol.is_empty()
+        && symbol.len() <= 20
+        && symbol.chars().all(|c| {
+            c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '.' | '-' | '^' | '=')
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(format!("Invalid symbol format: {:?}", symbol))
+    }
+}
+
 pub async fn fetch_price(client: &Client, symbol: &str) -> Result<PriceData, String> {
     fetch_price_with_fallback_currency(client, symbol, None).await
 }
@@ -28,7 +48,9 @@ async fn fetch_price_internal(
     fallback_currency: Option<&str>,
     url_template: &str,
 ) -> Result<PriceData, String> {
-    let url = url_template.replace("{}", symbol);
+    validate_symbol(symbol)?;
+    let encoded_symbol = urlencoding::encode(symbol);
+    let url = url_template.replace("{}", &encoded_symbol);
 
     let response = client
         .get(&url)
@@ -146,6 +168,65 @@ pub async fn fetch_all_prices(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Symbol validation ─────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_symbol_accepts_normal_tickers() {
+        for sym in &["AAPL", "BTC-USD", "XIU.TO", "^GSPC", "CL=F", "EURUSD=X"] {
+            assert!(validate_symbol(sym).is_ok(), "expected {} to be valid", sym);
+        }
+    }
+
+    #[test]
+    fn validate_symbol_rejects_path_traversal() {
+        assert!(validate_symbol("../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn validate_symbol_rejects_url_special_characters() {
+        for sym in &[
+            "AAPL?x=1",
+            "AAPL&y=2",
+            "AAPL/../x",
+            "AAPL#frag",
+            "AAPL TSLA",
+        ] {
+            assert!(
+                validate_symbol(sym).is_err(),
+                "expected {} to be rejected",
+                sym
+            );
+        }
+    }
+
+    #[test]
+    fn validate_symbol_rejects_empty_and_overlong() {
+        assert!(validate_symbol("").is_err());
+        assert!(validate_symbol(&"A".repeat(21)).is_err());
+        assert!(validate_symbol(&"A".repeat(20)).is_ok());
+    }
+
+    #[test]
+    fn validate_symbol_rejects_lowercase() {
+        // Yahoo symbols are always uppercase; lowercase is rejected rather than
+        // silently normalized to avoid masking malformed input.
+        assert!(validate_symbol("aapl").is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_price_rejects_invalid_symbol_before_any_request() {
+        let client = make_client();
+        let result = fetch_price_internal(
+            &client,
+            "../../etc/passwd",
+            None,
+            "https://example.invalid/{}",
+        )
+        .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid symbol"));
+    }
 
     fn make_client() -> Client {
         Client::builder()


### PR DESCRIPTION
## Summary

- **#669**: `date_part` in `src-tauri/src/analytics.rs` byte-sliced `transacted_at` at a fixed offset, which panics if the string is shorter than expected or has a multi-byte character straddling the byte-10 boundary. Switched to `str::get(..10)`, returning a `Result` that propagates as a validation error instead of panicking.
- **#670**: Ticker symbols were interpolated unvalidated and unencoded into Yahoo Finance URLs in three places (`price.rs::fetch_price_internal`, and two spots in `commands/analytics.rs` — `fetch_asset_profile` and the bulk quote URL). Since holding symbols aren't validated on insert, a malicious symbol (e.g. `../../etc/passwd`) could reach any of these. Added a shared `validate_symbol` check (`^[A-Z0-9.\-^=]{1,20}$`) plus `urlencoding::encode` before building each URL.
- **#699**: `ResilienceSummary.tsx` displayed "Largest Position" as `weight * 100`, but the backend already returns `weight` on a 0–100 scale (`portfolio-core/src/snapshot.rs`), so a 45% position rendered as "4500%". Removed the extra `* 100`.
- **#681**: The TypeScript port of the stress-test math (`frontend/lib/scenarioMath.ts`) was missing the `.max(0.0)` floor present in `portfolio-core/src/stress.rs`, so a shock beyond -100% could drive a holding's stressed value negative. Added the matching `Math.max(0, ...)` floor at both the per-holding and portfolio-total level.

## Test plan
- [x] `cargo build` — compiles clean
- [x] `cargo test` (src-tauri) — 275 passed, including new tests: `date_part_rejects_non_char_boundary_instead_of_panicking`, `validate_symbol_rejects_path_traversal`, `fetch_price_rejects_invalid_symbol_before_any_request`
- [x] `cargo clippy` — clean
- [x] `NODE_ENV=development npm test -- --run` — 328 passed, including new tests in `ResilienceSummary.test.tsx` (#699) and `scenarioMath.test.ts` (#681)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Pre-commit and pre-push hooks passed (lint, typecheck, format, build, tests, clippy)

Closes #669
Closes #670
Closes #699
Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)