### PR TITLE
test: import pipeline regression — integration tests and edge case fixes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ mod csv;
 mod db;
 pub mod error;
 mod fx;
-mod import_pipeline;
+pub mod import_pipeline;
 mod maintenance;
 mod portfolio;
 mod price;
@@ -15,7 +15,7 @@ mod search;
 mod stress;
 #[cfg(test)]
 mod test_helpers;
-mod types;
+pub mod types;
 
 #[cfg(test)]
 mod ts_binding_tests {

--- a/src-tauri/tests/fixtures/td_rrsp_sample.csv
+++ b/src-tauri/tests/fixtures/td_rrsp_sample.csv
@@ -1,0 +1,19 @@
+Portfolio report for RRSP account # 55901234 as of 2026-07-15T08:30:00
+
+Cash Details
+Currency,Account Type,Settled Cash,Trade Cash
+CAD,CASH,4521.90,4521.90
+USD,CASH,1875.33,1875.33
+
+Holding Details
+Asset Class,Sector,Security Description,Symbol,Quantity,Average Cost,Average Cost Currency,Total Cost,Market Value,Trade Date,Settlement Date,Maturity Date,Coupon Rate,Dividend Yield (%),Annualized Income,Ex-Dividend Date
+Equity,Information Technology,APPLE INC,AAPL:US,45,148.2200,USD,,7830.00,2024-03-01,2024-03-04,,,0.51,27.60,2026-05-10
+Equity,Financials,ROYAL BANK OF CANADA,RY:CA,60,98.4500,CAD,,7620.00,2024-04-11,2024-04-14,,,3.90,354.00,2026-04-24
+ETF,Broad Market,VANGUARD SP 500 INDEX ETF,VFV:CA,120,112.3000,CAD,,15200.00,2023-11-02,2023-11-05,,,1.20,180.00,2026-06-20
+Fixed Income,Fixed Income,GOVT OF CANADA BOND 2030,CA135087J546,10,1000.0000,CAD,,10250.00,2022-06-01,2022-06-03,2030-06-01,3.25,,,
+Equity,Consumer Discretionary,SHOPIFY INC,SHOP:CA,25,,CAD,2500.00,3100.00,2025-01-15,2025-01-17,,,,,
+Equity,Speculative,MYSTERY CORP,MYST:US,5,,USD,,500.00,2025-02-01,2025-02-03,,,,,
+Equity,Utilities,UNKNOWN POSITION,,15,45.0000,CAD,,675.00,2025-03-01,2025-03-03,,,,,
+
+
+Exchange Rate: 1 CAD = 0.7126USD  1 USD = 1.4033CAD

--- a/src-tauri/tests/import_integration.rs
+++ b/src-tauri/tests/import_integration.rs
@@ -1,0 +1,380 @@
+//! Integration tests for the Import Plus Insights pipeline
+//! (`src-tauri/src/import_pipeline/`), exercised through its public API
+//! (`portfolio_tracker_lib::import_pipeline::build_import_plan`) against a
+//! realistic multi-section TD Direct Investing RRSP export fixture.
+//!
+//! See docs/superpowers/specs/2026-05-24-import-plus-insights-design.md.
+
+use std::collections::HashMap;
+
+use portfolio_tracker_lib::import_pipeline::{build_import_plan, parser};
+use portfolio_tracker_lib::types::{ImportContext, RowAction};
+use sqlx::sqlite::SqlitePool;
+
+const FIXTURE: &str = include_str!("fixtures/td_rrsp_sample.csv");
+
+fn context() -> ImportContext {
+    ImportContext {
+        account_type: "rrsp".to_string(),
+        account_name: Some("TD RRSP".to_string()),
+        // Every test here leaves `account_id` unset. `build_import_plan` only
+        // queries the DB (via `classify_against_existing`) when an account id
+        // is present, so a pool that's never actually queried is fine —
+        // no migrations needed for these tests.
+        account_id: None,
+        source_profile: None,
+        column_overrides: HashMap::new(),
+    }
+}
+
+/// An unconnected-until-used in-memory pool. Never queried by these tests
+/// since `context().account_id` is always `None`.
+async fn unused_pool() -> SqlitePool {
+    SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite pool")
+}
+
+async fn write_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+    let path = dir.join("td_rrsp_sample.csv");
+    std::fs::write(&path, FIXTURE).expect("write fixture");
+    path
+}
+
+#[tokio::test]
+async fn test_detect_multi_section_format() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    assert_eq!(
+        plan.profile_detected,
+        parser::PROFILE_CANADIAN_BANK_MULTI_SECTION
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_cash_rows_parsed() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    assert_eq!(plan.cash_rows.len(), 2);
+
+    let cad = plan
+        .cash_rows
+        .iter()
+        .find(|r| r.currency.as_deref() == Some("CAD"))
+        .expect("CAD cash row");
+    assert_eq!(cad.resolved_symbol, Some("CAD-CASH".to_string()));
+    assert_eq!(cad.quantity, Some(4521.90));
+    assert_eq!(cad.action, RowAction::Create);
+
+    let usd = plan
+        .cash_rows
+        .iter()
+        .find(|r| r.currency.as_deref() == Some("USD"))
+        .expect("USD cash row");
+    assert_eq!(usd.resolved_symbol, Some("USD-CASH".to_string()));
+    assert_eq!(usd.quantity, Some(1875.33));
+    assert_eq!(usd.action, RowAction::Create);
+}
+
+#[tokio::test]
+async fn test_symbol_country_resolution() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let aapl = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("AAPL:US"))
+        .expect("AAPL row");
+    assert_eq!(aapl.resolved_symbol, Some("AAPL".to_string()));
+
+    let ry = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("RY:CA"))
+        .expect("RY row");
+    assert_eq!(ry.resolved_symbol, Some("RY.TO".to_string()));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_average_cost_is_per_unit() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let aapl = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("AAPL:US"))
+        .expect("AAPL row");
+    assert_eq!(aapl.cost_basis, Some(148.22));
+    assert_eq!(aapl.cost_basis_source, Some("average_cost".to_string()));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_derive_cost_from_total_cost() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let shop = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("SHOP:CA"))
+        .expect("SHOP row — Average Cost blank, Total Cost/Quantity present");
+    assert_eq!(shop.cost_basis, Some(100.0));
+    assert_eq!(
+        shop.cost_basis_source,
+        Some("derived:total_cost/qty".to_string())
+    );
+    assert_eq!(shop.action, RowAction::Create);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_blank_symbol_is_needs_fix() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let blank = plan
+        .rows
+        .iter()
+        .find(|r| r.name.as_deref() == Some("UNKNOWN POSITION"))
+        .expect("blank-symbol row");
+    assert_eq!(blank.action, RowAction::NeedsFix);
+    assert!(blank.symbol.is_none());
+    assert!(!blank.errors.is_empty());
+    assert!(blank.errors.iter().any(|e| e.contains("symbol")));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_fixed_income_is_warning() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let bond = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("CA135087J546"))
+        .expect("bond row");
+    assert_eq!(bond.action, RowAction::Warning);
+    assert_eq!(bond.asset_type, Some("Other".to_string()));
+    assert!(bond.warnings.iter().any(|w| w.contains("pricing")));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_column_mappings_surfaced() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let mapped_fields: Vec<&str> = plan
+        .column_mappings
+        .iter()
+        .filter_map(|m| m.canonical_field.as_deref())
+        .collect();
+
+    assert!(mapped_fields.contains(&"symbol"), "{mapped_fields:?}");
+    assert!(mapped_fields.contains(&"name"), "{mapped_fields:?}");
+    assert!(mapped_fields.contains(&"quantity"), "{mapped_fields:?}");
+    assert!(mapped_fields.contains(&"currency"), "{mapped_fields:?}");
+    assert!(mapped_fields.contains(&"asset_type"), "{mapped_fields:?}");
+    // The canonical registry has no standalone "cost_basis" field — per-unit
+    // cost basis is fed by the "average_cost" mapping (see
+    // `import_pipeline::normalize::derive_cost_basis`), which is what this
+    // asserts is surfaced in the plan's column mappings.
+    assert!(mapped_fields.contains(&"average_cost"), "{mapped_fields:?}");
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[tokio::test]
+async fn test_full_plan_counts() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    // 6 create (4 clean holdings + 2 cash rows), 1 warning (Fixed Income
+    // bond), 2 needs_fix (blank symbol, and Market-Value-only with no
+    // derivable cost basis). No updates/skips — nothing pre-exists in the DB
+    // and there are no intra-file duplicate symbols.
+    assert_eq!(plan.count_create, 6);
+    assert_eq!(plan.count_warning, 1);
+    assert_eq!(plan.count_needs_fix, 2);
+    assert_eq!(plan.count_update, 0);
+    assert_eq!(plan.count_skip, 0);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Edge case audit: Market Value must never be used to derive cost basis,
+/// even when it's the only value-like column present on the row.
+#[tokio::test]
+async fn test_market_value_never_used_for_cost_basis() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    let mystery = plan
+        .rows
+        .iter()
+        .find(|r| r.symbol.as_deref() == Some("MYST:US"))
+        .expect("Market-Value-only row");
+    assert_eq!(mystery.market_value, Some(500.0));
+    assert!(mystery.cost_basis.is_none());
+    assert_eq!(mystery.action, RowAction::NeedsFix);
+    assert!(mystery.errors.iter().any(|e| e.contains("cost basis")));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Edge case audit: blank lines between sections must never be counted as
+/// data rows, and the `Exchange Rate:` footer must be silently ignored
+/// rather than surfaced as an error or an extra row.
+#[tokio::test]
+async fn test_blank_lines_and_exchange_rate_footer_do_not_produce_rows_or_errors() {
+    let pool = unused_pool().await;
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = write_fixture(&dir).await;
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    assert_eq!(plan.rows.len(), 7, "exactly the 7 holding data rows");
+    assert_eq!(plan.cash_rows.len(), 2, "exactly the 2 cash data rows");
+    for row in plan.rows.iter().chain(plan.cash_rows.iter()) {
+        for v in row.raw.values() {
+            assert!(!v.contains("Exchange Rate"));
+        }
+        assert!(row
+            .errors
+            .iter()
+            .all(|e| !e.to_lowercase().contains("exchange rate")));
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Edge case audit: a mismatched Settlement Currency vs Average Cost
+/// Currency must be a `warning`, not a `needs_fix` — the row still commits.
+#[tokio::test]
+async fn test_settlement_currency_mismatch_is_warning_not_needs_fix() {
+    let pool = unused_pool().await;
+    let content =
+        "Symbol,Asset Class,Quantity,Average Cost,Average Cost Currency,Settlement Currency\n\
+                   AAPL,Equity,10,150.00,USD,CAD\n";
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("mismatch.csv");
+    std::fs::write(&path, content).unwrap();
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    assert_eq!(plan.rows.len(), 1);
+    assert_eq!(plan.rows[0].action, RowAction::Warning);
+    assert!(plan.rows[0]
+        .warnings
+        .iter()
+        .any(|w| w.contains("Settlement Currency")));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Edge case audit: a blank Asset Class must be `needs_fix`, not `warning` —
+/// unlike an unrecognized-but-present asset class value.
+#[tokio::test]
+async fn test_blank_asset_class_is_needs_fix_not_warning() {
+    let pool = unused_pool().await;
+    let content = "Symbol,Asset Class,Quantity,Average Cost,Currency\n\
+                   AAPL,,10,150.00,USD\n";
+    let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("blank_asset_class.csv");
+    std::fs::write(&path, content).unwrap();
+
+    let plan = build_import_plan(&pool, path.to_str().unwrap(), &context())
+        .await
+        .expect("plan should build");
+
+    assert_eq!(plan.rows.len(), 1);
+    assert_eq!(plan.rows[0].action, RowAction::NeedsFix);
+    assert!(plan.rows[0].asset_type.is_none());
+    assert!(plan.rows[0]
+        .errors
+        .iter()
+        .any(|e| e.contains("asset class")));
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/src-tauri/tests/import_integration.rs
+++ b/src-tauri/tests/import_integration.rs
@@ -20,7 +20,9 @@ fn context() -> ImportContext {
         // Every test here leaves `account_id` unset. `build_import_plan` only
         // queries the DB (via `classify_against_existing`) when an account id
         // is present, so a pool that's never actually queried is fine —
-        // no migrations needed for these tests.
+        // no migrations needed for these tests. A test that sets `account_id`
+        // needs a migrated pool instead (see `db::open_test_db` in the crate's
+        // own unit tests) or it'll fail with "no such table: holdings".
         account_id: None,
         source_profile: None,
         column_overrides: HashMap::new(),


### PR DESCRIPTION
## Summary
- Regression pass on the multi-section import pipeline merged in #716 (`src-tauri/src/import_pipeline/`).
- Adds `src-tauri/tests/fixtures/td_rrsp_sample.csv`, a realistic TD Direct Investing RRSP export (2 cash rows, 7 holding rows: equity USD, equity CA `:CA`→`.TO`, ETF, Fixed Income, blank-Average-Cost-derives-from-Total-Cost/Quantity, blank Symbol, Market-Value-only).
- Adds `src-tauri/tests/import_integration.rs` with 13 integration tests against `build_import_plan`, covering format detection, cash rows, symbol/country resolution, cost-basis derivation, `needs_fix`/`warning` classification, column mapping surfacing, and plan action counts.
- Audited the pipeline against the design spec's edge cases (blank lines/`Exchange Rate:` footer, Market Value never feeding cost basis, Settlement vs Average Cost Currency mismatch → warning not needs_fix, blank Asset Class → needs_fix not warning) — all were already handled correctly by the merged pipeline; the new tests lock that behavior in as regression coverage (verified by temporarily breaking one check in `normalize.rs` and confirming the corresponding test failed).
- `import_pipeline` and `types` are flipped from `mod` to `pub mod` in `lib.rs` — the only production-code change — purely so the new `tests/` integration binary (which links the lib as an external crate) can reach `build_import_plan` and the plan/row types. Both modules were already 100% `pub` internally, so this doesn't newly expose anything narrower.

## Test plan
- [x] `cargo test` — 396 pre-existing + 13 new backend tests pass (409 total), plus portfolio-core (70) and portfolio-mcp (83) unaffected
- [x] `cargo clippy -- -D warnings` — clean (matches CI's exact invocation)
- [x] Frontend `npm test` (364 tests) and `tsc --noEmit` — unaffected, no frontend files touched
- [x] Sanity-checked a test isn't vacuously true: temporarily flipped the blank-Asset-Class error to a warning, confirmed `test_blank_asset_class_is_needs_fix_not_warning` failed, then reverted
- [x] Full pre-push hook suite (lint/typecheck/format, frontend+backend build, all tests, clippy) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)