### PR TITLE
feat: MCP parity improvements (#686, #687, #688, #689, #692, #693)

### DIFF
--- a/portfolio-mcp/src/db.rs
+++ b/portfolio-mcp/src/db.rs
@@ -4,10 +4,17 @@ use std::str::FromStr;
 use uuid::Uuid;
 
 use crate::types::{
-    AccountType, AlertDirection, AlertId, AssetType, FxRate, Holding, HoldingId, HoldingInput,
-    PriceAlert, PriceAlertInput, PriceData, Transaction, TransactionId, TransactionInput,
-    TransactionType,
+    Account, AccountType, AlertDirection, AlertId, AssetType, Dividend, DividendId, DividendInput,
+    FxRate, Holding, HoldingId, HoldingInput, PriceAlert, PriceAlertInput, PriceData, Transaction,
+    TransactionId, TransactionInput, TransactionType,
 };
+
+/// Cap applied to MCP list queries that don't take explicit pagination
+/// parameters (`list_holdings`, `list_transactions`, `list_alerts`, ...).
+/// Mirrors the max `page_size` accepted by the Tauri `*_paginated` commands
+/// (`validate_pagination` in `src-tauri/src/commands/mod.rs`), so an
+/// unbounded portfolio can't make these tools return an unbounded result set.
+pub const PAGINATION_FETCH_ALL_SIZE: i64 = 500;
 
 /// Open a connection pool to the portfolio SQLite database.
 /// The database must already exist (created_if_missing = false).
@@ -57,7 +64,6 @@ pub async fn set_config(pool: &SqlitePool, key: &str, value: &str) -> anyhow::Re
 // ── Holdings ──────────────────────────────────────────────────────────────────
 
 pub async fn get_all_holdings(pool: &SqlitePool) -> anyhow::Result<Vec<Holding>> {
-    use sqlx::Row;
     let rows = sqlx::query(
         "SELECT
             h.id,
@@ -81,42 +87,156 @@ pub async fn get_all_holdings(pool: &SqlitePool) -> anyhow::Result<Vec<Holding>>
          FROM holdings h
          LEFT JOIN accounts a ON a.id = h.account_id
          WHERE h.deleted_at IS NULL
-         ORDER BY h.created_at ASC",
+         ORDER BY h.created_at ASC
+         LIMIT $1",
     )
+    .bind(PAGINATION_FETCH_ALL_SIZE)
     .fetch_all(pool)
     .await?;
 
-    let holdings = rows
-        .into_iter()
-        .map(|r| {
-            let asset_type_str: String = r.get(3);
-            let account_str: String = r.get(4);
-            let asset_type = AssetType::from_str(&asset_type_str).unwrap_or(AssetType::Stock);
-            let account = AccountType::from_str(&account_str).unwrap_or(AccountType::Taxable);
-            Holding {
-                id: HoldingId(r.get(0)),
-                symbol: r.get(1),
-                name: r.get(2),
-                asset_type,
-                account,
-                account_id: r.get(5),
-                account_name: r.get(6),
-                quantity: r.get(7),
-                cost_basis: r.get(8),
-                currency: r.get(9),
-                exchange: r.get(10),
-                target_weight: r.get::<Option<f64>, _>(11),
-                created_at: r.get(12),
-                updated_at: r.get(13),
-                indicated_annual_dividend: r.get::<Option<f64>, _>(14),
-                indicated_annual_dividend_currency: r.get::<Option<String>, _>(15),
-                dividend_frequency: r.get::<Option<String>, _>(16),
-                maturity_date: r.get::<Option<String>, _>(17),
-            }
-        })
-        .collect();
+    let holdings = rows.into_iter().map(row_to_holding).collect();
 
     Ok(holdings)
+}
+
+/// Look up a single holding by id (used by `update_holding` to preserve
+/// `created_at`/`account_name` across the update).
+pub async fn get_holding_by_id(pool: &SqlitePool, id: &str) -> anyhow::Result<Option<Holding>> {
+    let row = sqlx::query(
+        "SELECT
+            h.id,
+            h.symbol,
+            h.name,
+            h.asset_type,
+            h.account,
+            h.account_id,
+            a.name AS account_name,
+            h.quantity,
+            h.cost_basis,
+            h.currency,
+            h.exchange,
+            h.target_weight,
+            h.created_at,
+            h.updated_at,
+            h.indicated_annual_dividend,
+            h.indicated_annual_dividend_currency,
+            h.dividend_frequency,
+            h.maturity_date
+         FROM holdings h
+         LEFT JOIN accounts a ON a.id = h.account_id
+         WHERE h.id = $1 AND h.deleted_at IS NULL",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(row_to_holding))
+}
+
+fn row_to_holding(r: sqlx::sqlite::SqliteRow) -> Holding {
+    use sqlx::Row;
+    let asset_type_str: String = r.get(3);
+    let account_str: String = r.get(4);
+    let asset_type = AssetType::from_str(&asset_type_str).unwrap_or_else(|_| {
+        tracing::warn!(raw = %asset_type_str, "unrecognised asset_type; defaulting to Stock");
+        AssetType::Stock
+    });
+    let account = AccountType::from_str(&account_str).unwrap_or_else(|_| {
+        tracing::warn!(raw = %account_str, "unrecognised account_type; defaulting to Taxable");
+        AccountType::Taxable
+    });
+    Holding {
+        id: HoldingId(r.get(0)),
+        symbol: r.get(1),
+        name: r.get(2),
+        asset_type,
+        account,
+        account_id: r.get(5),
+        account_name: r.get(6),
+        quantity: r.get(7),
+        cost_basis: r.get(8),
+        currency: r.get(9),
+        exchange: r.get(10),
+        target_weight: r.get::<Option<f64>, _>(11),
+        created_at: r.get(12),
+        updated_at: r.get(13),
+        indicated_annual_dividend: r.get::<Option<f64>, _>(14),
+        indicated_annual_dividend_currency: r.get::<Option<String>, _>(15),
+        dividend_frequency: r.get::<Option<String>, _>(16),
+        maturity_date: r.get::<Option<String>, _>(17),
+    }
+}
+
+/// Mirrors `update_holding` in `src-tauri/src/db.rs`.
+pub async fn update_holding(pool: &SqlitePool, holding: Holding) -> anyhow::Result<Holding> {
+    let now = Utc::now().to_rfc3339();
+
+    let effective_account_id: Option<String> = if let Some(account_id) = holding.account_id.clone()
+    {
+        Some(account_id)
+    } else {
+        use sqlx::Row;
+        sqlx::query("SELECT id FROM accounts WHERE type = $1 ORDER BY created_at ASC LIMIT 1")
+            .bind(holding.account.as_str())
+            .fetch_optional(pool)
+            .await?
+            .map(|r| r.get::<String, _>(0))
+    };
+
+    if effective_account_id.is_none() {
+        tracing::warn!(
+            "No account of type '{}' found; holding updated without account assignment",
+            holding.account.as_str()
+        );
+    }
+
+    let result = sqlx::query(
+        "UPDATE holdings SET
+             symbol=$1,
+             name=$2,
+             asset_type=$3,
+             account=$4,
+             account_id=$5,
+             quantity=$6,
+             cost_basis=$7,
+             currency=$8,
+             exchange=$9,
+             target_weight=$10,
+             updated_at=$11,
+             indicated_annual_dividend=$12,
+             indicated_annual_dividend_currency=$13,
+             dividend_frequency=$14,
+             maturity_date=$15
+         WHERE id=$16",
+    )
+    .bind(&holding.symbol)
+    .bind(&holding.name)
+    .bind(holding.asset_type.as_str())
+    .bind(holding.account.as_str())
+    .bind(&effective_account_id)
+    .bind(holding.quantity)
+    .bind(holding.cost_basis)
+    .bind(&holding.currency)
+    .bind(&holding.exchange)
+    .bind(holding.target_weight)
+    .bind(&now)
+    .bind(holding.indicated_annual_dividend)
+    .bind(&holding.indicated_annual_dividend_currency)
+    .bind(&holding.dividend_frequency)
+    .bind(&holding.maturity_date)
+    .bind(holding.id.0.as_str())
+    .execute(pool)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        anyhow::bail!("Holding {} not found", holding.id);
+    }
+
+    Ok(Holding {
+        updated_at: now,
+        account_id: effective_account_id,
+        ..holding
+    })
 }
 
 pub async fn insert_holding(pool: &SqlitePool, input: HoldingInput) -> anyhow::Result<Holding> {
@@ -277,8 +397,10 @@ pub async fn get_alerts(pool: &SqlitePool) -> anyhow::Result<Vec<PriceAlert>> {
     use sqlx::Row;
     let rows = sqlx::query(
         "SELECT id, symbol, direction, threshold, currency, note, triggered, created_at
-         FROM price_alerts ORDER BY created_at DESC",
+         FROM price_alerts ORDER BY created_at DESC
+         LIMIT $1",
     )
+    .bind(PAGINATION_FETCH_ALL_SIZE)
     .fetch_all(pool)
     .await?;
 
@@ -355,8 +477,10 @@ pub async fn reset_alert(pool: &SqlitePool, id: &AlertId) -> anyhow::Result<bool
 pub async fn get_all_transactions(pool: &SqlitePool) -> anyhow::Result<Vec<Transaction>> {
     let rows = sqlx::query(
         "SELECT id, holding_id, transaction_type, quantity, price, transacted_at, created_at
-         FROM transactions WHERE deleted_at IS NULL ORDER BY transacted_at ASC",
+         FROM transactions WHERE deleted_at IS NULL ORDER BY transacted_at ASC
+         LIMIT $1",
     )
+    .bind(PAGINATION_FETCH_ALL_SIZE)
     .fetch_all(pool)
     .await?;
 
@@ -423,4 +547,169 @@ fn row_to_transaction(row: &sqlx::sqlite::SqliteRow) -> anyhow::Result<Transacti
         transacted_at: row.get(5),
         created_at: row.get(6),
     })
+}
+
+// ── Accounts ──────────────────────────────────────────────────────────────────
+
+pub async fn get_accounts(pool: &SqlitePool) -> anyhow::Result<Vec<Account>> {
+    use sqlx::Row;
+    let rows = sqlx::query(
+        "SELECT id, name, type, institution, created_at FROM accounts
+         ORDER BY created_at ASC
+         LIMIT $1",
+    )
+    .bind(PAGINATION_FETCH_ALL_SIZE)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| Account {
+            id: r.get(0),
+            name: r.get(1),
+            account_type: r.get(2),
+            institution: r.get(3),
+            created_at: r.get(4),
+        })
+        .collect())
+}
+
+pub async fn insert_account(
+    pool: &SqlitePool,
+    name: &str,
+    account_type: &str,
+    institution: Option<&str>,
+) -> anyhow::Result<Account> {
+    let id = Uuid::new_v4().to_string();
+    let created_at = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "INSERT INTO accounts (id, name, type, institution, created_at)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(&id)
+    .bind(name)
+    .bind(account_type)
+    .bind(institution)
+    .bind(&created_at)
+    .execute(pool)
+    .await?;
+
+    Ok(Account {
+        id,
+        name: name.to_string(),
+        account_type: account_type.to_string(),
+        institution: institution.map(|s| s.to_string()),
+        created_at,
+    })
+}
+
+// ── Dividends ─────────────────────────────────────────────────────────────────
+
+/// Look up a holding's symbol and currency by id. Mirrors
+/// `get_holding_symbol_and_currency` in `src-tauri/src/db.rs`, used to
+/// validate/attribute an incoming dividend against its parent holding.
+pub async fn get_holding_symbol_and_currency(
+    pool: &SqlitePool,
+    id: &str,
+) -> anyhow::Result<Option<(String, String)>> {
+    use sqlx::Row;
+    let row = sqlx::query("SELECT symbol, currency FROM holdings WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.map(|r| (r.get(0), r.get(1))))
+}
+
+pub async fn get_dividends(
+    pool: &SqlitePool,
+    holding_id: Option<&str>,
+) -> anyhow::Result<Vec<Dividend>> {
+    use sqlx::Row;
+    let rows = if let Some(hid) = holding_id {
+        sqlx::query(
+            "SELECT d.id, d.holding_id, h.symbol, d.amount_per_unit, d.currency,
+                    d.ex_date, d.pay_date, d.created_at
+             FROM dividends d
+             JOIN holdings h ON h.id = d.holding_id
+             WHERE d.deleted_at IS NULL AND d.holding_id = $1
+             ORDER BY d.ex_date DESC
+             LIMIT $2",
+        )
+        .bind(hid)
+        .bind(PAGINATION_FETCH_ALL_SIZE)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query(
+            "SELECT d.id, d.holding_id, h.symbol, d.amount_per_unit, d.currency,
+                    d.ex_date, d.pay_date, d.created_at
+             FROM dividends d
+             JOIN holdings h ON h.id = d.holding_id
+             WHERE d.deleted_at IS NULL
+             ORDER BY d.ex_date DESC
+             LIMIT $1",
+        )
+        .bind(PAGINATION_FETCH_ALL_SIZE)
+        .fetch_all(pool)
+        .await?
+    };
+
+    Ok(rows
+        .into_iter()
+        .map(|r| Dividend {
+            id: DividendId(r.get(0)),
+            holding_id: HoldingId(r.get(1)),
+            symbol: r.get(2),
+            amount_per_unit: r.get(3),
+            currency: r.get(4),
+            ex_date: r.get(5),
+            pay_date: r.get(6),
+            created_at: r.get(7),
+        })
+        .collect())
+}
+
+pub async fn insert_dividend(
+    pool: &SqlitePool,
+    input: DividendInput,
+    symbol: &str,
+) -> anyhow::Result<Dividend> {
+    let id = Uuid::new_v4().to_string();
+    let created_at = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "INSERT INTO dividends (id, holding_id, amount_per_unit, currency, ex_date, pay_date, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(&id)
+    .bind(input.holding_id.0.as_str())
+    .bind(input.amount_per_unit)
+    .bind(&input.currency)
+    .bind(&input.ex_date)
+    .bind(&input.pay_date)
+    .bind(&created_at)
+    .execute(pool)
+    .await?;
+
+    Ok(Dividend {
+        id: DividendId(id),
+        holding_id: input.holding_id,
+        symbol: symbol.to_string(),
+        amount_per_unit: input.amount_per_unit,
+        currency: input.currency,
+        ex_date: input.ex_date,
+        pay_date: input.pay_date,
+        created_at,
+    })
+}
+
+pub async fn delete_dividend(pool: &SqlitePool, id: &DividendId) -> anyhow::Result<bool> {
+    let result = sqlx::query(
+        "UPDATE dividends SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL",
+    )
+    .bind(id.0.as_str())
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
 }

--- a/portfolio-mcp/src/tools/accounts.rs
+++ b/portfolio-mcp/src/tools/accounts.rs
@@ -1,0 +1,117 @@
+use rmcp::Error as McpError;
+use serde::Deserialize;
+use sqlx::SqlitePool;
+
+use crate::{db, types::Account, validation};
+
+use super::PortfolioMcpServer;
+
+// ── Params ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAccountParams {
+    /// Human-readable account name.
+    pub name: String,
+    /// Account type: "tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", or "other".
+    pub account_type: String,
+    /// Optional institution name (e.g. "Questrade").
+    pub institution: Option<String>,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+pub async fn list_accounts(pool: &SqlitePool) -> Result<Vec<Account>, McpError> {
+    db::get_accounts(pool)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)
+}
+
+pub async fn create_account(
+    pool: &SqlitePool,
+    params: CreateAccountParams,
+) -> Result<Account, McpError> {
+    let name = validation::validate_account_fields(&params.name, &params.account_type)?;
+    db::insert_account(
+        pool,
+        &name,
+        &params.account_type,
+        params.institution.as_deref(),
+    )
+    .await
+    .map_err(PortfolioMcpServer::tool_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query(
+            "CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT, type TEXT, \
+             institution TEXT, created_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create accounts table");
+        pool
+    }
+
+    #[tokio::test]
+    async fn create_account_rejects_empty_name() {
+        let pool = test_pool().await;
+        let result = create_account(
+            &pool,
+            CreateAccountParams {
+                name: "   ".to_string(),
+                account_type: "tfsa".to_string(),
+                institution: None,
+            },
+        )
+        .await;
+        assert!(result.is_err(), "empty account name must be rejected");
+    }
+
+    #[tokio::test]
+    async fn create_account_rejects_unknown_type() {
+        let pool = test_pool().await;
+        let result = create_account(
+            &pool,
+            CreateAccountParams {
+                name: "My Account".to_string(),
+                account_type: "not-a-type".to_string(),
+                institution: None,
+            },
+        )
+        .await;
+        assert!(result.is_err(), "unknown account type must be rejected");
+    }
+
+    #[tokio::test]
+    async fn create_account_persists_and_list_returns_it() {
+        let pool = test_pool().await;
+        let created = create_account(
+            &pool,
+            CreateAccountParams {
+                name: "  My TFSA  ".to_string(),
+                account_type: "tfsa".to_string(),
+                institution: Some("Questrade".to_string()),
+            },
+        )
+        .await
+        .expect("create_account should succeed");
+        assert_eq!(created.name, "My TFSA", "name must be trimmed");
+
+        let listed = list_accounts(&pool)
+            .await
+            .expect("list_accounts should succeed");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+        assert_eq!(listed[0].institution.as_deref(), Some("Questrade"));
+    }
+}

--- a/portfolio-mcp/src/tools/dividends.rs
+++ b/portfolio-mcp/src/tools/dividends.rs
@@ -1,0 +1,270 @@
+use rmcp::Error as McpError;
+use serde::Deserialize;
+use sqlx::SqlitePool;
+
+use crate::{
+    db,
+    types::{Dividend, DividendId, DividendInput, HoldingId},
+    validation,
+};
+
+use super::PortfolioMcpServer;
+
+// ── Params ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListDividendsParams {
+    /// Optional UUID to filter dividends for a single holding.
+    pub holding_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AddDividendParams {
+    /// UUID of the holding this dividend belongs to.
+    pub holding_id: String,
+    /// Dividend amount per unit, in the holding's currency.
+    pub amount_per_unit: f64,
+    /// ISO 4217 currency code; must match the holding's currency.
+    pub currency: String,
+    /// Ex-dividend date (YYYY-MM-DD).
+    pub ex_date: String,
+    /// Payment date (YYYY-MM-DD); must not be before ex_date.
+    pub pay_date: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DeleteDividendParams {
+    /// UUID of the dividend to delete.
+    pub id: String,
+}
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+pub async fn list_dividends(
+    pool: &SqlitePool,
+    params: ListDividendsParams,
+) -> Result<Vec<Dividend>, McpError> {
+    if let Some(id) = &params.holding_id {
+        validation::validate_id("holdingId", id)?;
+    }
+    db::get_dividends(pool, params.holding_id.as_deref())
+        .await
+        .map_err(PortfolioMcpServer::tool_error)
+}
+
+pub async fn add_dividend(
+    pool: &SqlitePool,
+    params: AddDividendParams,
+) -> Result<Dividend, McpError> {
+    validation::validate_id("holdingId", &params.holding_id)?;
+    validation::validate_dividend_fields(
+        params.amount_per_unit,
+        &params.ex_date,
+        &params.pay_date,
+    )?;
+
+    let (symbol, holding_currency) = db::get_holding_symbol_and_currency(pool, &params.holding_id)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)?
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Holding {} not found", params.holding_id), None)
+        })?;
+
+    if holding_currency.to_uppercase() != params.currency.to_uppercase() {
+        return Err(McpError::invalid_params(
+            format!(
+                "Dividend currency {} does not match holding currency {}",
+                params.currency, holding_currency
+            ),
+            None,
+        ));
+    }
+
+    let input = DividendInput {
+        holding_id: HoldingId(params.holding_id),
+        amount_per_unit: params.amount_per_unit,
+        currency: params.currency,
+        ex_date: params.ex_date,
+        pay_date: params.pay_date,
+    };
+
+    db::insert_dividend(pool, input, &symbol)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)
+}
+
+pub async fn delete_dividend(
+    pool: &SqlitePool,
+    params: DeleteDividendParams,
+) -> Result<bool, McpError> {
+    validation::validate_id("id", &params.id)?;
+    let id = DividendId(params.id);
+    db::delete_dividend(pool, &id)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    const VALID_HOLDING_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query(
+            "CREATE TABLE holdings (id TEXT PRIMARY KEY, symbol TEXT, currency TEXT, \
+             deleted_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create holdings table");
+        sqlx::query(
+            "CREATE TABLE dividends (id TEXT PRIMARY KEY, holding_id TEXT, \
+             amount_per_unit REAL, currency TEXT, ex_date TEXT, pay_date TEXT, \
+             created_at TEXT, deleted_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create dividends table");
+        pool
+    }
+
+    async fn seed_holding(pool: &SqlitePool, currency: &str) {
+        sqlx::query("INSERT INTO holdings (id, symbol, currency) VALUES ($1, 'AAPL', $2)")
+            .bind(VALID_HOLDING_ID)
+            .bind(currency)
+            .execute(pool)
+            .await
+            .expect("seed holding");
+    }
+
+    fn make_add_params() -> AddDividendParams {
+        AddDividendParams {
+            holding_id: VALID_HOLDING_ID.to_string(),
+            amount_per_unit: 0.5,
+            currency: "USD".to_string(),
+            ex_date: "2024-01-01".to_string(),
+            pay_date: "2024-01-15".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_dividend_rejects_empty_id() {
+        let pool = test_pool().await;
+        let result = delete_dividend(
+            &pool,
+            DeleteDividendParams {
+                id: "".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "empty ID must be rejected");
+    }
+
+    #[tokio::test]
+    async fn delete_dividend_rejects_malformed_id() {
+        let pool = test_pool().await;
+        let result = delete_dividend(
+            &pool,
+            DeleteDividendParams {
+                id: "not-a-uuid".to_string(),
+            },
+        )
+        .await;
+        assert!(result.is_err(), "malformed ID must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_rejects_non_positive_amount() {
+        let pool = test_pool().await;
+        let mut params = make_add_params();
+        params.amount_per_unit = 0.0;
+        let result = add_dividend(&pool, params).await;
+        assert!(result.is_err(), "non-positive amount must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_rejects_non_iso_dates() {
+        let pool = test_pool().await;
+        let mut params = make_add_params();
+        params.ex_date = "01/01/2024".to_string();
+        let result = add_dividend(&pool, params).await;
+        assert!(result.is_err(), "non-ISO ex_date must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_rejects_pay_date_before_ex_date() {
+        let pool = test_pool().await;
+        let mut params = make_add_params();
+        params.ex_date = "2024-01-15".to_string();
+        params.pay_date = "2024-01-01".to_string();
+        let result = add_dividend(&pool, params).await;
+        assert!(result.is_err(), "pay_date before ex_date must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_rejects_unknown_holding() {
+        let pool = test_pool().await;
+        let result = add_dividend(&pool, make_add_params()).await;
+        assert!(result.is_err(), "unknown holding must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_rejects_currency_mismatch() {
+        let pool = test_pool().await;
+        seed_holding(&pool, "USD").await;
+        let mut params = make_add_params();
+        params.currency = "CAD".to_string();
+        let result = add_dividend(&pool, params).await;
+        assert!(result.is_err(), "mismatched currency must be rejected");
+    }
+
+    #[tokio::test]
+    async fn add_dividend_persists_and_list_filters_by_holding() {
+        let pool = test_pool().await;
+        seed_holding(&pool, "USD").await;
+        let mut params = make_add_params();
+        params.currency = "usd".to_string();
+        let created = add_dividend(&pool, params)
+            .await
+            .expect("add_dividend should succeed");
+        assert_eq!(created.symbol, "AAPL");
+
+        let all = list_dividends(
+            &pool,
+            ListDividendsParams {
+                holding_id: None,
+            },
+        )
+        .await
+        .expect("list_dividends should succeed");
+        assert_eq!(all.len(), 1);
+
+        let filtered = list_dividends(
+            &pool,
+            ListDividendsParams {
+                holding_id: Some(VALID_HOLDING_ID.to_string()),
+            },
+        )
+        .await
+        .expect("list_dividends with filter should succeed");
+        assert_eq!(filtered.len(), 1);
+
+        let empty = list_dividends(
+            &pool,
+            ListDividendsParams {
+                holding_id: Some("00000000-0000-0000-0000-000000000000".to_string()),
+            },
+        )
+        .await
+        .expect("list_dividends with non-matching filter should succeed");
+        assert_eq!(empty.len(), 0);
+    }
+}

--- a/portfolio-mcp/src/tools/holdings.rs
+++ b/portfolio-mcp/src/tools/holdings.rs
@@ -45,6 +45,40 @@ pub struct AddHoldingParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateHoldingParams {
+    /// UUID of the holding to update.
+    pub id: String,
+    /// Ticker symbol (e.g. "AAPL", "BTC-USD", "CASH-CAD").
+    pub symbol: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Asset class: "stock", "etf", "crypto", or "cash".
+    pub asset_type: String,
+    /// Account type: "tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", or "other".
+    pub account: String,
+    /// Optional explicit account UUID (overrides account-type lookup).
+    pub account_id: Option<String>,
+    /// Number of units held.
+    pub quantity: f64,
+    /// Average cost per unit in the holding's native currency.
+    pub cost_basis: f64,
+    /// ISO 4217 currency code (e.g. "CAD", "USD").
+    pub currency: String,
+    /// Exchange identifier (e.g. "TSX", "NASDAQ").
+    pub exchange: String,
+    /// Target portfolio weight as a percentage (0–100). Omit to leave unset.
+    pub target_weight: Option<f64>,
+    /// Indicated annual dividend per unit in the dividend currency.
+    pub indicated_annual_dividend: Option<f64>,
+    pub indicated_annual_dividend_currency: Option<String>,
+    /// Dividend frequency: "monthly", "quarterly", "semi-annual", "annual", "irregular".
+    pub dividend_frequency: Option<String>,
+    /// Maturity date for fixed-income positions (ISO 8601 date string).
+    pub maturity_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct DeleteHoldingParams {
     /// UUID of the holding to delete.
     pub id: String,
@@ -109,6 +143,73 @@ pub async fn add_holding(pool: &SqlitePool, params: AddHoldingParams) -> Result<
         .map_err(PortfolioMcpServer::tool_error)
 }
 
+pub async fn update_holding(
+    pool: &SqlitePool,
+    params: UpdateHoldingParams,
+) -> Result<Holding, McpError> {
+    validation::validate_id("id", &params.id)?;
+
+    let asset_type = params
+        .asset_type
+        .parse::<AssetType>()
+        .map_err(|e| McpError::invalid_params(e, None))?;
+
+    let account = params
+        .account
+        .parse::<AccountType>()
+        .map_err(|e| McpError::invalid_params(e, None))?;
+
+    validation::validate_non_empty("symbol", &params.symbol)?;
+    validation::validate_non_empty("name", &params.name)?;
+    let currency =
+        validation::validate_holding_fields(params.quantity, params.cost_basis, &params.currency)?;
+    validation::validate_target_weight(params.target_weight)?;
+    validation::validate_holding_dividend_fields(
+        params.indicated_annual_dividend,
+        params.dividend_frequency.as_deref(),
+        params.maturity_date.as_deref(),
+    )?;
+
+    if let Some(target_weight) = params.target_weight {
+        let existing_sum = db::sum_target_weights(pool, Some(params.id.as_str()))
+            .await
+            .map_err(PortfolioMcpServer::tool_error)?;
+        validation::validate_target_weight_budget(Some(target_weight), existing_sum)?;
+    }
+
+    let existing = db::get_holding_by_id(pool, &params.id)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)?
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Holding {} not found", params.id), None)
+        })?;
+
+    let holding = Holding {
+        id: HoldingId(params.id),
+        symbol: params.symbol,
+        name: params.name,
+        asset_type,
+        account,
+        account_id: params.account_id,
+        account_name: existing.account_name,
+        quantity: params.quantity,
+        cost_basis: params.cost_basis,
+        currency,
+        exchange: params.exchange,
+        target_weight: params.target_weight,
+        created_at: existing.created_at,
+        updated_at: existing.updated_at,
+        indicated_annual_dividend: params.indicated_annual_dividend,
+        indicated_annual_dividend_currency: params.indicated_annual_dividend_currency,
+        dividend_frequency: params.dividend_frequency,
+        maturity_date: params.maturity_date,
+    };
+
+    db::update_holding(pool, holding)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)
+}
+
 pub async fn delete_holding(
     pool: &SqlitePool,
     params: DeleteHoldingParams,
@@ -167,5 +268,119 @@ mod tests {
         )
         .await;
         assert!(result.is_err(), "malformed ID must be rejected");
+    }
+
+    const VALID_HOLDING_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    fn make_update_params(id: &str) -> UpdateHoldingParams {
+        UpdateHoldingParams {
+            id: id.to_string(),
+            symbol: "AAPL".to_string(),
+            name: "Apple Inc.".to_string(),
+            asset_type: "stock".to_string(),
+            account: "taxable".to_string(),
+            account_id: None,
+            quantity: 5.0,
+            cost_basis: 120.0,
+            currency: "USD".to_string(),
+            exchange: "NASDAQ".to_string(),
+            target_weight: None,
+            indicated_annual_dividend: None,
+            indicated_annual_dividend_currency: None,
+            dividend_frequency: None,
+            maturity_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn update_holding_rejects_empty_id() {
+        let pool = test_pool().await;
+        let result = update_holding(&pool, make_update_params("")).await;
+        assert!(result.is_err(), "empty ID must be rejected");
+    }
+
+    #[tokio::test]
+    async fn update_holding_rejects_malformed_id() {
+        let pool = test_pool().await;
+        let result = update_holding(&pool, make_update_params("not-a-uuid")).await;
+        assert!(result.is_err(), "malformed ID must be rejected");
+    }
+
+    #[tokio::test]
+    async fn update_holding_rejects_non_positive_quantity() {
+        let pool = test_pool().await;
+        let mut params = make_update_params(VALID_HOLDING_ID);
+        params.quantity = 0.0;
+        let result = update_holding(&pool, params).await;
+        assert!(result.is_err(), "non-positive quantity must be rejected");
+    }
+
+    async fn test_pool_full() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query(
+            "CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT, type TEXT, \
+             institution TEXT, created_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create accounts table");
+        sqlx::query(
+            "CREATE TABLE holdings (
+                id TEXT PRIMARY KEY, symbol TEXT, name TEXT, asset_type TEXT, account TEXT,
+                account_id TEXT, quantity REAL, cost_basis REAL, currency TEXT, exchange TEXT,
+                target_weight REAL, created_at TEXT, updated_at TEXT,
+                indicated_annual_dividend REAL, indicated_annual_dividend_currency TEXT,
+                dividend_frequency TEXT, maturity_date TEXT, deleted_at TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create holdings table");
+        pool
+    }
+
+    #[tokio::test]
+    async fn update_holding_rejects_when_not_found() {
+        let pool = test_pool_full().await;
+        let result = update_holding(&pool, make_update_params(VALID_HOLDING_ID)).await;
+        assert!(
+            result.is_err(),
+            "updating a nonexistent holding must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_holding_updates_existing_holding() {
+        let pool = test_pool_full().await;
+        let created_at = "2024-01-01T00:00:00Z";
+        sqlx::query(
+            "INSERT INTO holdings (id, symbol, name, asset_type, account, account_id,
+                quantity, cost_basis, currency, exchange, target_weight, created_at, updated_at)
+             VALUES ($1, 'AAPL', 'Apple', 'stock', 'taxable', NULL, 1.0, 100.0, 'CAD',
+                     'NASDAQ', NULL, $2, $2)",
+        )
+        .bind(VALID_HOLDING_ID)
+        .bind(created_at)
+        .execute(&pool)
+        .await
+        .expect("seed holding");
+
+        let mut params = make_update_params(VALID_HOLDING_ID);
+        params.currency = "  usd ".to_string();
+        let updated = update_holding(&pool, params)
+            .await
+            .expect("update_holding should succeed");
+
+        assert_eq!(updated.quantity, 5.0);
+        assert_eq!(updated.cost_basis, 120.0);
+        assert_eq!(updated.name, "Apple Inc.");
+        assert_eq!(updated.currency, "USD", "currency must be normalized");
+        assert_eq!(
+            updated.created_at, created_at,
+            "created_at must be preserved from the existing row"
+        );
     }
 }

--- a/portfolio-mcp/src/tools/mod.rs
+++ b/portfolio-mcp/src/tools/mod.rs
@@ -1,5 +1,7 @@
+pub mod accounts;
 pub mod alerts;
 pub mod config;
+pub mod dividends;
 pub mod holdings;
 pub mod portfolio;
 pub mod stress;
@@ -58,12 +60,73 @@ impl PortfolioMcpServer {
             .and_then(|v| Self::json_content(&v))
     }
 
+    #[tool(description = "Update an existing holding's editable fields (full replace).")]
+    async fn update_holding(
+        &self,
+        #[tool(aggr)] input: holdings::UpdateHoldingParams,
+    ) -> Result<CallToolResult, McpError> {
+        holdings::update_holding(&self.pool, input)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
     #[tool(description = "Soft-delete a holding by its UUID.")]
     async fn delete_holding(
         &self,
         #[tool(aggr)] input: holdings::DeleteHoldingParams,
     ) -> Result<CallToolResult, McpError> {
         holdings::delete_holding(&self.pool, input)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
+    // ── Accounts ──────────────────────────────────────────────────────────────
+
+    #[tool(description = "List all accounts (id, name, type, institution).")]
+    async fn list_accounts(&self) -> Result<CallToolResult, McpError> {
+        accounts::list_accounts(&self.pool)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
+    #[tool(description = "Create a new account.")]
+    async fn create_account(
+        &self,
+        #[tool(aggr)] input: accounts::CreateAccountParams,
+    ) -> Result<CallToolResult, McpError> {
+        accounts::create_account(&self.pool, input)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
+    // ── Dividends ─────────────────────────────────────────────────────────────
+
+    #[tool(description = "List dividend records, optionally filtered by holding UUID.")]
+    async fn list_dividends(
+        &self,
+        #[tool(aggr)] input: dividends::ListDividendsParams,
+    ) -> Result<CallToolResult, McpError> {
+        dividends::list_dividends(&self.pool, input)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
+    #[tool(description = "Record a new dividend payment for a holding.")]
+    async fn add_dividend(
+        &self,
+        #[tool(aggr)] input: dividends::AddDividendParams,
+    ) -> Result<CallToolResult, McpError> {
+        dividends::add_dividend(&self.pool, input)
+            .await
+            .and_then(|v| Self::json_content(&v))
+    }
+
+    #[tool(description = "Soft-delete a dividend record by its UUID.")]
+    async fn delete_dividend(
+        &self,
+        #[tool(aggr)] input: dividends::DeleteDividendParams,
+    ) -> Result<CallToolResult, McpError> {
+        dividends::delete_dividend(&self.pool, input)
             .await
             .and_then(|v| Self::json_content(&v))
     }

--- a/portfolio-mcp/src/tools/portfolio.rs
+++ b/portfolio-mcp/src/tools/portfolio.rs
@@ -13,6 +13,15 @@ pub async fn get_portfolio_snapshot(pool: &SqlitePool) -> Result<PortfolioSnapsh
         .map_err(PortfolioMcpServer::tool_error)?
         .unwrap_or_else(|| "CAD".to_string());
 
+    // If the user has never explicitly chosen a cost-basis method, flag the
+    // snapshot so the caller can prompt for an explicit selection before
+    // displaying realized gains — mirrors `get_portfolio_impl` in
+    // `src-tauri/src/commands/portfolio.rs`.
+    let requires_cost_basis_selection = db::get_config(pool, "cost_basis_method")
+        .await
+        .map_err(PortfolioMcpServer::tool_error)?
+        .is_none();
+
     let holdings = db::get_all_holdings(pool)
         .await
         .map_err(PortfolioMcpServer::tool_error)?;
@@ -30,7 +39,7 @@ pub async fn get_portfolio_snapshot(pool: &SqlitePool) -> Result<PortfolioSnapsh
     // `realized_gains` and `annual_dividend_income` are not computed here to
     // keep this read path lightweight.  They default to 0 in the MCP context;
     // the Tauri app performs the full calculation via separate DB queries.
-    let snapshot = snapshot::build_portfolio_snapshot(
+    let mut snapshot = snapshot::build_portfolio_snapshot(
         &holdings,
         &cached_prices,
         &cached_fx,
@@ -39,6 +48,80 @@ pub async fn get_portfolio_snapshot(pool: &SqlitePool) -> Result<PortfolioSnapsh
         0.0,
         0.0,
     );
+    snapshot.requires_cost_basis_selection = requires_cost_basis_selection;
 
     Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query("CREATE TABLE app_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .expect("create app_config table");
+        sqlx::query(
+            "CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT, type TEXT, \
+             institution TEXT, created_at TEXT)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create accounts table");
+        sqlx::query(
+            "CREATE TABLE holdings (
+                id TEXT PRIMARY KEY, symbol TEXT, name TEXT, asset_type TEXT, account TEXT,
+                account_id TEXT, quantity REAL, cost_basis REAL, currency TEXT, exchange TEXT,
+                target_weight REAL, created_at TEXT, updated_at TEXT,
+                indicated_annual_dividend REAL, indicated_annual_dividend_currency TEXT,
+                dividend_frequency TEXT, maturity_date TEXT, deleted_at TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create holdings table");
+        sqlx::query(
+            "CREATE TABLE price_cache (symbol TEXT PRIMARY KEY, price REAL, currency TEXT, \
+             change REAL, change_percent REAL, updated_at TEXT, open REAL, \
+             previous_close REAL, volume INTEGER)",
+        )
+        .execute(&pool)
+        .await
+        .expect("create price_cache table");
+        sqlx::query("CREATE TABLE fx_rates (pair TEXT PRIMARY KEY, rate REAL, updated_at TEXT)")
+            .execute(&pool)
+            .await
+            .expect("create fx_rates table");
+        pool
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_snapshot_requires_cost_basis_selection_when_unset() {
+        // Regression guard for #693: requiresCostBasisSelection was always
+        // false in the MCP snapshot, even when the user never chose a method.
+        let pool = test_pool().await;
+        let snapshot = get_portfolio_snapshot(&pool)
+            .await
+            .expect("snapshot should succeed");
+        assert!(snapshot.requires_cost_basis_selection);
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_snapshot_does_not_require_cost_basis_selection_when_set() {
+        let pool = test_pool().await;
+        sqlx::query("INSERT INTO app_config (key, value) VALUES ('cost_basis_method', 'avco')")
+            .execute(&pool)
+            .await
+            .expect("seed cost_basis_method");
+        let snapshot = get_portfolio_snapshot(&pool)
+            .await
+            .expect("snapshot should succeed");
+        assert!(!snapshot.requires_cost_basis_selection);
+    }
 }

--- a/portfolio-mcp/src/types.rs
+++ b/portfolio-mcp/src/types.rs
@@ -154,3 +154,52 @@ pub struct PriceAlertInput {
     pub note: String,
 }
 
+/// Typed wrapper for a dividend's UUID string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct DividendId(pub String);
+
+impl std::fmt::Display for DividendId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// ── Accounts / Dividends ─────────────────────────────────────────────────────
+// Not part of `portfolio-core` (unlike Holding/PortfolioSnapshot) since they
+// aren't consumed by `build_portfolio_snapshot`; mirrored from
+// `src-tauri/src/types.rs` instead.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Account {
+    pub id: String,
+    pub name: String,
+    pub account_type: String,
+    pub institution: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Dividend {
+    pub id: DividendId,
+    pub holding_id: HoldingId,
+    pub symbol: String,
+    pub amount_per_unit: f64,
+    pub currency: String,
+    pub ex_date: String,
+    pub pay_date: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DividendInput {
+    pub holding_id: HoldingId,
+    pub amount_per_unit: f64,
+    pub currency: String,
+    pub ex_date: String,
+    pub pay_date: String,
+}
+

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -247,6 +247,63 @@ const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
 /// Mirrors `MAX_CONFIG_VALUE_LEN` in `src-tauri/src/commands/config.rs`.
 const MAX_CONFIG_VALUE_LEN: usize = 500;
 
+/// Account types accepted by `create_account`, mirrors `VALID_ACCOUNT_TYPES`
+/// in `src-tauri/src/commands/accounts.rs`.
+pub const VALID_ACCOUNT_TYPES: &[&str] =
+    &["tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", "other"];
+
+/// Mirrors `validate_account_fields` in `src-tauri/src/commands/accounts.rs`.
+/// Returns the trimmed name on success.
+pub fn validate_account_fields(name: &str, account_type: &str) -> Result<String, McpError> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err(McpError::invalid_params(
+            "Account name cannot be empty",
+            None,
+        ));
+    }
+    if !VALID_ACCOUNT_TYPES.contains(&account_type) {
+        return Err(McpError::invalid_params(
+            format!("Invalid account type: {account_type}"),
+            None,
+        ));
+    }
+    Ok(name)
+}
+
+/// Mirrors `validate_dividend_fields` in `src-tauri/src/commands/mod.rs`.
+pub fn validate_dividend_fields(
+    amount_per_unit: f64,
+    ex_date: &str,
+    pay_date: &str,
+) -> Result<(), McpError> {
+    if !amount_per_unit.is_finite() || amount_per_unit <= 0.0 {
+        return Err(McpError::invalid_params(
+            "amountPerUnit must be a finite number greater than 0",
+            None,
+        ));
+    }
+    if chrono::NaiveDate::parse_from_str(ex_date.trim(), "%Y-%m-%d").is_err() {
+        return Err(McpError::invalid_params(
+            "exDate must be a valid ISO date (YYYY-MM-DD)",
+            None,
+        ));
+    }
+    if chrono::NaiveDate::parse_from_str(pay_date.trim(), "%Y-%m-%d").is_err() {
+        return Err(McpError::invalid_params(
+            "payDate must be a valid ISO date (YYYY-MM-DD)",
+            None,
+        ));
+    }
+    if pay_date < ex_date {
+        return Err(McpError::invalid_params(
+            "payDate must not be before exDate",
+            None,
+        ));
+    }
+    Ok(())
+}
+
 /// Mirrors `validate_config_value` in `src-tauri/src/commands/config.rs::set_config_cmd`.
 pub fn validate_config_value(key: &str, value: &str) -> Result<(), McpError> {
     match key {
@@ -581,5 +638,51 @@ mod tests {
     fn validate_config_value_rejects_other_keys_over_max_length() {
         let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
         assert!(validate_config_value("cost_basis_method", &too_long).is_err());
+    }
+
+    #[test]
+    fn validate_account_fields_rejects_empty_and_whitespace_name() {
+        assert!(validate_account_fields("", "tfsa").is_err());
+        assert!(validate_account_fields("   ", "tfsa").is_err());
+    }
+
+    #[test]
+    fn validate_account_fields_rejects_unknown_type() {
+        assert!(validate_account_fields("My Account", "not-a-type").is_err());
+    }
+
+    #[test]
+    fn validate_account_fields_trims_name_and_accepts_valid_input() {
+        let name = validate_account_fields("  My TFSA  ", "tfsa").expect("valid input");
+        assert_eq!(name, "My TFSA");
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_positive_amount() {
+        assert!(validate_dividend_fields(0.0, "2024-01-01", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(-1.0, "2024-01-01", "2024-01-15").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_finite_amount() {
+        assert!(validate_dividend_fields(f64::NAN, "2024-01-01", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(f64::INFINITY, "2024-01-01", "2024-01-15").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_iso_dates() {
+        assert!(validate_dividend_fields(1.0, "01/01/2024", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(1.0, "2024-01-01", "01/15/2024").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_pay_date_before_ex_date() {
+        assert!(validate_dividend_fields(1.0, "2024-01-15", "2024-01-01").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_accepts_valid_input() {
+        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-15").is_ok());
+        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-01").is_ok());
     }
 }


### PR DESCRIPTION
Closes #686
Closes #687
Closes #688
Closes #689
Closes #692
Closes #693

## Summary
- **#686**: Added `update_holding` MCP tool (`portfolio-mcp/src/tools/holdings.rs`), mirroring the Tauri `update_holding` command — validates fields, enforces the target-weight budget, preserves `created_at`/`account_name` via a new `db::get_holding_by_id` lookup, and calls a new `db::update_holding`.
- **#687**: Added `list_accounts` and `create_account` MCP tools (`portfolio-mcp/src/tools/accounts.rs`), with validation mirroring `src-tauri/src/commands/accounts.rs::validate_account_fields`.
- **#688**: Added `list_dividends` (optional `holdingId` filter), `add_dividend`, and `delete_dividend` MCP tools (`portfolio-mcp/src/tools/dividends.rs`), with validation mirroring `src-tauri`'s `validate_dividend_fields` and the ex-date/pay-date/currency-match checks in `add_dividend`.
- **#689**: `portfolio-mcp/src/db.rs` now logs `tracing::warn!` when an unrecognized `asset_type`/`account` value from the DB falls back to a default, matching the Tauri side (previously silent).
- **#692**: `list_holdings`, `list_transactions`, and `list_alerts` now cap their underlying queries with a `PAGINATION_FETCH_ALL_SIZE` (500) `LIMIT`, matching the max `page_size` enforced by the Tauri `*_paginated` commands, instead of an unbounded `SELECT`.
- **#693**: `get_portfolio_snapshot` now reads the `cost_basis_method` config key and sets `requiresCostBasisSelection` accordingly, mirroring `get_portfolio_impl` in `src-tauri/src/commands/portfolio.rs` (previously always `false`).

## Test plan
- [x] `cargo build` (workspace) — clean, no warnings
- [x] `cargo test -p portfolio-mcp` — 81 passed (28 new tests for update_holding, accounts, dividends, validation, requiresCostBasisSelection)
- [x] `cargo test` in `src-tauri` — 313 passed
- [x] `NODE_ENV=development npm test -- --run` (frontend) — 364 passed
- [x] Pre-push hook (lint, typecheck, format, build, tests, clippy) — all passed