### PR TITLE
fix: backend and config bug fixes (#661, #662, #663, #671–#674, #676, #684, #691)

### DIFF
--- a/frontend/lib/__tests__/i18n.test.ts
+++ b/frontend/lib/__tests__/i18n.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import de from '../../locales/de/translation.json';
+import en from '../../locales/en/translation.json';
+import es from '../../locales/es/translation.json';
+import fr from '../../locales/fr/translation.json';
+import ja from '../../locales/ja/translation.json';
+import pl from '../../locales/pl/translation.json';
+import pt from '../../locales/pt/translation.json';
+import zh from '../../locales/zh/translation.json';
+
+type TranslationTree = { [key: string]: string | TranslationTree };
+
+function flattenKeys(tree: TranslationTree, prefix = ''): Set<string> {
+  const keys = new Set<string>();
+  for (const [key, value] of Object.entries(tree)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      for (const nested of flattenKeys(value, fullKey)) keys.add(nested);
+    } else {
+      keys.add(fullKey);
+    }
+  }
+  return keys;
+}
+
+const LOCALES: Record<string, TranslationTree> = { de, es, fr, ja, pl, pt, zh };
+
+describe('locale key parity', () => {
+  const enKeys = flattenKeys(en);
+
+  it.each(Object.entries(LOCALES))('%s has every English key', (_locale, tree) => {
+    const keys = flattenKeys(tree);
+    const missing = [...enKeys].filter((k) => !keys.has(k));
+    expect(missing).toEqual([]);
+  });
+});

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/es/translation.json
+++ b/frontend/locales/es/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/fr/translation.json
+++ b/frontend/locales/fr/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/ja/translation.json
+++ b/frontend/locales/ja/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/pl/translation.json
+++ b/frontend/locales/pl/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/pt/translation.json
+++ b/frontend/locales/pt/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/frontend/locales/zh/translation.json
+++ b/frontend/locales/zh/translation.json
@@ -283,7 +283,6 @@
   "help.def.dividend": "A payment made by a company to shareholders.",
   "help.term.yield": "Yield",
   "help.def.yield": "Annual dividend payment as a percentage of the current share price.",
-
   "insights.targetDrift.title": "{{symbol}} is {{direction}} by {{pct}}%",
   "insights.targetDrift.overweight": "overweight",
   "insights.targetDrift.underweight": "underweight",
@@ -297,5 +296,14 @@
   "insights.idleCash.action": "View Holdings",
   "insights.missingTargets.title": "Target weights not set",
   "insights.missingTargets.explanation": "{{missing}} of {{total}} holdings have no target weight. Set targets to enable rebalancing recommendations.",
-  "insights.missingTargets.action": "Set Targets"
+  "insights.missingTargets.action": "Set Targets",
+  "alerts.resetAlert": "Reset alert",
+  "alerts.emptyActive": "No active alerts. Click 'New Alert' to create one.",
+  "transactions.empty": "No transactions recorded yet.",
+  "transactions.columns.date": "Date",
+  "transactions.columns.type": "Type",
+  "transactions.columns.quantity": "Quantity",
+  "transactions.columns.price": "Price",
+  "transactions.columns.total": "Total Value",
+  "transactions.columns.actions": "Actions"
 }

--- a/portfolio-core/src/snapshot.rs
+++ b/portfolio-core/src/snapshot.rs
@@ -74,7 +74,12 @@ pub fn build_portfolio_snapshot(
             match price_map.get(&holding.symbol) {
                 Some(p) if p.price > 0.0 && p.price.is_finite() => {
                     let stale = is_price_stale(&p.updated_at);
-                    (p.price, p.change_percent, stale)
+                    let change_percent = if p.change_percent.is_finite() {
+                        p.change_percent
+                    } else {
+                        0.0
+                    };
+                    (p.price, change_percent, stale)
                 }
                 // A cached price of exactly 0.0 is ambiguous: it may be a
                 // genuinely worthless security (penny stock, delisted share,
@@ -83,10 +88,15 @@ pub fn build_portfolio_snapshot(
                 // back to cost_basis the same as a cache miss.
                 Some(p) if p.price == 0.0 => {
                     let stale = is_price_stale(&p.updated_at);
+                    let change_percent = if p.change_percent.is_finite() {
+                        p.change_percent
+                    } else {
+                        0.0
+                    };
                     if stale {
                         (holding.cost_basis, 0.0, true)
                     } else {
-                        (0.0, p.change_percent, false)
+                        (0.0, change_percent, false)
                     }
                 }
                 // Negative, infinite, or NaN prices are never legitimate — treat as a cache miss.
@@ -523,6 +533,49 @@ mod tests {
             "expected daily_pnl == 220 for prior-day holding, got {}",
             snapshot.daily_pnl
         );
+    }
+
+    #[test]
+    fn build_portfolio_snapshot_guards_non_finite_change_percent() {
+        // Regression guard for #684: a price feed returning NaN/Infinity for
+        // change_percent must not silently propagate into daily_pnl or
+        // daily_change_percent — it should be treated as 0.0, matching the
+        // is_finite() guard already applied to `price` above.
+        let yesterday = (Utc::now() - chrono::Duration::days(1))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string();
+        let mut holding = make_holding("MSFT", AssetType::Stock, 10.0, 200.0, "CAD");
+        holding.created_at = yesterday;
+
+        let prices = vec![PriceData {
+            symbol: "MSFT".to_string(),
+            price: 220.0,
+            currency: "CAD".to_string(),
+            change: f64::NAN,
+            change_percent: f64::NAN,
+            updated_at: Utc::now().to_rfc3339(),
+            open: None,
+            previous_close: None,
+            volume: None,
+        }];
+
+        let snapshot = build_portfolio_snapshot(
+            &[holding],
+            &prices,
+            &[],
+            "CAD",
+            Utc::now().to_rfc3339(),
+            0.0,
+            0.0,
+        );
+
+        assert!(
+            snapshot.daily_pnl.is_finite(),
+            "daily_pnl must stay finite when change_percent is NaN, got {}",
+            snapshot.daily_pnl
+        );
+        assert_eq!(snapshot.daily_pnl, 0.0);
+        assert_eq!(snapshot.holdings[0].daily_change_percent, 0.0);
     }
 
     #[test]

--- a/portfolio-mcp/src/tools/config.rs
+++ b/portfolio-mcp/src/tools/config.rs
@@ -46,6 +46,7 @@ pub async fn get_config(
     pool: &SqlitePool,
     params: GetConfigParams,
 ) -> Result<ConfigValue, McpError> {
+    validation::validate_config_key(&params.key)?;
     let value = db::get_config(pool, &params.key)
         .await
         .map_err(PortfolioMcpServer::tool_error)?;
@@ -54,6 +55,53 @@ pub async fn get_config(
         key: params.key,
         value,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query("CREATE TABLE app_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .expect("create app_config table");
+        pool
+    }
+
+    #[tokio::test]
+    async fn get_config_rejects_unknown_key() {
+        // Regression guard for #662: get_config previously had no allowlist
+        // check at all (unlike set_config), so any key — including
+        // internal/sensitive ones — could be read.
+        let pool = test_pool().await;
+        let result = get_config(
+            &pool,
+            GetConfigParams {
+                key: "some_internal_secret".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "unknown config key must be rejected");
+    }
+
+    #[tokio::test]
+    async fn get_config_accepts_allowed_key() {
+        let pool = test_pool().await;
+        let result = get_config(
+            &pool,
+            GetConfigParams {
+                key: "base_currency".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_ok());
+    }
 }
 
 pub async fn set_config(

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -193,6 +193,7 @@ pub const ALLOWED_CONFIG_KEYS: &[&str] = &[
     "auto_refresh_market_hours_only",
     "cost_basis_method",
     "notifications_enabled",
+    "holdings_hidden_columns",
 ];
 
 /// Mirrors the allowlist check in `src-tauri/src/commands/config.rs::set_config_cmd`.

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -16,6 +16,7 @@ const ALLOWED_CONFIG_KEYS: &[&str] = &[
     "auto_refresh_market_hours_only",
     "cost_basis_method",
     "notifications_enabled",
+    "holdings_hidden_columns",
 ];
 
 fn validate_config_key(key: &str) -> Result<(), AppError> {
@@ -92,5 +93,13 @@ mod tests {
     #[test]
     fn validate_config_key_rejects_empty_key() {
         assert!(validate_config_key("").is_err());
+    }
+
+    #[test]
+    fn validate_config_key_accepts_holdings_hidden_columns() {
+        // Regression guard for #661: the frontend persists which Holdings
+        // table columns are hidden under this key, but it was missing from
+        // the allowlist, so get/set_config_cmd rejected it.
+        assert!(validate_config_key("holdings_hidden_columns").is_ok());
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -236,7 +236,17 @@ pub(crate) fn validate_dividend_fields(
             "amountPerUnit must be a finite number greater than 0".to_string(),
         ));
     }
-    if !ex_date.trim().is_empty() && !pay_date.trim().is_empty() && pay_date < ex_date {
+    if chrono::NaiveDate::parse_from_str(ex_date.trim(), "%Y-%m-%d").is_err() {
+        return Err(AppError::Validation(
+            "exDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
+        ));
+    }
+    if chrono::NaiveDate::parse_from_str(pay_date.trim(), "%Y-%m-%d").is_err() {
+        return Err(AppError::Validation(
+            "payDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
+        ));
+    }
+    if pay_date < ex_date {
         return Err(AppError::Validation(
             "payDate must not be before exDate".to_string(),
         ));

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -19,7 +19,13 @@ pub async fn get_portfolio(
     _client: State<'_, HttpClient>,
     gains_cache: State<'_, RealizedGainsCacheState>,
 ) -> Result<PortfolioSnapshot, AppError> {
-    let pool = &db.0;
+    get_portfolio_impl(&db.0, &gains_cache).await
+}
+
+async fn get_portfolio_impl(
+    pool: &sqlx::SqlitePool,
+    gains_cache: &RealizedGainsCacheState,
+) -> Result<PortfolioSnapshot, AppError> {
     let base_currency = get_base_currency(pool).await;
 
     let holdings = db::get_all_holdings(pool).await?;
@@ -57,9 +63,8 @@ pub async fn get_portfolio(
         summary.total_realized_gain
     };
 
-    let annual_dividend_income = db::get_annual_dividend_income(pool, &base_currency, &cached_fx)
-        .await
-        .unwrap_or(0.0);
+    let annual_dividend_income =
+        db::get_annual_dividend_income(pool, &base_currency, &cached_fx).await?;
 
     let mut snapshot = build_portfolio_snapshot(
         &holdings,
@@ -102,14 +107,25 @@ pub async fn add_holding(
     db: State<'_, DbState>,
     holding: HoldingInput,
 ) -> Result<Holding, AppError> {
-    validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
+    add_holding_impl(&db.0, holding).await
+}
+
+async fn add_holding_impl(
+    pool: &sqlx::SqlitePool,
+    holding: HoldingInput,
+) -> Result<Holding, AppError> {
+    let currency =
+        validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
     validate_target_weight(holding.target_weight)?;
     validate_holding_dividend_fields(
         holding.indicated_annual_dividend,
         holding.dividend_frequency.as_deref(),
         holding.maturity_date.as_deref(),
     )?;
-    let pool = &db.0;
+    let holding = HoldingInput {
+        currency,
+        ..holding
+    };
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
             let current_sum = db::sum_target_weights(pool, None).await?;
@@ -129,14 +145,25 @@ pub async fn add_holding(
 
 #[tauri::command]
 pub async fn update_holding(db: State<'_, DbState>, holding: Holding) -> Result<Holding, AppError> {
-    validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
+    update_holding_impl(&db.0, holding).await
+}
+
+async fn update_holding_impl(
+    pool: &sqlx::SqlitePool,
+    holding: Holding,
+) -> Result<Holding, AppError> {
+    let currency =
+        validate_holding_fields(holding.quantity, holding.cost_basis, &holding.currency)?;
     validate_target_weight(holding.target_weight)?;
     validate_holding_dividend_fields(
         holding.indicated_annual_dividend,
         holding.dividend_frequency.as_deref(),
         holding.maturity_date.as_deref(),
     )?;
-    let pool = &db.0;
+    let holding = Holding {
+        currency,
+        ..holding
+    };
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
             let current_sum = db::sum_target_weights(pool, Some(holding.id.0.as_str())).await?;
@@ -159,4 +186,92 @@ pub async fn delete_holding(db: State<'_, DbState>, id: HoldingId) -> Result<boo
     validate_id("holding ID", &id.0)?;
     let pool = &db.0;
     db::delete_holding(pool, &id).await.map_err(AppError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use crate::types::{AccountType, AssetType, HoldingInput};
+
+    fn make_input(symbol: &str, currency: &str) -> HoldingInput {
+        HoldingInput {
+            symbol: symbol.to_string(),
+            name: format!("{symbol} Inc."),
+            asset_type: AssetType::Stock,
+            account: AccountType::Taxable,
+            account_id: None,
+            quantity: 10.0,
+            cost_basis: 150.0,
+            currency: currency.to_string(),
+            exchange: "TSX".to_string(),
+            target_weight: None,
+            indicated_annual_dividend: None,
+            indicated_annual_dividend_currency: None,
+            dividend_frequency: None,
+            maturity_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_propagates_annual_dividend_income_error() {
+        // Regression guard for #672: get_portfolio previously called
+        // `.unwrap_or(0.0)` on get_annual_dividend_income, silently hiding
+        // any DB error (e.g. a query failure) behind a fake $0 figure.
+        let pool = db::open_test_db().await;
+        sqlx::query("DROP TABLE dividends")
+            .execute(&pool)
+            .await
+            .expect("drop dividends table to force a query error");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        let result = super::get_portfolio_impl(&pool, &gains_cache).await;
+        assert!(
+            result.is_err(),
+            "get_portfolio must surface the dividend-income query error instead of swallowing it"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_holding_persists_normalized_currency() {
+        // Regression guard for #691: validate_holding_fields returns the
+        // normalized (trimmed, uppercased) currency, but add_holding
+        // discarded it and persisted the raw user input instead.
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "  usd "))
+            .await
+            .expect("add_holding_impl should succeed");
+        assert_eq!(inserted.currency, "USD");
+
+        let fetched = db::get_all_holdings(&pool)
+            .await
+            .expect("get_all_holdings")
+            .into_iter()
+            .find(|h| h.id == inserted.id)
+            .expect("holding must exist");
+        assert_eq!(fetched.currency, "USD");
+    }
+
+    #[tokio::test]
+    async fn update_holding_persists_normalized_currency() {
+        // Same bug as add_holding, for the update path.
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "CAD"))
+            .await
+            .expect("add_holding_impl should succeed");
+
+        let mut to_update = inserted.clone();
+        to_update.currency = "  usd ".to_string();
+        let updated = super::update_holding_impl(&pool, to_update)
+            .await
+            .expect("update_holding_impl should succeed");
+        assert_eq!(updated.currency, "USD");
+
+        let fetched = db::get_all_holdings(&pool)
+            .await
+            .expect("get_all_holdings")
+            .into_iter()
+            .find(|h| h.id == inserted.id)
+            .expect("holding must exist");
+        assert_eq!(fetched.currency, "USD");
+    }
 }

--- a/src-tauri/src/commands_tests.rs
+++ b/src-tauri/src/commands_tests.rs
@@ -222,6 +222,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dividend_rejects_malformed_ex_date() {
+        // Regression guard for #676: ex_date/pay_date were stored as free-form
+        // strings with no format check.
+        assert!(matches!(
+            crate::commands::validate_dividend_fields(1.38, "03/15/2024", "2024-04-25"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            crate::commands::validate_dividend_fields(1.38, "not-a-date", "2024-04-25"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            crate::commands::validate_dividend_fields(1.38, "", "2024-04-25"),
+            Err(AppError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn dividend_rejects_malformed_pay_date() {
+        assert!(matches!(
+            crate::commands::validate_dividend_fields(1.38, "2024-03-15", "25/04/2024"),
+            Err(AppError::Validation(_))
+        ));
+        assert!(matches!(
+            crate::commands::validate_dividend_fields(1.38, "2024-03-15", ""),
+            Err(AppError::Validation(_))
+        ));
+    }
+
     // ── transaction validation (#624) ─────────────────────────────────────────
 
     #[test]

--- a/src-tauri/src/csv.rs
+++ b/src-tauri/src/csv.rs
@@ -137,7 +137,10 @@ fn parse_required_field(
 /// excessively large inputs.
 fn sanitize_str(s: &str) -> String {
     let s = if s.len() > crate::config::MAX_FIELD_LEN {
-        &s[..crate::config::MAX_FIELD_LEN]
+        match s.char_indices().nth(crate::config::MAX_FIELD_LEN) {
+            Some((i, _)) => &s[..i],
+            None => s,
+        }
     } else {
         s
     };
@@ -389,6 +392,17 @@ pub fn parse_import_rows(csv_content: &str) -> Result<Vec<ParsedImportRow>, Stri
 mod tests {
     use super::*;
     use crate::test_helpers::make_holding;
+
+    #[test]
+    fn sanitize_str_does_not_panic_on_multibyte_char_boundary() {
+        // MAX_FIELD_LEN (500) falls mid-character when the input is made of
+        // 3-byte UTF-8 chars (500 is not a multiple of 3), which previously
+        // panicked via the byte-offset slice `&s[..MAX_FIELD_LEN]`.
+        let s: String = std::iter::repeat('日').take(200).collect(); // 600 bytes
+        let result = sanitize_str(&s);
+        assert!(!result.is_empty());
+        assert!(result.chars().count() <= 200);
+    }
 
     #[test]
     fn normalize_symbol_strips_country_suffix() {

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1044,7 +1044,7 @@ pub async fn get_dividends(pool: &SqlitePool) -> Result<Vec<Dividend>, String> {
                 d.ex_date, d.pay_date, d.created_at
          FROM dividends d
          JOIN holdings h ON h.id = d.holding_id
-         WHERE d.deleted_at IS NULL AND h.deleted_at IS NULL
+         WHERE d.deleted_at IS NULL
          ORDER BY d.ex_date DESC",
     )
     .fetch_all(pool)
@@ -1093,7 +1093,7 @@ pub async fn get_annual_dividend_income(
         "SELECT d.amount_per_unit * h.quantity, d.currency
          FROM dividends d
          JOIN holdings h ON h.id = d.holding_id
-         WHERE d.pay_date >= $1 AND d.deleted_at IS NULL AND h.deleted_at IS NULL",
+         WHERE d.pay_date >= $1 AND d.deleted_at IS NULL",
     )
     .bind(&cutoff)
     .fetch_all(pool)
@@ -1493,7 +1493,7 @@ pub async fn get_dividends_paginated(
                 d.ex_date, d.pay_date, d.created_at
          FROM dividends d
          JOIN holdings h ON h.id = d.holding_id
-         WHERE d.deleted_at IS NULL AND h.deleted_at IS NULL
+         WHERE d.deleted_at IS NULL
          ORDER BY d.ex_date DESC
          LIMIT $1 OFFSET $2",
     )
@@ -2532,6 +2532,44 @@ mod tests {
             holding.account_id.as_deref(),
             Some("acc-first"),
             "holding should be assigned to the earliest-created account of matching type"
+        );
+    }
+
+    #[tokio::test]
+    async fn dividends_remain_visible_after_holding_soft_deleted() {
+        // Regression guard for #673: transactions stay visible for a
+        // soft-deleted holding (get_all_transactions doesn't join/filter on
+        // holdings.deleted_at), but dividends previously vanished because
+        // get_dividends joined holdings and filtered `h.deleted_at IS NULL`.
+        // Align dividends with the existing transaction behavior.
+        let pool = open_test_db().await;
+        let holding = insert_holding(&pool, make_input("DIVSOFT"))
+            .await
+            .expect("insert holding");
+
+        insert_dividend(
+            &pool,
+            DividendInput {
+                holding_id: holding.id.clone(),
+                amount_per_unit: 1.5,
+                currency: "CAD".to_string(),
+                ex_date: "2024-01-01".to_string(),
+                pay_date: "2024-01-15".to_string(),
+            },
+            &holding.symbol,
+        )
+        .await
+        .expect("insert dividend");
+
+        delete_holding(&pool, &holding.id)
+            .await
+            .expect("soft-delete holding");
+
+        let dividends = get_dividends(&pool).await.expect("get_dividends");
+        assert_eq!(
+            dividends.len(),
+            1,
+            "dividend should remain visible after its holding is soft-deleted, matching transaction behavior"
         );
     }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -48,12 +48,66 @@ impl From<reqwest::Error> for AppError {
 
 impl From<String> for AppError {
     fn from(s: String) -> Self {
-        AppError::Validation(s)
+        // Most `db.rs` functions return `Result<T, String>` (built via
+        // `.map_err(|e| e.to_string())`), so by the time an error reaches
+        // this conversion the original `sqlx::Error` variant is gone.
+        // Pattern-match the well-known SQLite error text so uniqueness/FK
+        // violations and missing-row lookups still surface as Conflict/
+        // NotFound to the frontend instead of a blanket Validation error.
+        if s.contains("UNIQUE constraint failed") || s.contains("FOREIGN KEY constraint failed") {
+            AppError::Conflict(s)
+        } else if s.contains("no rows returned by a query") {
+            AppError::NotFound(s)
+        } else {
+            AppError::Validation(s)
+        }
     }
 }
 
 impl From<&str> for AppError {
     fn from(s: &str) -> Self {
-        AppError::Validation(s.to_string())
+        AppError::from(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_string_classifies_unique_constraint_as_conflict() {
+        let err = AppError::from(
+            "error returned from database: (code: 2067) UNIQUE constraint failed: holdings.id"
+                .to_string(),
+        );
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[test]
+    fn from_string_classifies_foreign_key_violation_as_conflict() {
+        let err = AppError::from(
+            "error returned from database: (code: 787) FOREIGN KEY constraint failed".to_string(),
+        );
+        assert!(matches!(err, AppError::Conflict(_)));
+    }
+
+    #[test]
+    fn from_string_classifies_row_not_found_as_not_found() {
+        let err = AppError::from(
+            "no rows returned by a query that expected to return at least one row".to_string(),
+        );
+        assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn from_string_falls_back_to_validation_for_unrecognized_errors() {
+        let err = AppError::from("quantity must be positive".to_string());
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[test]
+    fn from_str_uses_same_classification_as_from_string() {
+        let err = AppError::from("UNIQUE constraint failed: accounts.id");
+        assert!(matches!(err, AppError::Conflict(_)));
     }
 }


### PR DESCRIPTION
## Summary

- **#661** — added `holdings_hidden_columns` to the Tauri `ALLOWED_CONFIG_KEYS` allowlist so the frontend can persist which Holdings table columns are hidden.
- **#662** — `get_config` in the MCP server now validates the key against the same allowlist `set_config` already enforces (previously any key, including internal ones, could be read). Also added `holdings_hidden_columns` to the MCP's mirrored allowlist for parity.
- **#663** — added the 9 translation keys (`alerts.resetAlert`, `alerts.emptyActive`, `transactions.empty`, `transactions.columns.*`) that existed only in `en/translation.json` to all 7 other locale files, using the English string as a placeholder. Added a locale-parity test (`frontend/lib/__tests__/i18n.test.ts`) to catch future drift.
- **#671** — `impl From<String> for AppError` now pattern-matches known SQLite error text (`UNIQUE constraint failed`, `FOREIGN KEY constraint failed`, `no rows returned by a query`) into `Conflict`/`NotFound` instead of blanket-wrapping every string error as `Validation`. The frontend's `AppError` type already had `not_found`/`conflict` variants and doesn't switch on `error.type` anywhere, so no frontend changes were needed.
- **#672** — `get_portfolio` no longer swallows `get_annual_dividend_income` failures behind `.unwrap_or(0.0)`; the error now propagates via `?`. Extracted `get_portfolio_impl`/`add_holding_impl`/`update_holding_impl` (pool-based, no `State`) so these command-layer bugs are directly unit-testable.
- **#673** — dividend queries (`get_dividends`, `get_dividends_paginated`, `get_annual_dividend_income`) no longer filter on `h.deleted_at IS NULL`, so a dividend stays visible after its parent holding is soft-deleted — matching the existing transaction/realized-gains behavior, which never filtered on the holding's soft-delete state.
- **#674** — `sanitize_str` truncates on a char boundary (`char_indices().nth(MAX_FIELD_LEN)`) instead of a raw byte slice, fixing a panic when `MAX_FIELD_LEN` fell inside a multi-byte UTF-8 character.
- **#676** — `validate_dividend_fields` now rejects malformed/empty `exDate`/`payDate` via `chrono::NaiveDate::parse_from_str(..., "%Y-%m-%d")`. (No portfolio-mcp change: the MCP server has no `add_dividend` tool, so there's no dividend date path to mirror there.)
- **#684** — `build_portfolio_snapshot` now guards `change_percent` with `.is_finite()` (defaulting to `0.0`), matching the existing `price.is_finite()` guard, so a NaN/Infinity value from the price feed can no longer propagate into `daily_pnl` / `daily_change_percent`.
- **#691** — `add_holding`/`update_holding` now persist the normalized (trimmed, uppercased) currency returned by `validate_holding_fields` instead of the raw, un-normalized user input — matching the MCP layer's existing behavior.

## Test plan
- [x] `cargo build` — clean (src-tauri, portfolio-core, portfolio-mcp)
- [x] `cargo test` — 288 passed (src-tauri), 52 passed (portfolio-core), 31 passed (portfolio-mcp)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `NODE_ENV=development npm test -- --run` — 335 passed (34 files), including new tests for each fix above
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Pre-push hook (lint, build, tests, clippy) — all passed

Closes #661
Closes #662
Closes #663
Closes #671
Closes #672
Closes #673
Closes #674
Closes #676
Closes #684
Closes #691