### PR TITLE
fix: backend tech debt and ErrorBoundary (#668, #675, #677, #678, #679, #680, #690, #702)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { getErrorMessage, tauriInvoke } from './lib/tauri';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { Layout } from './components/Layout';
 import { Dashboard } from './components/Dashboard';
 import { Holdings } from './components/Holdings';
@@ -289,12 +290,14 @@ function AppRoutes() {
 
 export default function App() {
   return (
-    <ToastProvider>
-      <PortfolioProvider>
-        <BrowserRouter>
-          <AppRoutes />
-        </BrowserRouter>
-      </PortfolioProvider>
-    </ToastProvider>
+    <ErrorBoundary>
+      <ToastProvider>
+        <PortfolioProvider>
+          <BrowserRouter>
+            <AppRoutes />
+          </BrowserRouter>
+        </PortfolioProvider>
+      </ToastProvider>
+    </ErrorBoundary>
   );
 }

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // eslint-disable-next-line no-console
+    console.error('Uncaught render error:', error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 16,
+            height: '100vh',
+            padding: 32,
+            textAlign: 'center',
+            background: 'var(--bg-primary)',
+            fontFamily: 'var(--font-sans)',
+          }}
+        >
+          <div>
+            <h1
+              style={{
+                color: 'var(--text-primary)',
+                fontSize: 18,
+                margin: '0 0 8px',
+              }}
+            >
+              Something went wrong
+            </h1>
+            <p
+              style={{
+                color: 'var(--text-secondary)',
+                fontSize: 13,
+                margin: 0,
+              }}
+            >
+              Portfolio Tracker hit an unexpected error. Your data is safe — reloading should fix
+              it.
+            </p>
+          </div>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              padding: '10px 20px',
+              background: 'var(--color-accent)',
+              border: 'none',
+              color: '#fff',
+              cursor: 'pointer',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 13,
+              borderRadius: 2,
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+function ThrowingChild(): never {
+  throw new Error('boom');
+}
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // React logs caught render errors to console.error; silence that expected noise.
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>All good</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('All good')).toBeTruthy();
+  });
+
+  it('renders a friendly fallback instead of crashing when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    expect(screen.queryByText('All good')).toBeNull();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+  });
+
+  it('reloads the page when the Reload button is clicked', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }));
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/portfolio-mcp/src/tools/config.rs
+++ b/portfolio-mcp/src/tools/config.rs
@@ -114,6 +114,7 @@ pub async fn set_config(
     } else {
         params.value
     };
+    validation::validate_config_value(&params.key, &value)?;
 
     db::set_config(pool, &params.key, &value)
         .await

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -218,6 +218,96 @@ pub fn validate_config_key(key: &str) -> Result<(), McpError> {
     Ok(())
 }
 
+/// Mirrors `SUPPORTED_LANGUAGES` in `src-tauri/src/commands/config.rs`.
+const SUPPORTED_LANGUAGES: &[&str] = &["en", "de", "es", "fr", "ja", "pl", "pt", "zh"];
+
+/// Mirrors `KNOWN_HOLDINGS_COLUMNS` in `src-tauri/src/commands/config.rs`.
+const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
+    "symbol",
+    "name",
+    "assetType",
+    "account",
+    "exchange",
+    "quantity",
+    "costBasis",
+    "currentPrice",
+    "marketValueCad",
+    "weight",
+    "targetWeight",
+    "targetDeltaPercent",
+    "targetDeltaValue",
+    "gainLoss",
+    "gainLossPercent",
+    "prevClose",
+    "dayOpen",
+    "openDate",
+    "maturityDate",
+];
+
+/// Mirrors `MAX_CONFIG_VALUE_LEN` in `src-tauri/src/commands/config.rs`.
+const MAX_CONFIG_VALUE_LEN: usize = 500;
+
+/// Mirrors `validate_config_value` in `src-tauri/src/commands/config.rs::set_config_cmd`.
+pub fn validate_config_value(key: &str, value: &str) -> Result<(), McpError> {
+    match key {
+        "app_theme" => {
+            if !["light", "dark", "system"].contains(&value) {
+                return Err(McpError::invalid_params(
+                    format!("app_theme must be one of: light, dark, system (got: {value})"),
+                    None,
+                ));
+            }
+        }
+        "app_language" => {
+            if !SUPPORTED_LANGUAGES.contains(&value) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "app_language must be one of: {} (got: {value})",
+                        SUPPORTED_LANGUAGES.join(", ")
+                    ),
+                    None,
+                ));
+            }
+        }
+        "base_currency" => {
+            if value.len() != 3 || !value.bytes().all(|b| b.is_ascii_uppercase()) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "base_currency must be a 3-letter uppercase currency code (got: {value})"
+                    ),
+                    None,
+                ));
+            }
+        }
+        "holdings_hidden_columns" => {
+            let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
+                McpError::invalid_params(
+                    "holdings_hidden_columns must be a JSON array of column names",
+                    None,
+                )
+            })?;
+            if let Some(unknown) = columns
+                .iter()
+                .find(|c| !KNOWN_HOLDINGS_COLUMNS.contains(&c.as_str()))
+            {
+                return Err(McpError::invalid_params(
+                    format!("holdings_hidden_columns contains unknown column: {unknown}"),
+                    None,
+                ));
+            }
+        }
+        _ => {
+            if value.len() > MAX_CONFIG_VALUE_LEN {
+                return Err(McpError::invalid_params(
+                    format!("{key} value exceeds max length of {MAX_CONFIG_VALUE_LEN} characters"),
+                    None,
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -430,5 +520,66 @@ mod tests {
         assert!(validate_config_key("cost_basis_method").is_ok());
         assert!(validate_config_key("some_arbitrary_key").is_err());
         assert!(validate_config_key("").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_known_theme_values() {
+        for value in ["light", "dark", "system"] {
+            assert!(validate_config_value("app_theme", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_theme() {
+        assert!(validate_config_value("app_theme", "solarized").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_supported_languages() {
+        for value in ["en", "de", "es", "fr", "ja", "pl", "pt", "zh"] {
+            assert!(validate_config_value("app_language", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unsupported_language() {
+        assert!(validate_config_value("app_language", "xx").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_base_currency() {
+        assert!(validate_config_value("base_currency", "CAD").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_malformed_base_currency() {
+        assert!(validate_config_value("base_currency", "cad").is_err());
+        assert!(validate_config_value("base_currency", "CA").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", r#"["symbol","weight"]"#).is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_column_in_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", r#"["notARealColumn"]"#).is_err());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_non_json_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", "not json").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_other_keys_within_max_length() {
+        assert!(validate_config_value("cost_basis_method", "avco").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_other_keys_over_max_length() {
+        let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
+        assert!(validate_config_value("cost_basis_method", &too_long).is_err());
     }
 }

--- a/src-tauri/migrations/0009_soft_delete.sql
+++ b/src-tauri/migrations/0009_soft_delete.sql
@@ -2,3 +2,14 @@
 ALTER TABLE holdings     ADD COLUMN deleted_at TIMESTAMP NULL DEFAULT NULL;
 ALTER TABLE transactions ADD COLUMN deleted_at TIMESTAMP NULL DEFAULT NULL;
 ALTER TABLE dividends    ADD COLUMN deleted_at TIMESTAMP NULL DEFAULT NULL;
+
+-- NOTE (#675): as of this migration, holdings are never hard-deleted — deletion
+-- goes through this soft-delete column instead (see db.rs delete_holding). This
+-- means the `ON DELETE CASCADE` on transactions.holding_id and
+-- dividends.holding_id (declared in 0001_initial_schema.sql) is dead: a real
+-- DELETE FROM holdings that would trigger the cascade never happens in
+-- application code. Soft-deleting a holding does NOT cascade to its
+-- transactions/dividends — callers that need cascaded soft-deletes must do so
+-- explicitly. The FK constraint itself is left in place (harmless, and would
+-- correctly cascade if a hard delete were ever introduced), but it should not
+-- be relied upon for cleanup today.

--- a/src-tauri/migrations/0013_dividends_pay_date_index.sql
+++ b/src-tauri/migrations/0013_dividends_pay_date_index.sql
@@ -1,0 +1,3 @@
+-- get_annual_dividend_income (db.rs) filters dividends by `d.pay_date >= $1`
+-- over the full table on every portfolio snapshot; index the column it scans.
+CREATE INDEX IF NOT EXISTS idx_dividends_pay_date ON dividends(pay_date);

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -81,9 +81,9 @@ pub(crate) async fn get_symbol_metadata_with_cache(
     client: &reqwest::Client,
     symbols: &[String],
     pool: Option<&sqlx::SqlitePool>,
-) -> Result<Vec<SymbolMetadata>, AppError> {
+) -> Vec<SymbolMetadata> {
     if symbols.is_empty() {
-        return Ok(vec![]);
+        return vec![];
     }
 
     const CACHE_TTL_SECS: i64 = 86_400; // 24 hours
@@ -104,7 +104,7 @@ pub(crate) async fn get_symbol_metadata_with_cache(
     }
 
     if stale_indices.is_empty() {
-        return Ok(results.into_iter().flatten().collect());
+        return results.into_iter().flatten().collect();
     }
 
     let stale_symbols: Vec<String> = stale_indices.iter().map(|&i| symbols[i].clone()).collect();
@@ -247,7 +247,7 @@ pub(crate) async fn get_symbol_metadata_with_cache(
         results[original_idx] = Some(meta);
     }
 
-    Ok(results.into_iter().flatten().collect())
+    results.into_iter().flatten().collect()
 }
 
 fn compute_portfolio_analytics(
@@ -429,9 +429,7 @@ pub async fn get_portfolio_analytics(
         .into_iter()
         .collect();
 
-    let metadata = get_symbol_metadata_with_cache(&http.0, &non_cash_symbols, Some(pool))
-        .await
-        .unwrap_or_default();
+    let metadata = get_symbol_metadata_with_cache(&http.0, &non_cash_symbols, Some(pool)).await;
 
     Ok(compute_portfolio_analytics(&snapshot, &metadata))
 }
@@ -471,11 +469,24 @@ pub async fn get_realized_gains(
     Ok(summary)
 }
 
+/// A negative, NaN/infinite, or >100 `drift_threshold` would silently disable
+/// or misapply the drift filter in `compute_rebalance_suggestions` — reject it
+/// at the command boundary instead.
+fn validate_drift_threshold(drift_threshold: f64) -> Result<(), AppError> {
+    if !drift_threshold.is_finite() || !(0.0..=100.0).contains(&drift_threshold) {
+        return Err(AppError::Validation(
+            "drift_threshold must be a finite number between 0 and 100".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn get_rebalance_suggestions(
     db: State<'_, DbState>,
     drift_threshold: f64,
 ) -> Result<Vec<RebalanceSuggestion>, AppError> {
+    validate_drift_threshold(drift_threshold)?;
     let base_currency = get_base_currency(&db.0).await;
 
     let pool = &db.0;
@@ -562,6 +573,35 @@ fn compute_rebalance_suggestions(
     });
 
     suggestions
+}
+
+#[cfg(test)]
+mod validate_drift_threshold_tests {
+    use super::validate_drift_threshold;
+
+    #[test]
+    fn rejects_negative_threshold() {
+        assert!(validate_drift_threshold(-0.01).is_err());
+    }
+
+    #[test]
+    fn rejects_threshold_above_100() {
+        assert!(validate_drift_threshold(100.01).is_err());
+    }
+
+    #[test]
+    fn rejects_nan_and_infinite_threshold() {
+        assert!(validate_drift_threshold(f64::NAN).is_err());
+        assert!(validate_drift_threshold(f64::INFINITY).is_err());
+        assert!(validate_drift_threshold(f64::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn accepts_boundary_and_typical_values() {
+        assert!(validate_drift_threshold(0.0).is_ok());
+        assert!(validate_drift_threshold(100.0).is_ok());
+        assert!(validate_drift_threshold(5.0).is_ok());
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -195,6 +195,50 @@ pub async fn restore_database(
     Ok("Database restored. Please restart the app to apply changes.".to_string())
 }
 
+/// Deletes leftover `.tmp` and `.restore_tmp` staging files in `dir`.
+///
+/// `atomic_copy` and `quiesce_and_restore_file` both stage a copy into a temp
+/// file before an atomic rename into place. If the process is killed between
+/// the write and the rename (e.g. `.tmp` from a backup, `.restore_tmp` from a
+/// restore), the staging file is orphaned — it was never consumed by a rename
+/// and never will be. Call this once at startup, before opening the DB pool,
+/// so orphaned staging files don't accumulate across restarts.
+pub fn cleanup_stale_staging_files(dir: &std::path::Path) -> std::io::Result<usize> {
+    let mut removed = 0;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name,
+            None => continue,
+        };
+        if name.ends_with(".tmp") || name.ends_with(".restore_tmp") {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {
+                    removed += 1;
+                    tracing::info!("Removed stale staging file: {}", path.display());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to remove stale staging file {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+    }
+    Ok(removed)
+}
+
 /// Copies `source` to `dest` without ever exposing a partially-written file
 /// at `dest`. Stages the copy into a temp file in the same directory as
 /// `dest`, then atomically renames it into place — a same-directory rename
@@ -402,6 +446,57 @@ mod tests {
             .expect("select marker");
         pool.close().await;
         row.map(|r| r.get::<String, _>(0))
+    }
+
+    #[test]
+    fn cleanup_stale_staging_files_removes_tmp_and_restore_tmp_files() {
+        // Regression guard for #668: staging files orphaned by a process kill
+        // between write and rename must be swept up on next startup.
+        let scratch = ScratchDir::new("cleanup-stale-staging");
+        std::fs::write(scratch.path("portfolio.db.tmp"), b"orphaned backup staging")
+            .expect("write orphaned tmp file");
+        std::fs::write(
+            scratch.path("portfolio.db.restore_tmp"),
+            b"orphaned restore staging",
+        )
+        .expect("write orphaned restore_tmp file");
+        std::fs::write(scratch.path("portfolio.db"), b"live db").expect("write live db");
+        std::fs::write(scratch.path("notes.txt"), b"unrelated file").expect("write unrelated file");
+
+        let removed = cleanup_stale_staging_files(&scratch.0).expect("cleanup should succeed");
+
+        assert_eq!(removed, 2, "should remove exactly the two staging files");
+        assert!(!scratch.path("portfolio.db.tmp").exists());
+        assert!(!scratch.path("portfolio.db.restore_tmp").exists());
+        assert!(
+            scratch.path("portfolio.db").exists(),
+            "live db must survive cleanup"
+        );
+        assert!(
+            scratch.path("notes.txt").exists(),
+            "unrelated file must survive cleanup"
+        );
+    }
+
+    #[test]
+    fn cleanup_stale_staging_files_is_noop_when_no_staging_files_present() {
+        let scratch = ScratchDir::new("cleanup-stale-staging-noop");
+        std::fs::write(scratch.path("portfolio.db"), b"live db").expect("write live db");
+
+        let removed = cleanup_stale_staging_files(&scratch.0).expect("cleanup should succeed");
+
+        assert_eq!(removed, 0);
+        assert!(scratch.path("portfolio.db").exists());
+    }
+
+    #[test]
+    fn cleanup_stale_staging_files_tolerates_missing_directory() {
+        let scratch = ScratchDir::new("cleanup-stale-staging-missing-dir");
+        let missing = scratch.path("does-not-exist");
+
+        let removed = cleanup_stale_staging_files(&missing).expect("missing dir should not error");
+
+        assert_eq!(removed, 0);
     }
 
     #[test]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -26,6 +26,95 @@ fn validate_config_key(key: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+/// BCP 47 tags this app ships translations for (`frontend/lib/i18n.ts`'s
+/// `SUPPORTED_LNG_CODES`).
+const SUPPORTED_LANGUAGES: &[&str] = &["en", "de", "es", "fr", "ja", "pl", "pt", "zh"];
+
+/// Holdings table columns a user can hide (`frontend/components/Holdings.tsx`'s
+/// `ALL_COLUMNS`), mirrored here so `holdings_hidden_columns` can't be set to
+/// reference a column that doesn't exist.
+const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
+    "symbol",
+    "name",
+    "assetType",
+    "account",
+    "exchange",
+    "quantity",
+    "costBasis",
+    "currentPrice",
+    "marketValueCad",
+    "weight",
+    "targetWeight",
+    "targetDeltaPercent",
+    "targetDeltaValue",
+    "gainLoss",
+    "gainLossPercent",
+    "prevClose",
+    "dayOpen",
+    "openDate",
+    "maturityDate",
+];
+
+/// Keys not otherwise recognized below fall through to this generic bound —
+/// long enough for any legitimate config value, short enough to stop the
+/// allowlisted-key check from being paired with an unbounded value.
+const MAX_CONFIG_VALUE_LEN: usize = 500;
+
+/// `validate_config_key` only checks that `key` is allowlisted; it says nothing
+/// about whether `value` is something the app can actually use. A malformed
+/// theme, language, currency code, or hidden-columns list would otherwise be
+/// written to `app_config` and only surface as a confusing failure wherever
+/// it's read back out.
+fn validate_config_value(key: &str, value: &str) -> Result<(), AppError> {
+    match key {
+        "app_theme" => {
+            if !["light", "dark", "system"].contains(&value) {
+                return Err(AppError::Validation(format!(
+                    "app_theme must be one of: light, dark, system (got: {value})"
+                )));
+            }
+        }
+        "app_language" => {
+            if !SUPPORTED_LANGUAGES.contains(&value) {
+                return Err(AppError::Validation(format!(
+                    "app_language must be one of: {} (got: {value})",
+                    SUPPORTED_LANGUAGES.join(", ")
+                )));
+            }
+        }
+        "base_currency" => {
+            if value.len() != 3 || !value.bytes().all(|b| b.is_ascii_uppercase()) {
+                return Err(AppError::Validation(format!(
+                    "base_currency must be a 3-letter uppercase currency code (got: {value})"
+                )));
+            }
+        }
+        "holdings_hidden_columns" => {
+            let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
+                AppError::Validation(
+                    "holdings_hidden_columns must be a JSON array of column names".to_string(),
+                )
+            })?;
+            if let Some(unknown) = columns
+                .iter()
+                .find(|c| !KNOWN_HOLDINGS_COLUMNS.contains(&c.as_str()))
+            {
+                return Err(AppError::Validation(format!(
+                    "holdings_hidden_columns contains unknown column: {unknown}"
+                )));
+            }
+        }
+        _ => {
+            if value.len() > MAX_CONFIG_VALUE_LEN {
+                return Err(AppError::Validation(format!(
+                    "{key} value exceeds max length of {MAX_CONFIG_VALUE_LEN} characters"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn get_config_cmd(
     db: State<'_, DbState>,
@@ -50,6 +139,7 @@ pub async fn set_config_cmd(
     } else {
         value
     };
+    validate_config_value(&key, &value)?;
     db::set_config(pool, &key, &value)
         .await
         .map_err(AppError::from)?;
@@ -101,5 +191,77 @@ mod tests {
         // table columns are hidden under this key, but it was missing from
         // the allowlist, so get/set_config_cmd rejected it.
         assert!(validate_config_key("holdings_hidden_columns").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_known_theme_values() {
+        for value in ["light", "dark", "system"] {
+            assert!(validate_config_value("app_theme", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_theme() {
+        // Regression guard for #690: previously any string was accepted for
+        // app_theme regardless of whether the frontend could render it.
+        assert!(validate_config_value("app_theme", "solarized").is_err());
+        assert!(validate_config_value("app_theme", "").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_supported_languages() {
+        for value in ["en", "de", "es", "fr", "ja", "pl", "pt", "zh"] {
+            assert!(validate_config_value("app_language", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unsupported_language() {
+        assert!(validate_config_value("app_language", "xx").is_err());
+        assert!(validate_config_value("app_language", "EN").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_base_currency() {
+        assert!(validate_config_value("base_currency", "CAD").is_ok());
+        assert!(validate_config_value("base_currency", "USD").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_malformed_base_currency() {
+        assert!(validate_config_value("base_currency", "cad").is_err());
+        assert!(validate_config_value("base_currency", "CA").is_err());
+        assert!(validate_config_value("base_currency", "CAND").is_err());
+        assert!(validate_config_value("base_currency", "C4D").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", r#"["symbol","weight"]"#).is_ok());
+        assert!(validate_config_value("holdings_hidden_columns", "[]").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_non_json_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", "not json").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_column_in_holdings_hidden_columns() {
+        // Regression guard for #690: an unknown column name would previously
+        // be persisted verbatim and silently ignored by the frontend.
+        assert!(validate_config_value("holdings_hidden_columns", r#"["notARealColumn"]"#).is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_other_keys_within_max_length() {
+        assert!(validate_config_value("cost_basis_method", "avco").is_ok());
+        assert!(validate_config_value("auto_refresh_interval_ms", "60000").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_other_keys_over_max_length() {
+        let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
+        assert!(validate_config_value("cost_basis_method", &too_long).is_err());
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -473,18 +473,29 @@ pub async fn upsert_symbol(pool: &SqlitePool, result: &SymbolResult) -> Result<(
     Ok(())
 }
 
+/// Escapes SQLite `LIKE` wildcards (`%`, `_`) and the escape character itself
+/// (`\`) in user-supplied search input, so a query like `A_B` matches the
+/// literal string `A_B` instead of `A` + any-character + `B`. Callers must
+/// pair this with `ESCAPE '\'` on the `LIKE` clause.
+fn escape_like_pattern(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 pub async fn search_symbol_cache(
     pool: &SqlitePool,
     query: &str,
 ) -> Result<Vec<SymbolResult>, String> {
     use sqlx::Row;
-    let pattern = format!("%{}%", query.to_lowercase());
-    let sym_prefix = format!("{}%", query.to_uppercase());
+    let pattern = format!("%{}%", escape_like_pattern(&query.to_lowercase()));
+    let sym_prefix = format!("{}%", escape_like_pattern(&query.to_uppercase()));
 
     let rows = sqlx::query(
         "SELECT symbol, name, asset_type, exchange, currency FROM symbol_cache
-         WHERE symbol LIKE $1 OR LOWER(name) LIKE $2
-         ORDER BY CASE WHEN symbol LIKE $1 THEN 0 ELSE 1 END
+         WHERE symbol LIKE $1 ESCAPE '\\' OR LOWER(name) LIKE $2 ESCAPE '\\'
+         ORDER BY CASE WHEN symbol LIKE $1 ESCAPE '\\' THEN 0 ELSE 1 END
          LIMIT 8",
     )
     .bind(&sym_prefix)
@@ -518,14 +529,14 @@ pub async fn search_symbol_cache_fresh(
     max_age_secs: i64,
 ) -> Result<Vec<SymbolResult>, String> {
     use sqlx::Row;
-    let pattern = format!("%{}%", query.to_lowercase());
-    let sym_prefix = format!("{}%", query.to_uppercase());
+    let pattern = format!("%{}%", escape_like_pattern(&query.to_lowercase()));
+    let sym_prefix = format!("{}%", escape_like_pattern(&query.to_uppercase()));
     let cutoff = (Utc::now() - chrono::Duration::seconds(max_age_secs)).to_rfc3339();
 
     let rows = sqlx::query(
         "SELECT symbol, name, asset_type, exchange, currency FROM symbol_cache
-         WHERE (symbol LIKE $1 OR LOWER(name) LIKE $2) AND updated_at >= $3
-         ORDER BY CASE WHEN symbol LIKE $1 THEN 0 ELSE 1 END
+         WHERE (symbol LIKE $1 ESCAPE '\\' OR LOWER(name) LIKE $2 ESCAPE '\\') AND updated_at >= $3
+         ORDER BY CASE WHEN symbol LIKE $1 ESCAPE '\\' THEN 0 ELSE 1 END
          LIMIT 8",
     )
     .bind(&sym_prefix)
@@ -1813,6 +1824,73 @@ mod tests {
             .await
             .expect("query with 300s max age");
         assert_eq!(lenient.len(), 1, "2-minute-old row is within 300s max age");
+    }
+
+    #[tokio::test]
+    async fn search_symbol_cache_treats_underscore_as_literal_not_wildcard() {
+        // Regression guard for #679: `_` is a SQLite LIKE single-char wildcard,
+        // so searching "A_B" must NOT also match "AXB" once escaped.
+        let pool = open_test_db().await;
+        for (symbol, name) in [("A_B", "Underscore Co"), ("AXB", "Wildcard Match Co")] {
+            upsert_symbol(
+                &pool,
+                &SymbolResult {
+                    symbol: symbol.to_string(),
+                    name: name.to_string(),
+                    asset_type: AssetType::Stock,
+                    exchange: "NMS".to_string(),
+                    currency: "USD".to_string(),
+                },
+            )
+            .await
+            .expect("upsert symbol");
+        }
+
+        let results = search_symbol_cache(&pool, "A_B")
+            .await
+            .expect("query cache");
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|r| r.symbol.as_str())
+                .collect::<Vec<_>>(),
+            vec!["A_B"],
+            "underscore must match literally, not as a single-char wildcard"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_symbol_cache_treats_percent_as_literal_not_wildcard() {
+        // A literal `%` in the query must not act as a multi-char wildcard.
+        let pool = open_test_db().await;
+        for (symbol, name) in [("A%B", "Percent Co"), ("AZZZB", "Unrelated Co")] {
+            upsert_symbol(
+                &pool,
+                &SymbolResult {
+                    symbol: symbol.to_string(),
+                    name: name.to_string(),
+                    asset_type: AssetType::Stock,
+                    exchange: "NMS".to_string(),
+                    currency: "USD".to_string(),
+                },
+            )
+            .await
+            .expect("upsert symbol");
+        }
+
+        let results = search_symbol_cache(&pool, "A%B")
+            .await
+            .expect("query cache");
+
+        assert_eq!(
+            results
+                .iter()
+                .map(|r| r.symbol.as_str())
+                .collect::<Vec<_>>(),
+            vec!["A%B"],
+            "percent must match literally, not as a multi-char wildcard"
+        );
     }
 
     // ── upsert_symbol_fundamentals ────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -135,6 +135,10 @@ pub fn run() {
 
             std::fs::create_dir_all(&app_data_dir)?;
 
+            if let Err(e) = commands::backup::cleanup_stale_staging_files(&app_data_dir) {
+                tracing::warn!("Failed to clean up stale backup staging files: {}", e);
+            }
+
             let db_path = app_data_dir.join(config::DB_FILE_NAME);
             let db_url = format!("sqlite:{}", db_path.to_string_lossy());
 


### PR DESCRIPTION
Closes #668
Closes #675
Closes #677
Closes #678
Closes #679
Closes #680
Closes #690
Closes #702

## Summary
- **#668** — Added `cleanup_stale_staging_files` in `commands/backup.rs`, called from `lib.rs` setup before the DB pool opens, to sweep up orphaned `.tmp`/`.restore_tmp` staging files left behind if the process is killed mid-backup/restore.
- **#675** — Documented in `0009_soft_delete.sql` that the `ON DELETE CASCADE` on `transactions.holding_id`/`dividends.holding_id` never fires because holdings are soft-deleted, not hard-deleted. No behavior change.
- **#677** — Added migration `0013_dividends_pay_date_index.sql` creating `idx_dividends_pay_date` for the `pay_date >=` range filter in `get_annual_dividend_income`.
- **#678** — `get_rebalance_suggestions` now validates `drift_threshold` is finite and in `[0, 100]`, returning `AppError::Validation` otherwise. (Not exposed via MCP, so no mirrored change needed there.)
- **#679** — Symbol search (`search_symbol_cache`, `search_symbol_cache_fresh`) now escapes `%`, `_`, and `\` in user input before building `LIKE` patterns, with `ESCAPE '\'` added to the SQL.
- **#680** — `get_symbol_metadata_with_cache` had no path that ever returned `Err`; changed its return type from `Result<Vec<SymbolMetadata>, AppError>` to `Vec<SymbolMetadata>` and updated its one call site.
- **#690** — Added per-key value validation for `set_config`/`set_config_cmd` in both the Tauri command and the MCP tool: `app_theme` (light/dark/system), `app_language` (supported BCP 47 codes), `base_currency` (`[A-Z]{3}`), `holdings_hidden_columns` (JSON array of known column names), and a 500-char max length for all other keys.
- **#702** — Added `frontend/components/ErrorBoundary.tsx` (class component with `getDerivedStateFromError`/`componentDidCatch`) wrapping the top-level app in `App.tsx`, with a friendly fallback UI and Reload button. Added `ErrorBoundary.test.tsx`.

## Test plan
- [x] `cargo build` (workspace) — clean
- [x] `cargo test` (workspace: portfolio-core, portfolio-mcp, portfolio-tracker) — 433 passed, 0 failed
- [x] `NODE_ENV=development npm test -- --run` — 348 passed across 37 files
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `cargo clippy` (via pre-push hook) — clean