### PR TITLE
feat: import pipeline backend — multi-section CSV parser and plan builder

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -5,11 +5,36 @@ use tauri::State;
 use crate::csv::{build_holdings_csv, parse_import_rows};
 use crate::db;
 use crate::error::AppError;
+use crate::import_pipeline;
 use crate::types::{
-    AssetType, HoldingInput, ImportError, ImportResult, PreviewImportResult, PreviewRow,
+    AssetType, HoldingInput, ImportCommitRequest, ImportCommitResult, ImportContext, ImportError,
+    ImportPlan, ImportResult, PreviewImportResult, PreviewRow,
 };
 
 use super::{validate_symbol, DbState, HttpClient, WEIGHT_EPSILON};
+
+/// Reads and normalizes a source file (CSV; multi-section bank exports are
+/// auto-detected) into a reviewable `ImportPlan`. Never writes to the DB —
+/// see `commit_import` for that. This is the new Import Plus Insights
+/// pipeline, separate from `import_holdings_csv`/`preview_import_csv` above.
+#[tauri::command]
+pub async fn parse_import_file(
+    db: State<'_, DbState>,
+    file_path: String,
+    context: ImportContext,
+) -> Result<ImportPlan, AppError> {
+    import_pipeline::build_import_plan(&db.0, &file_path, &context).await
+}
+
+/// Writes the rows the user selected from an `ImportPlan` to the DB and
+/// returns a summary with insight deltas for the post-import panel.
+#[tauri::command]
+pub async fn commit_import(
+    db: State<'_, DbState>,
+    request: ImportCommitRequest,
+) -> Result<ImportCommitResult, AppError> {
+    import_pipeline::commit_import_rows(&db.0, &request).await
+}
 
 #[tauri::command]
 pub async fn export_holdings_csv(db: State<'_, DbState>) -> Result<String, AppError> {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -37,6 +37,10 @@ pub const MAX_IMPORT_ROWS: usize = 500;
 /// Maximum length (in bytes) for any individual string field in a CSV import row.
 pub const MAX_FIELD_LEN: usize = 500;
 
+/// Maximum size (in bytes) of a file accepted by the `parse_import_file` pipeline.
+/// Guards against loading an excessively large or malicious file fully into memory.
+pub const MAX_IMPORT_FILE_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
+
 // ── Cache TTLs ────────────────────────────────────────────────────────────────
 
 /// How long (seconds) a symbol search result is cached in memory and SQLite.

--- a/src-tauri/src/csv.rs
+++ b/src-tauri/src/csv.rs
@@ -99,7 +99,7 @@ pub fn build_holdings_csv(holdings: &[Holding]) -> Result<String, String> {
     String::from_utf8(bytes).map_err(|e| e.to_string())
 }
 
-fn detect_csv_delimiter(content: &str) -> u8 {
+pub(crate) fn detect_csv_delimiter(content: &str) -> u8 {
     let first_line = content.lines().next().unwrap_or_default();
     if first_line.contains(';') && !first_line.contains(',') {
         b';'

--- a/src-tauri/src/import_pipeline/aliases.rs
+++ b/src-tauri/src/import_pipeline/aliases.rs
@@ -1,0 +1,318 @@
+//! Column alias registry, asset-class mapping, and symbol resolution for the
+//! import pipeline. See docs/superpowers/specs/2026-05-24-import-plus-insights-design.md.
+
+/// Country codes with a known Yahoo Finance exchange-suffix mapping in
+/// `crate::csv::normalize_symbol_for_import`. Anything else is passed through
+/// unsuffixed and flagged with a warning rather than silently guessed.
+const KNOWN_COUNTRY_CODES: &[&str] = &["US", "CA", "GB", "DE", "FR", "AU", "JP", "HK"];
+
+/// Maps a source CSV header to a canonical holding field, using a static
+/// curated alias registry. Matching is case-insensitive and trims whitespace.
+/// Returns `None` for headers with no known mapping (preserved in preview
+/// metadata but otherwise ignored).
+pub fn canonical_field(header: &str) -> Option<&'static str> {
+    match header.trim().to_lowercase().as_str() {
+        "symbol" | "ticker" | "security id" | "cusip" | "isin" => Some("symbol"),
+        "security description"
+        | "description"
+        | "security name"
+        | "investment name"
+        | "holding name"
+        | "name" => Some("name"),
+        "quantity" | "shares" | "units" | "qty" | "open qty" | "number of shares"
+        | "units held" | "position quantity" => Some("quantity"),
+        "average cost"
+        | "avg cost"
+        | "book cost per share"
+        | "cost per unit"
+        | "average book cost"
+        | "book value per unit"
+        | "unit cost"
+        | "average buy price"
+        | "book cost per unit" => Some("average_cost"),
+        "total cost" | "book value" | "book cost" | "adjusted cost base" | "acb"
+        | "total book value" | "cost basis" => Some("book_value"),
+        "average cost currency" | "settlement currency" | "currency" | "ccy" | "denomination" => {
+            Some("currency")
+        }
+        "market value"
+        | "current value"
+        | "total market value"
+        | "current market value"
+        | "value" => Some("market_value"),
+        "asset class" | "asset type" | "type" | "security type" | "category"
+        | "investment type" | "product type" => Some("asset_type"),
+        "exchange" | "market" | "listing exchange" | "market code" => Some("exchange"),
+        "settled cash" | "trade cash" | "cash balance" | "cash" | "cash position" | "balance" => {
+            Some("cash_balance")
+        }
+        "dividend yield (%)" | "dividend yield" => Some("dividend_yield"),
+        "annualized income" => Some("annualized_income"),
+        "ex-dividend date" | "ex dividend date" => Some("ex_dividend_date"),
+        _ => None,
+    }
+}
+
+/// Maps a source `Asset Class` value to an app asset type string
+/// ("Stock" | "ETF" | "Crypto" | "Cash" | "Other"), plus an optional warning.
+/// A blank value returns `(None, None)`; the caller marks the row `NeedsFix`.
+///
+/// Note: the app's `AssetType` enum only has four variants (stock/etf/crypto/
+/// cash) — there is no persisted "Other" asset type today. Rows that resolve
+/// to "Other" are shown in the plan with a warning (matching the design doc),
+/// but `commit_import` cannot write them to the holdings table and reports
+/// them as a skipped-with-error row instead of silently miscategorizing them.
+pub fn map_asset_class(raw: &str) -> (Option<String>, Option<String>) {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return (None, None);
+    }
+    match trimmed.to_lowercase().as_str() {
+        "equity" => (Some("Stock".to_string()), None),
+        "etf" | "mutual fund" => (Some("ETF".to_string()), None),
+        "crypto" | "cryptocurrency" => (Some("Crypto".to_string()), None),
+        "cash" => (Some("Cash".to_string()), None),
+        "fixed income" | "gic" | "money market" | "bond" => (
+            Some("Other".to_string()),
+            Some(format!(
+                "Asset class '{trimmed}' has no live pricing support and is imported as Other"
+            )),
+        ),
+        _ => (
+            Some("Other".to_string()),
+            Some(format!(
+                "Unrecognized asset class '{trimmed}'; imported as Other (no live pricing)"
+            )),
+        ),
+    }
+}
+
+/// Resolves a `SYMBOL:COUNTRY` (or plain) symbol to a Yahoo Finance symbol,
+/// reusing the app's existing country-suffix logic
+/// (`crate::csv::normalize_symbol_for_import`). Returns the resolved symbol
+/// plus an optional warning when the country code isn't one of the app's
+/// known exchange suffixes (the symbol is still returned, unsuffixed).
+pub fn resolve_symbol(raw: &str) -> (String, Option<String>) {
+    let resolved = crate::csv::normalize_symbol_for_import(raw);
+    let warning = raw.trim().split_once(':').and_then(|(_, country)| {
+        let cc = country.trim().to_uppercase();
+        if cc.is_empty() || KNOWN_COUNTRY_CODES.contains(&cc.as_str()) {
+            None
+        } else {
+            Some(format!(
+                "Unrecognized country code '{}' in symbol '{}'; kept without an exchange suffix",
+                cc,
+                raw.trim()
+            ))
+        }
+    });
+    (resolved, warning)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── canonical_field: at least 10 alias cases across different fields ──
+
+    #[test]
+    fn canonical_field_matches_symbol_aliases() {
+        assert_eq!(canonical_field("Symbol"), Some("symbol"));
+        assert_eq!(canonical_field("Ticker"), Some("symbol"));
+        assert_eq!(canonical_field("CUSIP"), Some("symbol"));
+        assert_eq!(canonical_field("isin"), Some("symbol"));
+    }
+
+    #[test]
+    fn canonical_field_matches_name_aliases() {
+        assert_eq!(canonical_field("Security Description"), Some("name"));
+        assert_eq!(canonical_field("Investment Name"), Some("name"));
+    }
+
+    #[test]
+    fn canonical_field_matches_quantity_aliases() {
+        assert_eq!(canonical_field("Quantity"), Some("quantity"));
+        assert_eq!(canonical_field("Open Qty"), Some("quantity"));
+        assert_eq!(canonical_field("Number of Shares"), Some("quantity"));
+    }
+
+    #[test]
+    fn canonical_field_matches_average_cost_aliases() {
+        assert_eq!(canonical_field("Average Cost"), Some("average_cost"));
+        assert_eq!(canonical_field("Avg Cost"), Some("average_cost"));
+        assert_eq!(canonical_field("Average Buy Price"), Some("average_cost"));
+    }
+
+    #[test]
+    fn canonical_field_matches_book_value_aliases() {
+        assert_eq!(canonical_field("Total Cost"), Some("book_value"));
+        assert_eq!(canonical_field("Adjusted Cost Base"), Some("book_value"));
+        assert_eq!(canonical_field("ACB"), Some("book_value"));
+    }
+
+    #[test]
+    fn canonical_field_matches_currency_aliases() {
+        assert_eq!(canonical_field("Average Cost Currency"), Some("currency"));
+        assert_eq!(canonical_field("Settlement Currency"), Some("currency"));
+        assert_eq!(canonical_field("CCY"), Some("currency"));
+    }
+
+    #[test]
+    fn canonical_field_matches_market_value_aliases() {
+        assert_eq!(canonical_field("Market Value"), Some("market_value"));
+        assert_eq!(canonical_field("Current Value"), Some("market_value"));
+    }
+
+    #[test]
+    fn canonical_field_matches_asset_type_aliases() {
+        assert_eq!(canonical_field("Asset Class"), Some("asset_type"));
+        assert_eq!(canonical_field("Security Type"), Some("asset_type"));
+    }
+
+    #[test]
+    fn canonical_field_matches_exchange_aliases() {
+        assert_eq!(canonical_field("Exchange"), Some("exchange"));
+        assert_eq!(canonical_field("Listing Exchange"), Some("exchange"));
+    }
+
+    #[test]
+    fn canonical_field_matches_cash_balance_aliases() {
+        assert_eq!(canonical_field("Settled Cash"), Some("cash_balance"));
+        assert_eq!(canonical_field("Trade Cash"), Some("cash_balance"));
+    }
+
+    #[test]
+    fn canonical_field_matches_insight_metadata_aliases() {
+        assert_eq!(
+            canonical_field("Dividend Yield (%)"),
+            Some("dividend_yield")
+        );
+        assert_eq!(
+            canonical_field("Annualized Income"),
+            Some("annualized_income")
+        );
+        assert_eq!(
+            canonical_field("Ex-Dividend Date"),
+            Some("ex_dividend_date")
+        );
+    }
+
+    #[test]
+    fn canonical_field_is_case_and_whitespace_insensitive() {
+        assert_eq!(canonical_field("  SYMBOL  "), Some("symbol"));
+        assert_eq!(canonical_field("aVeRaGe CoSt"), Some("average_cost"));
+    }
+
+    #[test]
+    fn canonical_field_returns_none_for_unknown_header() {
+        assert_eq!(canonical_field("Some Random Column"), None);
+    }
+
+    // ── SYMBOL:COUNTRY resolution ──────────────────────────────────────────
+
+    #[test]
+    fn resolve_symbol_us_has_no_suffix_and_no_warning() {
+        let (resolved, warning) = resolve_symbol("AAPL:US");
+        assert_eq!(resolved, "AAPL");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn resolve_symbol_ca_adds_to_suffix_and_no_warning() {
+        let (resolved, warning) = resolve_symbol("TD:CA");
+        assert_eq!(resolved, "TD.TO");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn resolve_symbol_gb_adds_l_suffix_and_no_warning() {
+        let (resolved, warning) = resolve_symbol("BARC:GB");
+        assert_eq!(resolved, "BARC.L");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn resolve_symbol_de_fr_au_known_suffixes_have_no_warning() {
+        assert_eq!(resolve_symbol("SAP:DE"), ("SAP.DE".to_string(), None));
+        assert_eq!(resolve_symbol("AIR:FR"), ("AIR.PA".to_string(), None));
+        assert_eq!(resolve_symbol("CBA:AU"), ("CBA.AX".to_string(), None));
+    }
+
+    #[test]
+    fn resolve_symbol_unknown_country_code_flags_warning_but_keeps_symbol() {
+        let (resolved, warning) = resolve_symbol("XYZ:ZZ");
+        assert_eq!(resolved, "XYZ");
+        let warning = warning.expect("unknown country code should produce a warning");
+        assert!(warning.contains("ZZ"));
+        assert!(warning.contains("XYZ"));
+    }
+
+    #[test]
+    fn resolve_symbol_plain_symbol_has_no_warning() {
+        let (resolved, warning) = resolve_symbol("AAPL");
+        assert_eq!(resolved, "AAPL");
+        assert!(warning.is_none());
+    }
+
+    // ── Asset class mapping ─────────────────────────────────────────────────
+
+    #[test]
+    fn map_asset_class_equity_maps_to_stock() {
+        assert_eq!(map_asset_class("Equity"), (Some("Stock".to_string()), None));
+    }
+
+    #[test]
+    fn map_asset_class_etf_and_mutual_fund_map_to_etf() {
+        assert_eq!(map_asset_class("ETF"), (Some("ETF".to_string()), None));
+        assert_eq!(
+            map_asset_class("Mutual Fund"),
+            (Some("ETF".to_string()), None)
+        );
+    }
+
+    #[test]
+    fn map_asset_class_crypto_maps_to_crypto() {
+        assert_eq!(
+            map_asset_class("Crypto"),
+            (Some("Crypto".to_string()), None)
+        );
+        assert_eq!(
+            map_asset_class("Cryptocurrency"),
+            (Some("Crypto".to_string()), None)
+        );
+    }
+
+    #[test]
+    fn map_asset_class_cash_maps_to_cash() {
+        assert_eq!(map_asset_class("Cash"), (Some("Cash".to_string()), None));
+    }
+
+    #[test]
+    fn map_asset_class_fixed_income_maps_to_other_with_warning() {
+        let (asset_type, warning) = map_asset_class("Fixed Income");
+        assert_eq!(asset_type, Some("Other".to_string()));
+        let warning = warning.expect("Fixed Income should produce a warning");
+        assert!(warning.contains("Fixed Income"));
+        assert!(warning.contains("no live pricing"));
+    }
+
+    #[test]
+    fn map_asset_class_gic_and_money_market_map_to_other_with_warning() {
+        assert!(map_asset_class("GIC").1.is_some());
+        assert!(map_asset_class("Money Market").1.is_some());
+        assert_eq!(map_asset_class("GIC").0, Some("Other".to_string()));
+    }
+
+    #[test]
+    fn map_asset_class_blank_returns_none() {
+        assert_eq!(map_asset_class(""), (None, None));
+        assert_eq!(map_asset_class("   "), (None, None));
+    }
+
+    #[test]
+    fn map_asset_class_unrecognized_value_maps_to_other_with_warning() {
+        let (asset_type, warning) = map_asset_class("Structured Note");
+        assert_eq!(asset_type, Some("Other".to_string()));
+        assert!(warning.is_some());
+    }
+}

--- a/src-tauri/src/import_pipeline/commit.rs
+++ b/src-tauri/src/import_pipeline/commit.rs
@@ -1,0 +1,502 @@
+//! Commits the rows a user selected from an `ImportPlan` to the database,
+//! and computes the insight deltas shown in the post-import summary panel.
+
+use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use sqlx::SqlitePool;
+
+use crate::db;
+use crate::error::AppError;
+use crate::types::{
+    AccountType, AssetType, Holding, HoldingInput, ImportCommitRequest, ImportCommitResult,
+    RowAction,
+};
+
+/// Mirrors `portfolio_core::snapshot`'s private staleness check (24 h) —
+/// duplicated locally rather than made `pub` across the crate boundary for
+/// what is a small, self-contained calculation.
+const PRICE_STALE_SECS: i64 = 24 * 3600;
+
+fn is_price_stale(updated_at: &str) -> bool {
+    DateTime::parse_from_rfc3339(updated_at)
+        .ok()
+        .map(|t| {
+            Utc::now()
+                .signed_duration_since(t.with_timezone(&Utc))
+                .num_seconds()
+                > PRICE_STALE_SECS
+        })
+        .unwrap_or(true)
+}
+
+fn empty_result() -> ImportCommitResult {
+    ImportCommitResult {
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        errors: Vec::new(),
+        new_symbols: Vec::new(),
+        changed_symbols: Vec::new(),
+        missing_from_import: Vec::new(),
+        stale_symbols: Vec::new(),
+    }
+}
+
+/// Commits the rows selected by the user (`request.plan_rows`) to the DB.
+///
+/// Rows whose `action` is `Skip` or `NeedsFix` are counted as skipped and
+/// never written. Rows whose resolved `asset_type` doesn't map to one of the
+/// app's four persisted asset types (`stock`/`etf`/`crypto`/`cash` — there is
+/// no "Other" asset type in the schema today, see
+/// `import_pipeline::aliases::map_asset_class`) are reported as a per-row
+/// error and skipped, rather than silently miscategorized or panicking.
+/// Cash rows are only committed when `include_cash` is set.
+///
+/// Each row is committed independently (not inside one all-or-nothing
+/// transaction, unlike the legacy CSV importer): a failure on one row is
+/// recorded in `errors` and does not prevent the remaining rows from being
+/// committed.
+pub async fn commit_import_rows(
+    pool: &SqlitePool,
+    request: &ImportCommitRequest,
+) -> Result<ImportCommitResult, AppError> {
+    let mut result = empty_result();
+
+    let existing_holdings = db::get_all_holdings(pool).await?;
+    let existing_by_symbol: HashMap<String, &Holding> = existing_holdings
+        .iter()
+        .filter(|h| h.account_id.as_deref() == Some(request.account_id.as_str()))
+        .map(|h| (h.symbol.to_uppercase(), h))
+        .collect();
+
+    let mut committed_symbols: HashSet<String> = HashSet::new();
+    let symbols_in_request: HashSet<String> = request
+        .plan_rows
+        .iter()
+        .filter_map(|r| r.resolved_symbol.clone().or_else(|| r.symbol.clone()))
+        .map(|s| s.to_uppercase())
+        .collect();
+
+    for row in &request.plan_rows {
+        if !matches!(
+            row.action,
+            RowAction::Create | RowAction::Update | RowAction::Warning
+        ) {
+            result.skipped += 1;
+            continue;
+        }
+
+        let Some(asset_type_str) = row.asset_type.as_deref() else {
+            result.errors.push(format!(
+                "Row {}: missing asset type; skipped",
+                row.row_number
+            ));
+            result.skipped += 1;
+            continue;
+        };
+
+        if asset_type_str.eq_ignore_ascii_case("cash") && !request.include_cash {
+            result.skipped += 1;
+            continue;
+        }
+
+        let Ok(asset_type) = AssetType::from_str(&asset_type_str.to_lowercase()) else {
+            result.errors.push(format!(
+                "Row {}: asset type '{}' is not yet supported for holdings (no live pricing model); skipped",
+                row.row_number, asset_type_str
+            ));
+            result.skipped += 1;
+            continue;
+        };
+
+        let (Some(symbol), Some(quantity), Some(cost_basis), Some(currency)) = (
+            row.resolved_symbol.clone().or_else(|| row.symbol.clone()),
+            row.quantity,
+            row.cost_basis,
+            row.currency.clone(),
+        ) else {
+            result.errors.push(format!(
+                "Row {}: missing required field(s) at commit time; skipped",
+                row.row_number
+            ));
+            result.skipped += 1;
+            continue;
+        };
+
+        let symbol_key = symbol.to_uppercase();
+        let name = row
+            .name
+            .clone()
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or_else(|| symbol.clone());
+        let account =
+            AccountType::from_str(&row.account_type.to_lowercase()).unwrap_or(AccountType::Other);
+
+        if let Some(existing) = existing_by_symbol.get(&symbol_key) {
+            let quantity_changed = (existing.quantity - quantity).abs() > f64::EPSILON;
+            let cost_basis_changed = (existing.cost_basis - cost_basis).abs() > f64::EPSILON;
+            let updated = Holding {
+                id: existing.id.clone(),
+                symbol: symbol.clone(),
+                name,
+                asset_type,
+                account,
+                account_id: Some(request.account_id.clone()),
+                account_name: existing.account_name.clone(),
+                quantity,
+                cost_basis,
+                currency,
+                exchange: existing.exchange.clone(),
+                target_weight: existing.target_weight,
+                created_at: existing.created_at.clone(),
+                updated_at: existing.updated_at.clone(),
+                indicated_annual_dividend: existing.indicated_annual_dividend,
+                indicated_annual_dividend_currency: existing
+                    .indicated_annual_dividend_currency
+                    .clone(),
+                dividend_frequency: existing.dividend_frequency.clone(),
+                maturity_date: existing.maturity_date.clone(),
+            };
+            match db::update_holding(pool, updated).await {
+                Ok(_) => {
+                    result.updated += 1;
+                    committed_symbols.insert(symbol_key);
+                    if quantity_changed || cost_basis_changed {
+                        result.changed_symbols.push(symbol);
+                    }
+                }
+                Err(e) => {
+                    result.errors.push(format!(
+                        "Row {}: failed to update {}: {}",
+                        row.row_number, symbol, e
+                    ));
+                    result.skipped += 1;
+                }
+            }
+        } else {
+            let input = HoldingInput {
+                symbol: symbol.clone(),
+                name,
+                asset_type,
+                account,
+                account_id: Some(request.account_id.clone()),
+                quantity,
+                cost_basis,
+                currency,
+                exchange: String::new(),
+                target_weight: None,
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            };
+            match db::insert_holding(pool, input).await {
+                Ok(_) => {
+                    result.created += 1;
+                    committed_symbols.insert(symbol_key);
+                    result.new_symbols.push(symbol);
+                }
+                Err(e) => {
+                    result.errors.push(format!(
+                        "Row {}: failed to create {}: {}",
+                        row.row_number, symbol, e
+                    ));
+                    result.skipped += 1;
+                }
+            }
+        }
+    }
+
+    // Existing holdings in the target account whose symbol never appeared
+    // anywhere in the submitted plan rows — review candidates only, never
+    // auto-deleted.
+    for (symbol_key, holding) in &existing_by_symbol {
+        if !symbols_in_request.contains(symbol_key) {
+            result.missing_from_import.push(holding.symbol.clone());
+        }
+    }
+
+    // Stale/unpriced symbols among what was actually committed this run.
+    if !committed_symbols.is_empty() {
+        let cached_prices = db::get_cached_prices(pool).await?;
+        let price_by_symbol: HashMap<String, &crate::types::PriceData> = cached_prices
+            .iter()
+            .map(|p| (p.symbol.to_uppercase(), p))
+            .collect();
+        for symbol_key in &committed_symbols {
+            if symbol_key.ends_with("-CASH") {
+                continue; // cash never has a live price
+            }
+            match price_by_symbol.get(symbol_key) {
+                None => result.stale_symbols.push(symbol_key.clone()),
+                Some(price) if is_price_stale(&price.updated_at) => {
+                    result.stale_symbols.push(symbol_key.clone())
+                }
+                Some(_) => {}
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{NormalizedImportRow, PriceData};
+
+    fn base_row(row_number: usize) -> NormalizedImportRow {
+        NormalizedImportRow {
+            row_number,
+            action: RowAction::Create,
+            symbol: Some("AAPL".to_string()),
+            resolved_symbol: Some("AAPL".to_string()),
+            name: Some("Apple Inc.".to_string()),
+            asset_type: Some("Stock".to_string()),
+            quantity: Some(10.0),
+            cost_basis: Some(150.0),
+            cost_basis_source: Some("average_cost".to_string()),
+            currency: Some("USD".to_string()),
+            book_value: None,
+            market_value: None,
+            account_type: "taxable".to_string(),
+            account_name: None,
+            warnings: Vec::new(),
+            errors: Vec::new(),
+            raw: HashMap::new(),
+            dividend_yield: None,
+            annualized_income: None,
+            ex_dividend_date: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn commit_creates_a_new_holding() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![base_row(8)],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 1);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.new_symbols, vec!["AAPL".to_string()]);
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(holdings.len(), 1);
+        assert_eq!(holdings[0].symbol, "AAPL");
+    }
+
+    #[tokio::test]
+    async fn commit_updates_existing_holding_and_reports_changed_symbol() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+        db::insert_holding(
+            &pool,
+            HoldingInput {
+                symbol: "AAPL".to_string(),
+                name: "Apple Inc.".to_string(),
+                asset_type: AssetType::Stock,
+                account: AccountType::Taxable,
+                account_id: Some("acct-1".to_string()),
+                quantity: 5.0,
+                cost_basis: 100.0,
+                currency: "USD".to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut row = base_row(8);
+        row.action = RowAction::Update;
+        row.quantity = Some(10.0);
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.updated, 1);
+        assert_eq!(result.created, 0);
+        assert_eq!(result.changed_symbols, vec!["AAPL".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn commit_skips_needs_fix_and_skip_rows() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let mut needs_fix = base_row(8);
+        needs_fix.action = RowAction::NeedsFix;
+        let mut skip = base_row(9);
+        skip.action = RowAction::Skip;
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![needs_fix, skip],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 0);
+        assert_eq!(result.updated, 0);
+        assert_eq!(result.skipped, 2);
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_unsupported_asset_type_other_with_error() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let mut row = base_row(8);
+        row.action = RowAction::Warning;
+        row.asset_type = Some("Other".to_string());
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 0);
+        assert_eq!(result.skipped, 1);
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.contains("not yet supported")));
+    }
+
+    #[tokio::test]
+    async fn commit_excludes_cash_rows_when_include_cash_is_false() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Cash", "cash", None)
+            .await
+            .unwrap();
+
+        let mut row = base_row(5);
+        row.symbol = Some("CAD-CASH".to_string());
+        row.resolved_symbol = Some("CAD-CASH".to_string());
+        row.asset_type = Some("Cash".to_string());
+        row.cost_basis = Some(1.0);
+        row.currency = Some("CAD".to_string());
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 0);
+        assert_eq!(result.skipped, 1);
+    }
+
+    #[tokio::test]
+    async fn missing_from_import_lists_existing_holdings_not_in_the_request() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+        db::insert_holding(
+            &pool,
+            HoldingInput {
+                symbol: "MSFT".to_string(),
+                name: "Microsoft".to_string(),
+                asset_type: AssetType::Stock,
+                account: AccountType::Taxable,
+                account_id: Some("acct-1".to_string()),
+                quantity: 5.0,
+                cost_basis: 200.0,
+                currency: "USD".to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![base_row(8)], // only AAPL in this import
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.missing_from_import, vec!["MSFT".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn stale_symbols_reported_when_no_cached_price_exists() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![base_row(8)],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.stale_symbols, vec!["AAPL".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn fresh_cached_price_is_not_reported_as_stale() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+        db::upsert_price(
+            &pool,
+            &PriceData {
+                symbol: "AAPL".to_string(),
+                price: 150.0,
+                currency: "USD".to_string(),
+                change: 0.0,
+                change_percent: 0.0,
+                updated_at: Utc::now().to_rfc3339(),
+                open: None,
+                previous_close: None,
+                volume: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let request = ImportCommitRequest {
+            plan_rows: vec![base_row(8)],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert!(result.stale_symbols.is_empty());
+    }
+}

--- a/src-tauri/src/import_pipeline/commit.rs
+++ b/src-tauri/src/import_pipeline/commit.rs
@@ -72,6 +72,13 @@ pub async fn commit_import_rows(
         .collect();
 
     let mut committed_symbols: HashSet<String> = HashSet::new();
+    // Guards against two rows in the same request resolving to the same
+    // symbol (e.g. a duplicate the plan flagged as `Skip` gets flipped back
+    // on by the client): `existing_by_symbol` is a snapshot taken once
+    // before this loop and is never updated as rows are written, so without
+    // this a second matching row would independently miss it and insert a
+    // duplicate holding rather than being treated as an update.
+    let mut attempted_symbols: HashSet<String> = HashSet::new();
     let symbols_in_request: HashSet<String> = request
         .plan_rows
         .iter()
@@ -125,7 +132,25 @@ pub async fn commit_import_rows(
             continue;
         };
 
+        if quantity < 0.0 {
+            result.errors.push(format!(
+                "Row {}: negative quantity ({}) — short positions are not supported; skipped",
+                row.row_number, quantity
+            ));
+            result.skipped += 1;
+            continue;
+        }
+
         let symbol_key = symbol.to_uppercase();
+        if !attempted_symbols.insert(symbol_key.clone()) {
+            result.errors.push(format!(
+                "Row {}: duplicate symbol '{}' already processed earlier in this commit request; skipped",
+                row.row_number, symbol
+            ));
+            result.skipped += 1;
+            continue;
+        }
+
         let name = row
             .name
             .clone()
@@ -410,6 +435,62 @@ mod tests {
 
         assert_eq!(result.created, 0);
         assert_eq!(result.skipped, 1);
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_negative_quantity_with_a_friendly_error_not_a_raw_db_error() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let mut row = base_row(8);
+        row.action = RowAction::Warning;
+        row.quantity = Some(-5.0);
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 0);
+        assert_eq!(result.skipped, 1);
+        assert!(result
+            .errors
+            .iter()
+            .any(|e| e.contains("negative quantity") && !e.contains("CHECK")));
+    }
+
+    #[tokio::test]
+    async fn commit_rejects_second_row_with_a_duplicate_symbol_in_the_same_request() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let mut second = base_row(9);
+        second.quantity = Some(20.0);
+        let request = ImportCommitRequest {
+            plan_rows: vec![base_row(8), second],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(
+            result.created, 1,
+            "only the first occurrence should be created"
+        );
+        assert_eq!(result.skipped, 1);
+        assert!(result.errors.iter().any(|e| e.contains("duplicate symbol")));
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(
+            holdings.len(),
+            1,
+            "the duplicate must not create a second row"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/import_pipeline/mod.rs
+++ b/src-tauri/src/import_pipeline/mod.rs
@@ -1,0 +1,372 @@
+//! Import Plus Insights backend pipeline: read file -> detect format ->
+//! extract sections -> infer columns -> normalize rows -> build import plan
+//! -> commit selected clean rows -> return summary and insights.
+//!
+//! See docs/superpowers/specs/2026-05-24-import-plus-insights-design.md.
+//! This is a new, separate pipeline from the legacy `parse_import_rows`
+//! path in `crate::csv` (still used by `import_holdings_csv`/
+//! `preview_import_csv`), which remains as a compatibility path.
+
+pub mod aliases;
+pub mod commit;
+pub mod normalize;
+pub mod parser;
+
+use std::collections::HashSet;
+
+use sqlx::SqlitePool;
+
+use crate::db;
+use crate::error::AppError;
+use crate::types::{ColumnMapping, ImportContext, ImportPlan, NormalizedImportRow, RowAction};
+
+pub use commit::commit_import_rows;
+
+fn read_import_file(file_path: &str) -> Result<String, AppError> {
+    let path = std::fs::canonicalize(file_path)
+        .map_err(|e| AppError::Validation(format!("Cannot resolve file path: {e}")))?;
+    let metadata = std::fs::metadata(&path)
+        .map_err(|e| AppError::Validation(format!("Cannot read file: {e}")))?;
+    if metadata.len() > crate::config::MAX_IMPORT_FILE_BYTES {
+        return Err(AppError::Validation(format!(
+            "Import file exceeds the maximum size of {} bytes",
+            crate::config::MAX_IMPORT_FILE_BYTES
+        )));
+    }
+    std::fs::read_to_string(&path)
+        .map_err(|e| AppError::Validation(format!("Cannot read file: {e}")))
+}
+
+/// Builds column mappings for a set of headers, tagging validated
+/// multi-section headers with "profile" confidence and everything else with
+/// "alias" confidence (or "unmapped" when no canonical field is known).
+/// User-selected `column_overrides` always win, with "user" confidence.
+fn build_column_mappings(
+    headers: &[String],
+    profile: &str,
+    overrides: &std::collections::HashMap<String, String>,
+) -> Vec<ColumnMapping> {
+    headers
+        .iter()
+        .map(|header| {
+            if let Some(canonical) = overrides.get(header) {
+                return ColumnMapping {
+                    source_header: header.clone(),
+                    canonical_field: Some(canonical.clone()),
+                    confidence: "user".to_string(),
+                    reason: format!("User-selected mapping: '{header}' -> {canonical}"),
+                };
+            }
+            match aliases::canonical_field(header) {
+                Some(field) => {
+                    let confidence = if profile == parser::PROFILE_CANADIAN_BANK_MULTI_SECTION {
+                        "profile"
+                    } else {
+                        "alias"
+                    };
+                    ColumnMapping {
+                        source_header: header.clone(),
+                        canonical_field: Some(field.to_string()),
+                        confidence: confidence.to_string(),
+                        reason: format!("Matched alias registry: '{header}' -> {field}"),
+                    }
+                }
+                None => ColumnMapping {
+                    source_header: header.clone(),
+                    canonical_field: None,
+                    confidence: "unmapped".to_string(),
+                    reason: format!("No known canonical field for '{header}'; ignored"),
+                },
+            }
+        })
+        .collect()
+}
+
+/// Marks the second and later occurrences of a resolved symbol within the
+/// same import file as `Skip` (a "duplicate" row, per the design doc), never
+/// overriding a row that's already `NeedsFix`.
+fn mark_intra_file_duplicates(rows: &mut [NormalizedImportRow]) {
+    let mut seen: HashSet<String> = HashSet::new();
+    for row in rows.iter_mut() {
+        if row.action == RowAction::NeedsFix {
+            continue;
+        }
+        let Some(symbol) = row.resolved_symbol.clone() else {
+            continue;
+        };
+        let key = symbol.to_uppercase();
+        if seen.contains(&key) {
+            row.action = RowAction::Skip;
+            row.warnings.push(format!(
+                "Duplicate symbol '{symbol}' already appears earlier in this file; skipped"
+            ));
+        } else {
+            seen.insert(key);
+        }
+    }
+}
+
+/// Reclassifies `Create` rows as `Update` when a holding with the same
+/// symbol already exists in the target account. Requires `account_id` to be
+/// known — a not-yet-created account has no existing holdings to match
+/// against, so every row stays `Create`.
+async fn classify_against_existing(
+    pool: &SqlitePool,
+    rows: &mut [NormalizedImportRow],
+    account_id: Option<&str>,
+) -> Result<(), AppError> {
+    let Some(account_id) = account_id else {
+        return Ok(());
+    };
+    let existing = db::get_all_holdings(pool).await?;
+    let existing_symbols: HashSet<String> = existing
+        .iter()
+        .filter(|h| h.account_id.as_deref() == Some(account_id))
+        .map(|h| h.symbol.to_uppercase())
+        .collect();
+    for row in rows.iter_mut() {
+        if row.action != RowAction::Create {
+            continue;
+        }
+        if let Some(symbol) = row.resolved_symbol.as_deref() {
+            if existing_symbols.contains(&symbol.to_uppercase()) {
+                row.action = RowAction::Update;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn count_actions(
+    rows: &[NormalizedImportRow],
+    cash_rows: &[NormalizedImportRow],
+) -> (usize, usize, usize, usize, usize) {
+    let mut create = 0;
+    let mut update = 0;
+    let mut skip = 0;
+    let mut needs_fix = 0;
+    let mut warning = 0;
+    for row in rows.iter().chain(cash_rows.iter()) {
+        match row.action {
+            RowAction::Create => create += 1,
+            RowAction::Update => update += 1,
+            RowAction::Skip => skip += 1,
+            RowAction::NeedsFix => needs_fix += 1,
+            RowAction::Warning => warning += 1,
+        }
+    }
+    (create, update, skip, needs_fix, warning)
+}
+
+/// Reads `file_path`, detects its format, normalizes every row, and
+/// classifies each row's proposed action. Never writes to the DB.
+pub async fn build_import_plan(
+    pool: &SqlitePool,
+    file_path: &str,
+    context: &ImportContext,
+) -> Result<ImportPlan, AppError> {
+    let content = read_import_file(file_path)?;
+    let detected = parser::detect_and_parse(&content).map_err(AppError::Validation)?;
+
+    let total_rows = detected.holdings_section.rows.len()
+        + detected
+            .cash_section
+            .as_ref()
+            .map(|s| s.rows.len())
+            .unwrap_or(0);
+    if total_rows > crate::config::MAX_IMPORT_ROWS {
+        return Err(AppError::Validation(format!(
+            "Import file has {total_rows} data rows, which exceeds the limit of {}",
+            crate::config::MAX_IMPORT_ROWS
+        )));
+    }
+
+    let mut column_mappings = build_column_mappings(
+        &detected.holdings_section.headers,
+        detected.profile,
+        &context.column_overrides,
+    );
+    if let Some(cash) = &detected.cash_section {
+        for mapping in
+            build_column_mappings(&cash.headers, detected.profile, &context.column_overrides)
+        {
+            if !column_mappings
+                .iter()
+                .any(|m| m.source_header == mapping.source_header)
+            {
+                column_mappings.push(mapping);
+            }
+        }
+    }
+
+    let mut rows: Vec<NormalizedImportRow> = detected
+        .holdings_section
+        .rows
+        .iter()
+        .map(|raw| normalize::normalize_row(raw, context))
+        .collect();
+    let mut cash_rows: Vec<NormalizedImportRow> = detected
+        .cash_section
+        .as_ref()
+        .map(|section| {
+            section
+                .rows
+                .iter()
+                .map(|raw| normalize::normalize_cash_row(raw, context))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    mark_intra_file_duplicates(&mut rows);
+    mark_intra_file_duplicates(&mut cash_rows);
+
+    classify_against_existing(pool, &mut rows, context.account_id.as_deref()).await?;
+    classify_against_existing(pool, &mut cash_rows, context.account_id.as_deref()).await?;
+
+    let (count_create, count_update, count_skip, count_needs_fix, count_warning) =
+        count_actions(&rows, &cash_rows);
+
+    Ok(ImportPlan {
+        profile_detected: detected.profile.to_string(),
+        column_mappings,
+        rows,
+        count_create,
+        count_update,
+        count_skip,
+        count_needs_fix,
+        count_warning,
+        suggested_account_type: detected.suggested_account_type,
+        suggested_account_number: detected.suggested_account_number,
+        cash_rows,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::db;
+
+    fn context(account_id: Option<&str>) -> ImportContext {
+        ImportContext {
+            account_type: "rrsp".to_string(),
+            account_name: Some("TD RRSP".to_string()),
+            account_id: account_id.map(str::to_string),
+            source_profile: None,
+            column_overrides: HashMap::new(),
+        }
+    }
+
+    const SAMPLE: &str = "Portfolio report for RRSP account # 12345 as of 2026-01-01T09:08:10\n\
+\n\
+Cash Details\n\
+Currency,Account Type,Settled Cash,Trade Cash\n\
+CAD,CASH,89192.24,89192.24\n\
+\n\
+Holding Details\n\
+Asset Class,Sector,Security Description,Symbol,Quantity,Average Cost,Average Cost Currency\n\
+Equity,Information Tech.,APPLE INC,AAPL:US,100,135.5045,USD\n\
+\n\
+\n\
+Exchange Rate: 1 CAD = 0.7126USD  1 USD = 1.4033CAD\n";
+
+    #[tokio::test]
+    async fn build_plan_from_multi_section_sample_produces_expected_counts() {
+        let pool = db::open_test_db().await;
+        let dir = std::env::temp_dir().join(format!("import-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sample.csv");
+        std::fs::write(&path, SAMPLE).unwrap();
+
+        let plan = build_import_plan(&pool, path.to_str().unwrap(), &context(None))
+            .await
+            .expect("plan should build");
+
+        assert_eq!(
+            plan.profile_detected,
+            parser::PROFILE_CANADIAN_BANK_MULTI_SECTION
+        );
+        assert_eq!(plan.rows.len(), 1);
+        assert_eq!(plan.cash_rows.len(), 1);
+        assert_eq!(plan.count_create, 2);
+        assert_eq!(plan.suggested_account_type, Some("RRSP".to_string()));
+        assert_eq!(plan.suggested_account_number, Some("12345".to_string()));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn existing_holding_in_target_account_is_classified_as_update() {
+        let pool = db::open_test_db().await;
+        let account_id = "acct-1";
+        db::insert_account(&pool, account_id, "TD RRSP", "rrsp", None)
+            .await
+            .expect("insert account");
+        db::insert_holding(
+            &pool,
+            crate::types::HoldingInput {
+                symbol: "AAPL".to_string(),
+                name: "Apple Inc.".to_string(),
+                asset_type: crate::types::AssetType::Stock,
+                account: crate::types::AccountType::Rrsp,
+                account_id: Some(account_id.to_string()),
+                quantity: 50.0,
+                cost_basis: 100.0,
+                currency: "USD".to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+        )
+        .await
+        .expect("insert holding");
+
+        let dir = std::env::temp_dir().join(format!("import-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sample.csv");
+        std::fs::write(&path, SAMPLE).unwrap();
+
+        let plan = build_import_plan(&pool, path.to_str().unwrap(), &context(Some(account_id)))
+            .await
+            .expect("plan should build");
+
+        assert_eq!(plan.rows[0].action, RowAction::Update);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn duplicate_symbol_within_file_is_marked_skip() {
+        let pool = db::open_test_db().await;
+        let content = "Symbol,Asset Class,Quantity,Average Cost,Currency\n\
+                        AAPL,Equity,10,100,USD\n\
+                        AAPL,Equity,5,110,USD\n";
+        let dir = std::env::temp_dir().join(format!("import-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sample.csv");
+        std::fs::write(&path, content).unwrap();
+
+        let plan = build_import_plan(&pool, path.to_str().unwrap(), &context(None))
+            .await
+            .expect("plan should build");
+
+        assert_eq!(plan.rows.len(), 2);
+        assert_eq!(plan.rows[0].action, RowAction::Create);
+        assert_eq!(plan.rows[1].action, RowAction::Skip);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn nonexistent_file_path_returns_validation_error() {
+        let pool = db::open_test_db().await;
+        let err = build_import_plan(&pool, "/no/such/file.csv", &context(None))
+            .await
+            .expect_err("missing file should error");
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+}

--- a/src-tauri/src/import_pipeline/mod.rs
+++ b/src-tauri/src/import_pipeline/mod.rs
@@ -22,9 +22,31 @@ use crate::types::{ColumnMapping, ImportContext, ImportPlan, NormalizedImportRow
 
 pub use commit::commit_import_rows;
 
+/// Extensions accepted by `parse_import_file`. `file_path` is expected to
+/// come from a native file-picker dialog (as `restore_database`'s
+/// `source_path` does), but this pipeline has no content-based validation
+/// analogous to `restore_database`'s SQLite magic-byte check, so the
+/// extension allowlist is the cheapest guard against pointing it at an
+/// arbitrary file on disk.
+const ALLOWED_IMPORT_EXTENSIONS: &[&str] = &["csv", "txt"];
+
 fn read_import_file(file_path: &str) -> Result<String, AppError> {
     let path = std::fs::canonicalize(file_path)
         .map_err(|e| AppError::Validation(format!("Cannot resolve file path: {e}")))?;
+    let has_allowed_extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            ALLOWED_IMPORT_EXTENSIONS
+                .iter()
+                .any(|a| ext.eq_ignore_ascii_case(a))
+        });
+    if !has_allowed_extension {
+        return Err(AppError::Validation(format!(
+            "Import file must have one of these extensions: {}",
+            ALLOWED_IMPORT_EXTENSIONS.join(", ")
+        )));
+    }
     let metadata = std::fs::metadata(&path)
         .map_err(|e| AppError::Validation(format!("Cannot read file: {e}")))?;
     if metadata.len() > crate::config::MAX_IMPORT_FILE_BYTES {
@@ -203,7 +225,7 @@ pub async fn build_import_plan(
         .holdings_section
         .rows
         .iter()
-        .map(|raw| normalize::normalize_row(raw, context))
+        .map(|raw| normalize::normalize_row(raw, &detected.holdings_section.headers, context))
         .collect();
     let mut cash_rows: Vec<NormalizedImportRow> = detected
         .cash_section
@@ -368,5 +390,21 @@ Exchange Rate: 1 CAD = 0.7126USD  1 USD = 1.4033CAD\n";
             .await
             .expect_err("missing file should error");
         assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn disallowed_file_extension_is_rejected() {
+        let pool = db::open_test_db().await;
+        let dir = std::env::temp_dir().join(format!("import-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("sample.exe");
+        std::fs::write(&path, SAMPLE).unwrap();
+
+        let err = build_import_plan(&pool, path.to_str().unwrap(), &context(None))
+            .await
+            .expect_err("disallowed extension should be rejected");
+        assert!(matches!(err, AppError::Validation(_)));
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src-tauri/src/import_pipeline/normalize.rs
+++ b/src-tauri/src/import_pipeline/normalize.rs
@@ -1,0 +1,430 @@
+//! Row normalization: turns one raw source row into a `NormalizedImportRow`,
+//! classifying it as `Create` (default; reclassified against the DB later),
+//! `NeedsFix`, or `Warning`.
+
+use std::collections::HashMap;
+
+use crate::import_pipeline::aliases::{canonical_field, map_asset_class, resolve_symbol};
+use crate::import_pipeline::parser::RawRow;
+use crate::types::{ImportContext, NormalizedImportRow, RowAction};
+
+/// Case-insensitive lookup of a raw row value by its original header text.
+fn raw_get<'a>(row: &'a HashMap<String, String>, header: &str) -> Option<&'a str> {
+    row.iter()
+        .find(|(k, _)| k.trim().eq_ignore_ascii_case(header))
+        .map(|(_, v)| v.as_str())
+        .filter(|v| !v.trim().is_empty())
+}
+
+/// Builds a canonical-field -> value map from a row's headers, using the
+/// alias registry. The first header that maps to a given canonical field
+/// wins, so an earlier, more specific column (e.g. `Average Cost Currency`)
+/// is not silently overwritten by a later generic alias collision.
+fn build_canonical_map(row: &HashMap<String, String>) -> HashMap<&'static str, String> {
+    let mut map = HashMap::new();
+    for (header, value) in row {
+        if value.trim().is_empty() {
+            continue;
+        }
+        if let Some(field) = canonical_field(header) {
+            map.entry(field).or_insert_with(|| value.clone());
+        }
+    }
+    map
+}
+
+fn parse_f64(value: Option<&str>) -> Option<f64> {
+    value.and_then(|v| v.trim().parse::<f64>().ok())
+}
+
+/// Derives `(cost_basis, cost_basis_source)`:
+/// 1. Directly from `average_cost` (already per-unit).
+/// 2. Otherwise from `book_value / quantity` when quantity is positive.
+/// 3. Otherwise `(None, None)` — the caller marks the row `NeedsFix`.
+fn derive_cost_basis(
+    average_cost: Option<f64>,
+    book_value: Option<f64>,
+    quantity: Option<f64>,
+) -> (Option<f64>, Option<String>) {
+    if let Some(ac) = average_cost {
+        return (Some(ac), Some("average_cost".to_string()));
+    }
+    if let (Some(bv), Some(q)) = (book_value, quantity) {
+        if q > 0.0 {
+            return (Some(bv / q), Some("derived:total_cost/qty".to_string()));
+        }
+    }
+    (None, None)
+}
+
+/// Normalizes one Holding Details / generic-CSV row into a
+/// `NormalizedImportRow`. Shared by both `CanadianBankMultiSection` and
+/// generic-CSV profiles — the profile only affects section detection, not
+/// this per-row algorithm.
+pub fn normalize_row(raw: &RawRow, context: &ImportContext) -> NormalizedImportRow {
+    let canonical = build_canonical_map(&raw.values);
+
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    // ── Symbol ──
+    let symbol_raw = canonical.get("symbol").cloned();
+    let (resolved_symbol, symbol_warning) = match symbol_raw.as_deref() {
+        Some(s) if !s.trim().is_empty() => {
+            let (resolved, warning) = resolve_symbol(s);
+            (Some(resolved), warning)
+        }
+        _ => (None, None),
+    };
+    if let Some(w) = symbol_warning {
+        warnings.push(w);
+    }
+    if symbol_raw
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        errors.push("Missing or unresolvable symbol".to_string());
+    }
+
+    // ── Name ──
+    let name = canonical.get("name").cloned();
+
+    // ── Asset type ──
+    let asset_type_raw = canonical.get("asset_type").cloned().unwrap_or_default();
+    let (asset_type, asset_type_warning) = map_asset_class(&asset_type_raw);
+    if asset_type.is_none() {
+        errors.push("Missing asset class".to_string());
+    }
+    if let Some(w) = asset_type_warning {
+        warnings.push(w);
+    }
+
+    // ── Quantity ──
+    let quantity = parse_f64(canonical.get("quantity").map(|s| s.as_str()));
+    match quantity {
+        None => errors.push("Missing or invalid quantity".to_string()),
+        Some(0.0) => errors.push("Quantity is zero".to_string()),
+        Some(q) if q < 0.0 => warnings.push(format!(
+            "Negative quantity ({q}) — short positions are not modeled; row kept as-is"
+        )),
+        _ => {}
+    }
+
+    // ── Currency: Average Cost Currency > Settlement Currency > generic alias ──
+    let average_cost_currency = raw_get(&raw.values, "Average Cost Currency");
+    let settlement_currency = raw_get(&raw.values, "Settlement Currency");
+    let currency = average_cost_currency
+        .or(settlement_currency)
+        .map(str::to_string)
+        .or_else(|| canonical.get("currency").cloned());
+    if currency.as_deref().map(str::trim).unwrap_or("").is_empty() {
+        errors.push("Missing currency".to_string());
+    }
+    if let (Some(acc), Some(sc)) = (average_cost_currency, settlement_currency) {
+        if !acc.eq_ignore_ascii_case(sc) {
+            warnings.push(format!(
+                "Settlement Currency ({sc}) does not match Average Cost Currency ({acc})"
+            ));
+        }
+    }
+
+    // ── Cost basis ──
+    let average_cost = parse_f64(canonical.get("average_cost").map(|s| s.as_str()));
+    let book_value = parse_f64(canonical.get("book_value").map(|s| s.as_str()));
+    let (cost_basis, cost_basis_source) = derive_cost_basis(average_cost, book_value, quantity);
+    if cost_basis.is_none() {
+        errors.push("Could not determine cost basis (no Average Cost, and no Total Cost/Quantity to derive from)".to_string());
+    }
+
+    let market_value = parse_f64(canonical.get("market_value").map(|s| s.as_str()));
+    let dividend_yield = parse_f64(canonical.get("dividend_yield").map(|s| s.as_str()));
+    let annualized_income = parse_f64(canonical.get("annualized_income").map(|s| s.as_str()));
+    let ex_dividend_date = canonical.get("ex_dividend_date").cloned();
+
+    let action = if !errors.is_empty() {
+        RowAction::NeedsFix
+    } else if !warnings.is_empty() {
+        RowAction::Warning
+    } else {
+        RowAction::Create
+    };
+
+    NormalizedImportRow {
+        row_number: raw.row_number,
+        action,
+        symbol: symbol_raw,
+        resolved_symbol,
+        name,
+        asset_type,
+        quantity,
+        cost_basis,
+        cost_basis_source,
+        currency,
+        book_value,
+        market_value,
+        account_type: context.account_type.clone(),
+        account_name: context.account_name.clone(),
+        warnings,
+        errors,
+        raw: raw.values.clone(),
+        dividend_yield,
+        annualized_income,
+        ex_dividend_date,
+    }
+}
+
+/// Normalizes one row from the Cash Details section
+/// (`Currency, Account Type, Settled Cash, Trade Cash`) into a synthetic cash
+/// holding candidate: symbol `{CURRENCY}-CASH`, cost basis fixed at 1.0.
+pub fn normalize_cash_row(raw: &RawRow, context: &ImportContext) -> NormalizedImportRow {
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    let currency = raw_get(&raw.values, "Currency").map(str::to_string);
+    if currency.is_none() {
+        errors.push("Cash row is missing a Currency".to_string());
+    }
+    let quantity = parse_f64(raw_get(&raw.values, "Settled Cash"));
+    if quantity.is_none() {
+        errors.push("Cash row has a missing or invalid Settled Cash balance".to_string());
+    } else if quantity == Some(0.0) {
+        warnings.push("Settled Cash balance is zero".to_string());
+    }
+
+    let symbol = currency
+        .as_ref()
+        .map(|c| format!("{}-CASH", c.to_uppercase()));
+
+    let action = if !errors.is_empty() {
+        RowAction::NeedsFix
+    } else if !warnings.is_empty() {
+        RowAction::Warning
+    } else {
+        RowAction::Create
+    };
+
+    NormalizedImportRow {
+        row_number: raw.row_number,
+        action,
+        symbol: symbol.clone(),
+        resolved_symbol: symbol,
+        name: currency.as_ref().map(|c| format!("{c} Cash")),
+        asset_type: Some("Cash".to_string()),
+        quantity,
+        cost_basis: Some(1.0),
+        cost_basis_source: Some("fixed:cash".to_string()),
+        currency: currency.clone(),
+        book_value: None,
+        market_value: None,
+        account_type: context.account_type.clone(),
+        account_name: context.account_name.clone(),
+        warnings,
+        errors,
+        raw: raw.values.clone(),
+        dividend_yield: None,
+        annualized_income: None,
+        ex_dividend_date: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context() -> ImportContext {
+        ImportContext {
+            account_type: "RRSP".to_string(),
+            account_name: Some("TD RRSP".to_string()),
+            account_id: None,
+            source_profile: None,
+            column_overrides: HashMap::new(),
+        }
+    }
+
+    fn row(pairs: &[(&str, &str)], row_number: usize) -> RawRow {
+        let mut values = HashMap::new();
+        for (k, v) in pairs {
+            values.insert(k.to_string(), v.to_string());
+        }
+        RawRow { row_number, values }
+    }
+
+    #[test]
+    fn cost_basis_direct_from_average_cost() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Average Cost", "135.50"),
+                ("Average Cost Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.cost_basis, Some(135.50));
+        assert_eq!(
+            normalized.cost_basis_source,
+            Some("average_cost".to_string())
+        );
+        assert_eq!(normalized.action, RowAction::Create);
+    }
+
+    #[test]
+    fn cost_basis_derived_from_total_cost_over_quantity() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Total Cost", "13550.0"),
+                ("Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.cost_basis, Some(135.5));
+        assert_eq!(
+            normalized.cost_basis_source,
+            Some("derived:total_cost/qty".to_string())
+        );
+    }
+
+    #[test]
+    fn needs_fix_when_cost_basis_undeterminable() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+        assert!(normalized.cost_basis.is_none());
+        assert!(normalized.errors.iter().any(|e| e.contains("cost basis")));
+    }
+
+    #[test]
+    fn needs_fix_when_symbol_blank() {
+        let r = row(
+            &[
+                ("Symbol", ""),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Average Cost", "10"),
+                ("Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+        assert!(normalized.symbol.is_none());
+        assert!(normalized.errors.iter().any(|e| e.contains("symbol")));
+    }
+
+    #[test]
+    fn warning_when_asset_class_is_fixed_income() {
+        let r = row(
+            &[
+                ("Symbol", "GIC123"),
+                ("Asset Class", "Fixed Income"),
+                ("Quantity", "1"),
+                ("Average Cost", "1000"),
+                ("Currency", "CAD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::Warning);
+        assert_eq!(normalized.asset_type, Some("Other".to_string()));
+        assert!(normalized
+            .warnings
+            .iter()
+            .any(|w| w.contains("no live pricing")));
+    }
+
+    #[test]
+    fn currency_priority_prefers_average_cost_currency_over_settlement_currency() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Average Cost", "135.50"),
+                ("Average Cost Currency", "USD"),
+                ("Settlement Currency", "CAD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.currency, Some("USD".to_string()));
+        assert!(normalized
+            .warnings
+            .iter()
+            .any(|w| w.contains("Settlement Currency")));
+    }
+
+    #[test]
+    fn negative_quantity_is_a_warning_not_needs_fix() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "-5"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::Warning);
+        assert!(normalized.warnings.iter().any(|w| w.contains("Negative")));
+    }
+
+    #[test]
+    fn zero_quantity_is_needs_fix() {
+        let r = row(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "0"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+            ],
+            8,
+        );
+        let normalized = normalize_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+    }
+
+    #[test]
+    fn cash_row_parses_from_cash_details_section() {
+        let r = row(
+            &[
+                ("Currency", "CAD"),
+                ("Account Type", "CASH"),
+                ("Settled Cash", "89192.24"),
+                ("Trade Cash", "89192.24"),
+            ],
+            5,
+        );
+        let normalized = normalize_cash_row(&r, &context());
+        assert_eq!(normalized.symbol, Some("CAD-CASH".to_string()));
+        assert_eq!(normalized.currency, Some("CAD".to_string()));
+        assert_eq!(normalized.quantity, Some(89192.24));
+        assert_eq!(normalized.cost_basis, Some(1.0));
+        assert_eq!(normalized.action, RowAction::Create);
+    }
+
+    #[test]
+    fn cash_row_needs_fix_when_settled_cash_missing() {
+        let r = row(&[("Currency", "CAD"), ("Account Type", "CASH")], 5);
+        let normalized = normalize_cash_row(&r, &context());
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+    }
+}

--- a/src-tauri/src/import_pipeline/normalize.rs
+++ b/src-tauri/src/import_pipeline/normalize.rs
@@ -16,25 +16,43 @@ fn raw_get<'a>(row: &'a HashMap<String, String>, header: &str) -> Option<&'a str
         .filter(|v| !v.trim().is_empty())
 }
 
-/// Builds a canonical-field -> value map from a row's headers, using the
-/// alias registry. The first header that maps to a given canonical field
-/// wins, so an earlier, more specific column (e.g. `Average Cost Currency`)
-/// is not silently overwritten by a later generic alias collision.
-fn build_canonical_map(row: &HashMap<String, String>) -> HashMap<&'static str, String> {
+/// Builds a canonical-field -> value map from a row, walking `headers` in
+/// their original column order (not `row`'s `HashMap` iteration order, which
+/// is unordered) so that when two columns alias to the same canonical field,
+/// the earlier-declared column deterministically wins rather than whichever
+/// happened to be visited last. `overrides` (user-selected column mappings
+/// from the review UI) take priority over the static alias registry.
+fn build_canonical_map(
+    row: &HashMap<String, String>,
+    headers: &[String],
+    overrides: &HashMap<String, String>,
+) -> HashMap<String, String> {
     let mut map = HashMap::new();
-    for (header, value) in row {
+    for header in headers {
+        let Some(value) = row.get(header) else {
+            continue;
+        };
         if value.trim().is_empty() {
             continue;
         }
-        if let Some(field) = canonical_field(header) {
+        let field = overrides
+            .get(header)
+            .cloned()
+            .or_else(|| canonical_field(header).map(str::to_string));
+        if let Some(field) = field {
             map.entry(field).or_insert_with(|| value.clone());
         }
     }
     map
 }
 
+/// Parses a numeric field, rejecting non-finite results (`NaN`/`Infinity`,
+/// including overflow like `1e400`) that would otherwise silently bypass the
+/// `>= 0` sign checks below and the `holdings` table's `CHECK` constraints.
 fn parse_f64(value: Option<&str>) -> Option<f64> {
-    value.and_then(|v| v.trim().parse::<f64>().ok())
+    value
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .filter(|n| n.is_finite())
 }
 
 /// Derives `(cost_basis, cost_basis_source)`:
@@ -61,8 +79,12 @@ fn derive_cost_basis(
 /// `NormalizedImportRow`. Shared by both `CanadianBankMultiSection` and
 /// generic-CSV profiles — the profile only affects section detection, not
 /// this per-row algorithm.
-pub fn normalize_row(raw: &RawRow, context: &ImportContext) -> NormalizedImportRow {
-    let canonical = build_canonical_map(&raw.values);
+pub fn normalize_row(
+    raw: &RawRow,
+    headers: &[String],
+    context: &ImportContext,
+) -> NormalizedImportRow {
+    let canonical = build_canonical_map(&raw.values, headers, &context.column_overrides);
 
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
@@ -134,8 +156,12 @@ pub fn normalize_row(raw: &RawRow, context: &ImportContext) -> NormalizedImportR
     let average_cost = parse_f64(canonical.get("average_cost").map(|s| s.as_str()));
     let book_value = parse_f64(canonical.get("book_value").map(|s| s.as_str()));
     let (cost_basis, cost_basis_source) = derive_cost_basis(average_cost, book_value, quantity);
-    if cost_basis.is_none() {
-        errors.push("Could not determine cost basis (no Average Cost, and no Total Cost/Quantity to derive from)".to_string());
+    match cost_basis {
+        None => errors.push(
+            "Could not determine cost basis (no Average Cost, and no Total Cost/Quantity to derive from)".to_string(),
+        ),
+        Some(cb) if cb < 0.0 => errors.push(format!("Cost basis cannot be negative ({cb})")),
+        _ => {}
     }
 
     let market_value = parse_f64(canonical.get("market_value").map(|s| s.as_str()));
@@ -251,9 +277,24 @@ mod tests {
         RawRow { row_number, values }
     }
 
+    fn headers_of(pairs: &[(&str, &str)]) -> Vec<String> {
+        pairs.iter().map(|(k, _)| k.to_string()).collect()
+    }
+
+    /// Builds a row from `pairs` (in the given order) and normalizes it,
+    /// so column-order-sensitive behavior (e.g. alias-collision precedence)
+    /// is exercised the same way production code builds `headers`.
+    fn normalize(
+        pairs: &[(&str, &str)],
+        row_number: usize,
+        ctx: &ImportContext,
+    ) -> NormalizedImportRow {
+        normalize_row(&row(pairs, row_number), &headers_of(pairs), ctx)
+    }
+
     #[test]
     fn cost_basis_direct_from_average_cost() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -262,8 +303,8 @@ mod tests {
                 ("Average Cost Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.cost_basis, Some(135.50));
         assert_eq!(
             normalized.cost_basis_source,
@@ -274,7 +315,7 @@ mod tests {
 
     #[test]
     fn cost_basis_derived_from_total_cost_over_quantity() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -283,8 +324,8 @@ mod tests {
                 ("Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.cost_basis, Some(135.5));
         assert_eq!(
             normalized.cost_basis_source,
@@ -294,7 +335,7 @@ mod tests {
 
     #[test]
     fn needs_fix_when_cost_basis_undeterminable() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -302,8 +343,8 @@ mod tests {
                 ("Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.action, RowAction::NeedsFix);
         assert!(normalized.cost_basis.is_none());
         assert!(normalized.errors.iter().any(|e| e.contains("cost basis")));
@@ -311,7 +352,7 @@ mod tests {
 
     #[test]
     fn needs_fix_when_symbol_blank() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", ""),
                 ("Asset Class", "Equity"),
@@ -320,8 +361,8 @@ mod tests {
                 ("Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.action, RowAction::NeedsFix);
         assert!(normalized.symbol.is_none());
         assert!(normalized.errors.iter().any(|e| e.contains("symbol")));
@@ -329,7 +370,7 @@ mod tests {
 
     #[test]
     fn warning_when_asset_class_is_fixed_income() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "GIC123"),
                 ("Asset Class", "Fixed Income"),
@@ -338,8 +379,8 @@ mod tests {
                 ("Currency", "CAD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.action, RowAction::Warning);
         assert_eq!(normalized.asset_type, Some("Other".to_string()));
         assert!(normalized
@@ -350,7 +391,7 @@ mod tests {
 
     #[test]
     fn currency_priority_prefers_average_cost_currency_over_settlement_currency() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -360,8 +401,8 @@ mod tests {
                 ("Settlement Currency", "CAD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.currency, Some("USD".to_string()));
         assert!(normalized
             .warnings
@@ -371,7 +412,7 @@ mod tests {
 
     #[test]
     fn negative_quantity_is_a_warning_not_needs_fix() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -380,15 +421,15 @@ mod tests {
                 ("Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.action, RowAction::Warning);
         assert!(normalized.warnings.iter().any(|w| w.contains("Negative")));
     }
 
     #[test]
     fn zero_quantity_is_needs_fix() {
-        let r = row(
+        let normalized = normalize(
             &[
                 ("Symbol", "AAPL:US"),
                 ("Asset Class", "Equity"),
@@ -397,9 +438,95 @@ mod tests {
                 ("Currency", "USD"),
             ],
             8,
+            &context(),
         );
-        let normalized = normalize_row(&r, &context());
         assert_eq!(normalized.action, RowAction::NeedsFix);
+    }
+
+    #[test]
+    fn non_finite_quantity_is_needs_fix_not_silently_accepted() {
+        let normalized = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "NaN"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &context(),
+        );
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+        assert!(normalized.quantity.is_none());
+    }
+
+    #[test]
+    fn negative_cost_basis_is_needs_fix() {
+        let normalized = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "10"),
+                ("Average Cost", "-5"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &context(),
+        );
+        assert_eq!(normalized.action, RowAction::NeedsFix);
+        assert!(normalized.errors.iter().any(|e| e.contains("negative")));
+    }
+
+    #[test]
+    fn column_override_maps_an_unrecognized_header_to_a_canonical_field() {
+        let mut ctx = context();
+        ctx.column_overrides
+            .insert("My Custom Qty".to_string(), "quantity".to_string());
+        let normalized = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("My Custom Qty", "42"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &ctx,
+        );
+        assert_eq!(normalized.quantity, Some(42.0));
+    }
+
+    #[test]
+    fn alias_collision_deterministically_prefers_earlier_declared_column() {
+        // Both "Total Cost" and "Book Value" alias to `book_value`; the
+        // earlier-declared column (by header order) must always win, not
+        // whichever the HashMap happened to visit last.
+        let a = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "10"),
+                ("Total Cost", "100"),
+                ("Book Value", "200"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &context(),
+        );
+        let b = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "10"),
+                ("Book Value", "200"),
+                ("Total Cost", "100"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &context(),
+        );
+        assert_eq!(a.book_value, Some(100.0));
+        assert_eq!(b.book_value, Some(200.0));
     }
 
     #[test]

--- a/src-tauri/src/import_pipeline/parser.rs
+++ b/src-tauri/src/import_pipeline/parser.rs
@@ -5,6 +5,13 @@
 //!   Cash Details block, Holding Details block, Exchange Rate footer), as
 //!   validated against TD Direct Investing RRSP/TFSA portfolio reports.
 //! - Generic flat CSV: a single header row followed by data rows.
+//!
+//! Note: the file is first split into lines, then each line is parsed as one
+//! CSV record — this correctly handles a quoted field containing an embedded
+//! delimiter (e.g. `"Bank of Montreal, Inc"`), but not a quoted field
+//! containing an embedded newline, which would be split across two lines
+//! before the CSV parser ever sees it. Low real-world risk for the numeric/
+//! symbol-heavy brokerage exports this pipeline targets.
 
 use std::collections::HashMap;
 
@@ -74,16 +81,23 @@ fn extract_account_context(line: &str) -> Option<(String, String)> {
     Some((account_type.trim().to_string(), account_number.to_string()))
 }
 
-/// Collects contiguous non-blank data lines starting at `start`, stopping at
-/// the first blank line, the `Exchange Rate:` footer, or end of file.
-/// Returns the collected lines and the number of lines consumed (including
-/// any trailing blank line, so the caller can resume scanning after it).
+/// Collects contiguous data lines starting at `start`, stopping at the first
+/// blank line, the `Exchange Rate:` footer, the next section marker
+/// (`Cash Details` / `Holding Details`), or end of file. The section-marker
+/// check guards against a real-world export that omits the blank line
+/// between sections — without it, a missing separator would let this
+/// section's scan swallow the next section's header and data rows.
 fn collect_section_lines(lines: &[&str], start: usize) -> Vec<(usize, String)> {
     let mut collected = Vec::new();
     let mut idx = start;
     while idx < lines.len() {
         let line = lines[idx];
-        if line.trim().is_empty() || line.trim_start().starts_with("Exchange Rate:") {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("Exchange Rate:")
+            || trimmed == "Cash Details"
+            || trimmed == "Holding Details"
+        {
             break;
         }
         collected.push((idx, line.to_string()));
@@ -305,6 +319,33 @@ Exchange Rate: 1 CAD = 0.7126USD  1 USD = 1.4033CAD\n";
         let content = "Portfolio report for TFSA account # 999 as of now\n\nCash Details\nCurrency,Account Type,Settled Cash,Trade Cash\nCAD,CASH,1.0,1.0\n";
         let err = detect_and_parse(content).expect_err("should error without Holding Details");
         assert!(err.contains("Holding Details"));
+    }
+
+    #[test]
+    fn cash_section_does_not_swallow_holding_details_when_blank_separator_is_missing() {
+        // Same as SAMPLE, but the blank line between the Cash Details row and
+        // the "Holding Details" marker is omitted — the parser must still stop
+        // the cash section at the section marker, not consume it as data.
+        let content = "Portfolio report for RRSP account # 12345 as of 2026-01-01T09:08:10\n\
+\n\
+Cash Details\n\
+Currency,Account Type,Settled Cash,Trade Cash\n\
+CAD,CASH,89192.24,89192.24\n\
+Holding Details\n\
+Asset Class,Sector,Security Description,Symbol,Quantity,Average Cost,Average Cost Currency\n\
+Equity,Information Tech.,APPLE INC,AAPL:US,100,135.5045,USD\n";
+
+        let detected = detect_and_parse(content).expect("should parse");
+        let cash = detected
+            .cash_section
+            .expect("cash section should be present");
+        assert_eq!(
+            cash.rows.len(),
+            1,
+            "cash section must not include the Holding Details header/row"
+        );
+        assert_eq!(detected.holdings_section.rows.len(), 1);
+        assert_eq!(detected.holdings_section.headers[0], "Asset Class");
     }
 
     #[test]

--- a/src-tauri/src/import_pipeline/parser.rs
+++ b/src-tauri/src/import_pipeline/parser.rs
@@ -1,0 +1,350 @@
+//! Format detection and section splitting for the import pipeline.
+//!
+//! Two shapes are supported:
+//! - `CanadianBankMultiSection`: a multi-section document (account header,
+//!   Cash Details block, Holding Details block, Exchange Rate footer), as
+//!   validated against TD Direct Investing RRSP/TFSA portfolio reports.
+//! - Generic flat CSV: a single header row followed by data rows.
+
+use std::collections::HashMap;
+
+use ::csv::ReaderBuilder;
+
+use crate::csv::detect_csv_delimiter;
+
+pub const PROFILE_CANADIAN_BANK_MULTI_SECTION: &str = "CanadianBankMultiSection";
+pub const PROFILE_GENERIC_CSV: &str = "GenericCSV";
+
+/// One data row plus its 1-indexed absolute line number in the source file,
+/// preserved for the preview's "source row number" field and error messages.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawRow {
+    pub row_number: usize,
+    pub values: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ParsedSection {
+    pub headers: Vec<String>,
+    pub rows: Vec<RawRow>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DetectedFile {
+    pub profile: &'static str,
+    pub suggested_account_type: Option<String>,
+    pub suggested_account_number: Option<String>,
+    pub cash_section: Option<ParsedSection>,
+    pub holdings_section: ParsedSection,
+}
+
+/// Parses one CSV line into trimmed fields, honoring quoted commas via the
+/// `csv` crate rather than a naive `split(',')`.
+fn parse_line_as_fields(line: &str, delimiter: u8) -> Result<Vec<String>, String> {
+    let mut reader = ReaderBuilder::new()
+        .has_headers(false)
+        .delimiter(delimiter)
+        .from_reader(line.as_bytes());
+    match reader.records().next() {
+        Some(Ok(record)) => Ok(record.iter().map(|f| f.trim().to_string()).collect()),
+        Some(Err(e)) => Err(e.to_string()),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn build_row(headers: &[String], fields: &[String], row_number: usize) -> RawRow {
+    let mut values = HashMap::with_capacity(headers.len());
+    for (i, header) in headers.iter().enumerate() {
+        values.insert(header.clone(), fields.get(i).cloned().unwrap_or_default());
+    }
+    RawRow { row_number, values }
+}
+
+/// Line 1 heuristic: `^Portfolio report for .+ account #`.
+fn is_multi_section(first_line: &str) -> bool {
+    first_line.starts_with("Portfolio report for") && first_line.contains("account #")
+}
+
+/// Extracts `(account_type, account_number)` from a line like
+/// `Portfolio report for RRSP account # nnn as of 2026-01-01T00:00:00`.
+fn extract_account_context(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("Portfolio report for ")?;
+    let (account_type, rest) = rest.split_once(" account # ")?;
+    let account_number = rest.split_whitespace().next()?;
+    Some((account_type.trim().to_string(), account_number.to_string()))
+}
+
+/// Collects contiguous non-blank data lines starting at `start`, stopping at
+/// the first blank line, the `Exchange Rate:` footer, or end of file.
+/// Returns the collected lines and the number of lines consumed (including
+/// any trailing blank line, so the caller can resume scanning after it).
+fn collect_section_lines(lines: &[&str], start: usize) -> Vec<(usize, String)> {
+    let mut collected = Vec::new();
+    let mut idx = start;
+    while idx < lines.len() {
+        let line = lines[idx];
+        if line.trim().is_empty() || line.trim_start().starts_with("Exchange Rate:") {
+            break;
+        }
+        collected.push((idx, line.to_string()));
+        idx += 1;
+    }
+    collected
+}
+
+fn parse_section(
+    lines: &[&str],
+    header_line_idx: usize,
+    delimiter: u8,
+) -> Result<ParsedSection, String> {
+    let headers = parse_line_as_fields(lines[header_line_idx], delimiter)?;
+    let data_lines = collect_section_lines(lines, header_line_idx + 1);
+    let mut rows = Vec::with_capacity(data_lines.len());
+    for (line_idx, line) in data_lines {
+        let fields = parse_line_as_fields(&line, delimiter)?;
+        if fields.iter().all(|f| f.trim().is_empty()) {
+            continue;
+        }
+        // Absolute file line number, 1-indexed.
+        rows.push(build_row(&headers, &fields, line_idx + 1));
+    }
+    Ok(ParsedSection { headers, rows })
+}
+
+fn find_line_index(lines: &[&str], exact: &str) -> Option<usize> {
+    lines.iter().position(|l| l.trim() == exact)
+}
+
+fn parse_multi_section(content: &str) -> Result<DetectedFile, String> {
+    let lines: Vec<&str> = content.lines().collect();
+    let delimiter = b',';
+
+    let first_line = lines
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .copied()
+        .unwrap_or_default();
+    let (suggested_account_type, suggested_account_number) =
+        match extract_account_context(first_line) {
+            Some((t, n)) => (Some(t), Some(n)),
+            None => (None, None),
+        };
+
+    let cash_section = match find_line_index(&lines, "Cash Details") {
+        Some(idx) => {
+            let header_idx = idx + 1;
+            if header_idx >= lines.len() {
+                None
+            } else {
+                Some(parse_section(&lines, header_idx, delimiter)?)
+            }
+        }
+        None => None,
+    };
+
+    let holding_details_idx = find_line_index(&lines, "Holding Details")
+        .ok_or_else(|| "Multi-section file is missing a 'Holding Details' section".to_string())?;
+    let header_idx = holding_details_idx + 1;
+    if header_idx >= lines.len() || !lines[header_idx].starts_with("Asset Class,") {
+        return Err(
+            "'Holding Details' section is missing its 'Asset Class,...' header row".to_string(),
+        );
+    }
+    let holdings_section = parse_section(&lines, header_idx, delimiter)?;
+
+    Ok(DetectedFile {
+        profile: PROFILE_CANADIAN_BANK_MULTI_SECTION,
+        suggested_account_type,
+        suggested_account_number,
+        cash_section,
+        holdings_section,
+    })
+}
+
+/// Generic flat CSV fallback: the first line with at least 3 non-empty
+/// comma-separated fields is treated as the header row; every subsequent
+/// non-blank line is a data row, read to end of file.
+fn parse_generic_flat(content: &str) -> Result<DetectedFile, String> {
+    let delimiter = detect_csv_delimiter(content);
+    let lines: Vec<&str> = content.lines().collect();
+
+    let header_idx = lines
+        .iter()
+        .position(|l| {
+            if l.trim().is_empty() {
+                return false;
+            }
+            match parse_line_as_fields(l, delimiter) {
+                Ok(fields) => fields.iter().filter(|f| !f.trim().is_empty()).count() >= 3,
+                Err(_) => false,
+            }
+        })
+        .ok_or_else(|| {
+            "No header row found (need at least 3 comma-separated columns)".to_string()
+        })?;
+
+    let headers = parse_line_as_fields(lines[header_idx], delimiter)?;
+    let mut rows = Vec::new();
+    for (i, line) in lines.iter().enumerate().skip(header_idx + 1) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let fields = parse_line_as_fields(line, delimiter)?;
+        if fields.iter().all(|f| f.trim().is_empty()) {
+            continue;
+        }
+        rows.push(build_row(&headers, &fields, i + 1));
+    }
+
+    Ok(DetectedFile {
+        profile: PROFILE_GENERIC_CSV,
+        suggested_account_type: None,
+        suggested_account_number: None,
+        cash_section: None,
+        holdings_section: ParsedSection { headers, rows },
+    })
+}
+
+/// Detects the source file's format and splits it into sections.
+pub fn detect_and_parse(content: &str) -> Result<DetectedFile, String> {
+    let content = content.trim_start_matches('\u{feff}');
+    let first_line = content.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+    if is_multi_section(first_line) {
+        parse_multi_section(content)
+    } else {
+        parse_generic_flat(content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "Portfolio report for RRSP account # 12345 as of 2026-01-01T09:08:10\n\
+\n\
+Cash Details\n\
+Currency,Account Type,Settled Cash,Trade Cash\n\
+CAD,CASH,89192.24,89192.24\n\
+\n\
+Holding Details\n\
+Asset Class,Sector,Security Description,Symbol,Quantity,Average Cost,Average Cost Currency\n\
+Equity,Information Tech.,APPLE INC,AAPL:US,100,135.5045,USD\n\
+\n\
+\n\
+Exchange Rate: 1 CAD = 0.7126USD  1 USD = 1.4033CAD\n";
+
+    #[test]
+    fn detects_multi_section_format() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        assert_eq!(detected.profile, PROFILE_CANADIAN_BANK_MULTI_SECTION);
+    }
+
+    #[test]
+    fn extracts_account_type_and_number_from_line_one() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        assert_eq!(detected.suggested_account_type, Some("RRSP".to_string()));
+        assert_eq!(detected.suggested_account_number, Some("12345".to_string()));
+    }
+
+    #[test]
+    fn splits_cash_details_section() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        let cash = detected
+            .cash_section
+            .expect("cash section should be present");
+        assert_eq!(
+            cash.headers,
+            vec!["Currency", "Account Type", "Settled Cash", "Trade Cash"]
+        );
+        assert_eq!(cash.rows.len(), 1);
+        assert_eq!(cash.rows[0].values.get("Currency").unwrap(), "CAD");
+        assert_eq!(cash.rows[0].values.get("Settled Cash").unwrap(), "89192.24");
+    }
+
+    #[test]
+    fn splits_holding_details_section() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        let holdings = &detected.holdings_section;
+        assert_eq!(holdings.headers[0], "Asset Class");
+        assert_eq!(holdings.rows.len(), 1);
+        assert_eq!(holdings.rows[0].values.get("Symbol").unwrap(), "AAPL:US");
+        assert_eq!(holdings.rows[0].values.get("Quantity").unwrap(), "100");
+    }
+
+    #[test]
+    fn blank_lines_between_sections_are_not_treated_as_data_rows() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        // One cash row, one holding row — the blank separator lines must not
+        // have been counted as (empty) data rows.
+        assert_eq!(detected.cash_section.unwrap().rows.len(), 1);
+        assert_eq!(detected.holdings_section.rows.len(), 1);
+    }
+
+    #[test]
+    fn ignores_exchange_rate_footer() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        // The footer line must never show up as a holdings/cash data row.
+        for row in &detected.holdings_section.rows {
+            for v in row.values.values() {
+                assert!(!v.contains("Exchange Rate"));
+            }
+        }
+    }
+
+    #[test]
+    fn row_numbers_reflect_absolute_file_line_numbers() {
+        let detected = detect_and_parse(SAMPLE).expect("should parse");
+        // "Equity,..." is line 9 (1-indexed) in SAMPLE.
+        assert_eq!(detected.holdings_section.rows[0].row_number, 9);
+        // "CAD,CASH,..." is line 5 (1-indexed).
+        assert_eq!(detected.cash_section.unwrap().rows[0].row_number, 5);
+    }
+
+    #[test]
+    fn multi_section_missing_holding_details_errors() {
+        let content = "Portfolio report for TFSA account # 999 as of now\n\nCash Details\nCurrency,Account Type,Settled Cash,Trade Cash\nCAD,CASH,1.0,1.0\n";
+        let err = detect_and_parse(content).expect_err("should error without Holding Details");
+        assert!(err.contains("Holding Details"));
+    }
+
+    #[test]
+    fn detects_generic_flat_csv_when_no_multi_section_header() {
+        let content = "Symbol,Name,Quantity,Currency\nAAPL,Apple Inc.,10,USD\n";
+        let detected = detect_and_parse(content).expect("should parse");
+        assert_eq!(detected.profile, PROFILE_GENERIC_CSV);
+        assert_eq!(detected.holdings_section.rows.len(), 1);
+        assert!(detected.cash_section.is_none());
+    }
+
+    #[test]
+    fn generic_flat_csv_supports_semicolon_delimiter() {
+        let content = "Symbol;Name;Quantity;Currency\nAAPL;Apple Inc.;10;USD\n";
+        let detected = detect_and_parse(content).expect("should parse");
+        assert_eq!(
+            detected.holdings_section.headers,
+            vec!["Symbol", "Name", "Quantity", "Currency"]
+        );
+        assert_eq!(
+            detected.holdings_section.rows[0]
+                .values
+                .get("Symbol")
+                .unwrap(),
+            "AAPL"
+        );
+    }
+
+    #[test]
+    fn generic_flat_csv_skips_leading_junk_lines_before_header() {
+        let content = "Export generated 2026-01-01\n\nSymbol,Name,Quantity,Currency\nAAPL,Apple Inc.,10,USD\n";
+        let detected = detect_and_parse(content).expect("should parse");
+        assert_eq!(detected.holdings_section.headers[0], "Symbol");
+        assert_eq!(detected.holdings_section.rows.len(), 1);
+    }
+
+    #[test]
+    fn bom_prefixed_multi_section_file_is_handled() {
+        let content = format!("\u{feff}{}", SAMPLE);
+        let detected = detect_and_parse(&content).expect("should parse");
+        assert_eq!(detected.profile, PROFILE_CANADIAN_BANK_MULTI_SECTION);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod csv;
 mod db;
 pub mod error;
 mod fx;
+mod import_pipeline;
 mod maintenance;
 mod portfolio;
 mod price;
@@ -21,13 +22,14 @@ mod ts_binding_tests {
     use ts_rs::{Config, TS as _};
 
     use crate::types::{
-        Account, AccountType, AlertDirection, AssetType, CountryWeight, CreateAccountRequest,
-        Dividend, DividendInput, ExportPayload, FxRate, Holding, HoldingInput, HoldingWithPrice,
-        ImportError, ImportResult, PerformancePoint, PortfolioAnalytics, PortfolioRiskMetrics,
-        PortfolioSnapshot, PreviewImportResult, PreviewRow, PriceAlert, PriceAlertInput, PriceData,
-        RealizedGainsSummary, RealizedLot, RebalanceSuggestion, RefreshResult, SectorWeight,
-        StressResult, StressScenario, SymbolMetadata, SymbolResult, Transaction, TransactionInput,
-        TransactionType,
+        Account, AccountType, AlertDirection, AssetType, ColumnMapping, CountryWeight,
+        CreateAccountRequest, Dividend, DividendInput, ExportPayload, FxRate, Holding,
+        HoldingInput, HoldingWithPrice, ImportCommitRequest, ImportCommitResult, ImportContext,
+        ImportError, ImportPlan, ImportResult, NormalizedImportRow, PerformancePoint,
+        PortfolioAnalytics, PortfolioRiskMetrics, PortfolioSnapshot, PreviewImportResult,
+        PreviewRow, PriceAlert, PriceAlertInput, PriceData, RealizedGainsSummary, RealizedLot,
+        RebalanceSuggestion, RefreshResult, RowAction, SectorWeight, StressResult, StressScenario,
+        SymbolMetadata, SymbolResult, Transaction, TransactionInput, TransactionType,
     };
     // StressHoldingResult is only reachable via portfolio-core in this crate (it's
     // nested inside StressResult, not referenced standalone) — import it directly
@@ -44,6 +46,7 @@ mod ts_binding_tests {
         AccountType::export_all(&cfg).expect("AccountType");
         AlertDirection::export_all(&cfg).expect("AlertDirection");
         AssetType::export_all(&cfg).expect("AssetType");
+        ColumnMapping::export_all(&cfg).expect("ColumnMapping");
         CountryWeight::export_all(&cfg).expect("CountryWeight");
         CreateAccountRequest::export_all(&cfg).expect("CreateAccountRequest");
         Dividend::export_all(&cfg).expect("Dividend");
@@ -53,8 +56,13 @@ mod ts_binding_tests {
         Holding::export_all(&cfg).expect("Holding");
         HoldingInput::export_all(&cfg).expect("HoldingInput");
         HoldingWithPrice::export_all(&cfg).expect("HoldingWithPrice");
+        ImportCommitRequest::export_all(&cfg).expect("ImportCommitRequest");
+        ImportCommitResult::export_all(&cfg).expect("ImportCommitResult");
+        ImportContext::export_all(&cfg).expect("ImportContext");
         ImportError::export_all(&cfg).expect("ImportError");
+        ImportPlan::export_all(&cfg).expect("ImportPlan");
         ImportResult::export_all(&cfg).expect("ImportResult");
+        NormalizedImportRow::export_all(&cfg).expect("NormalizedImportRow");
         PerformancePoint::export_all(&cfg).expect("PerformancePoint");
         PortfolioAnalytics::export_all(&cfg).expect("PortfolioAnalytics");
         PortfolioRiskMetrics::export_all(&cfg).expect("PortfolioRiskMetrics");
@@ -68,6 +76,7 @@ mod ts_binding_tests {
         RealizedLot::export_all(&cfg).expect("RealizedLot");
         RebalanceSuggestion::export_all(&cfg).expect("RebalanceSuggestion");
         RefreshResult::export_all(&cfg).expect("RefreshResult");
+        RowAction::export_all(&cfg).expect("RowAction");
         SectorWeight::export_all(&cfg).expect("SectorWeight");
         StressHoldingResult::export_all(&cfg).expect("StressHoldingResult");
         StressResult::export_all(&cfg).expect("StressResult");
@@ -228,6 +237,8 @@ pub fn run() {
             commands::import_holdings_csv,
             commands::preview_import_csv,
             commands::export_holdings_csv,
+            commands::parse_import_file,
+            commands::commit_import,
             commands::refresh_prices,
             commands::run_stress_test_cmd,
             commands::get_performance,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -483,6 +485,129 @@ pub struct RebalanceSuggestion {
     pub suggested_trade_cad: f64, // positive = sell, negative = buy
     pub suggested_units: f64,     // positive = sell, negative = buy
     pub current_price_cad: f64,
+}
+
+// ── Import Plus Insights pipeline ──────────────────────────────────────────────
+// See docs/superpowers/specs/2026-05-24-import-plus-insights-design.md.
+// This is a new pipeline, separate from the legacy `parse_import_rows` path
+// above (`ImportError`/`ImportResult`/`PreviewRow`/`PreviewImportResult`),
+// which remains as a compatibility path per the design doc.
+
+/// User-supplied context applied to every row of an import unless the file
+/// provides stronger per-row account information.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportContext {
+    /// TFSA, RRSP, FHSA, Taxable, Cash, Crypto, or Other.
+    pub account_type: String,
+    pub account_name: Option<String>,
+    pub account_id: Option<String>,
+    /// Hint such as "CanadianBankMultiSection", "GenericCSV".
+    pub source_profile: Option<String>,
+    /// User-selected column overrides: source column header -> canonical field name.
+    #[serde(default)]
+    pub column_overrides: HashMap<String, String>,
+}
+
+/// The action the import plan proposes for a given row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+pub enum RowAction {
+    Create,
+    Update,
+    Skip,
+    NeedsFix,
+    Warning,
+}
+
+/// Describes how a source column was mapped to a canonical holding field.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnMapping {
+    pub source_header: String,
+    pub canonical_field: Option<String>,
+    /// "exact" | "alias" | "profile" | "user" | "derived"
+    pub confidence: String,
+    pub reason: String,
+}
+
+/// Canonical interpretation of one source row, produced by the row normalizer.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct NormalizedImportRow {
+    pub row_number: usize,
+    pub action: RowAction,
+    pub symbol: Option<String>,
+    pub resolved_symbol: Option<String>,
+    pub name: Option<String>,
+    pub asset_type: Option<String>,
+    pub quantity: Option<f64>,
+    pub cost_basis: Option<f64>,
+    /// e.g. "average_cost", "derived:total_cost/qty"
+    pub cost_basis_source: Option<String>,
+    pub currency: Option<String>,
+    pub book_value: Option<f64>,
+    pub market_value: Option<f64>,
+    pub account_type: String,
+    pub account_name: Option<String>,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+    /// Original CSV values for this row, keyed by source header.
+    pub raw: HashMap<String, String>,
+    // ── Insight metadata: surfaced post-import, never written to the holdings table ──
+    pub dividend_yield: Option<f64>,
+    pub annualized_income: Option<f64>,
+    pub ex_dividend_date: Option<String>,
+}
+
+/// Preview payload returned by `parse_import_file`. Never writes to the DB.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportPlan {
+    pub profile_detected: String,
+    pub column_mappings: Vec<ColumnMapping>,
+    pub rows: Vec<NormalizedImportRow>,
+    pub count_create: usize,
+    pub count_update: usize,
+    pub count_skip: usize,
+    pub count_needs_fix: usize,
+    pub count_warning: usize,
+    pub suggested_account_type: Option<String>,
+    pub suggested_account_number: Option<String>,
+    pub cash_rows: Vec<NormalizedImportRow>,
+}
+
+/// Selected rows to write to the DB, as chosen by the user in the review UI.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportCommitRequest {
+    pub plan_rows: Vec<NormalizedImportRow>,
+    pub account_id: String,
+    pub include_cash: bool,
+}
+
+/// Result of committing an import plan, including insight deltas for the
+/// post-import summary panel.
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportCommitResult {
+    pub created: usize,
+    pub updated: usize,
+    pub skipped: usize,
+    pub errors: Vec<String>,
+    pub new_symbols: Vec<String>,
+    pub changed_symbols: Vec<String>,
+    /// Existing holdings in the target account not present in the imported file.
+    /// Surfaced as review candidates only — never auto-deleted.
+    pub missing_from_import: Vec<String>,
+    pub stale_symbols: Vec<String>,
 }
 
 // ── Pagination ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Backend half of the Import Plus Insights pipeline (see `docs/superpowers/specs/2026-05-24-import-plus-insights-design.md`), kept as a new, separate code path from the existing `parse_import_rows`/`import_holdings_csv`/`preview_import_csv` importer, which is untouched and remains as a compatibility path.

- **Format detection** (`import_pipeline::parser`): detects `CanadianBankMultiSection` (TD Direct Investing-style multi-section export — account header, Cash Details block, Holding Details block, Exchange Rate footer) vs. a generic flat CSV fallback. Tracks absolute 1-indexed file line numbers per row for the preview.
- **Alias registry** (`import_pipeline::aliases`): static column-header → canonical-field mapping (~40 known brokerage header variants), asset-class mapping (Equity→Stock, ETF/Mutual Fund→ETF, Crypto→Crypto, Cash→Cash, Fixed Income/GIC/Money Market/Bond→"Other" + warning), and `SYMBOL:COUNTRY` resolution reusing the existing `normalize_symbol_for_import` helper.
- **Row normalization** (`import_pipeline::normalize`): derives cost basis (direct from Average Cost, or Total Cost / Quantity), classifies each row `Create`/`NeedsFix`/`Warning` based on missing/invalid symbol, quantity, currency, cost basis, or asset class.
- **Plan builder** (`import_pipeline::mod`): orchestrates parsing + normalization, marks intra-file duplicate symbols `Skip`, reclassifies `Create`→`Update` against existing holdings in the target account.
- **Commit** (`import_pipeline::commit`): writes selected rows via the existing `db::insert_holding`/`db::update_holding`, computes insight deltas (new/changed/missing_from_import/stale_symbols).

Two new Tauri commands: `parse_import_file` (read-only, builds the plan) and `commit_import` (writes selected rows).

### Notable scope decisions
- The app's `AssetType` enum has no "Other" variant (schema CHECK constraint only allows stock/etf/crypto/cash). Rows resolving to "Other" (Fixed Income/GIC/Money Market/Bond) are shown in the plan with a warning, but `commit_import` reports them as a per-row error and skips them rather than writing invalid data — extending the enum was judged too large a ripple effect (stress test, analytics, frontend badges) for a backend-only session.
- Per-row commit is not wrapped in one all-or-nothing transaction (unlike the legacy CSV importer) — a failure on one row doesn't block the rest.
- Generated TypeScript bindings under `frontend/types/bindings/` are intentionally **not** included in this PR — backend-only scope, no frontend changes.

### Code review
Ran a code-reviewer pass before opening this PR; fixed 7 Important findings: `column_overrides` not actually reaching normalization, NaN/Infinity bypassing numeric validation and the DB's `>= 0` CHECK constraints, non-deterministic alias-collision resolution (HashMap iteration order), no in-request duplicate-symbol guard at commit time, negative quantity producing a raw DB error instead of a friendly one, a missing-blank-line edge case letting the Cash Details section swallow Holding Details, and an unrestricted file-path read (added a `.csv`/`.txt` extension allowlist).

## Test plan

- [x] `cargo test -p portfolio-tracker` — 396 passed, 0 failed
- [x] `cargo clippy -p portfolio-tracker --all-targets` — no new warnings (3 pre-existing, unrelated warnings on `main` untouched)
- [x] Full pre-push verification (lint, typecheck, format, frontend build, frontend tests, backend build/tests, clippy) passed
- [x] Required coverage per task brief: multi-section detection/splitting, cash row parsing, alias matching (10+ cases), `SYMBOL:COUNTRY` resolution incl. edge cases, asset class mapping, cost basis direct/derived/needs_fix, needs_fix on blank symbol, warning on Fixed Income, currency priority (Average Cost Currency > Settlement Currency)
- [ ] Frontend wizard UI wiring (out of scope for this PR)