### PR TITLE
fix: resolve cargo clippy --all-targets warnings

### DIFF
--- a/src-tauri/src/csv.rs
+++ b/src-tauri/src/csv.rs
@@ -398,7 +398,7 @@ mod tests {
         // MAX_FIELD_LEN (500) falls mid-character when the input is made of
         // 3-byte UTF-8 chars (500 is not a multiple of 3), which previously
         // panicked via the byte-offset slice `&s[..MAX_FIELD_LEN]`.
-        let s: String = std::iter::repeat('日').take(200).collect(); // 600 bytes
+        let s: String = "日".repeat(200); // 600 bytes
         let result = sanitize_str(&s);
         assert!(!result.is_empty());
         assert!(result.chars().count() <= 200);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,78 +17,6 @@ mod stress;
 mod test_helpers;
 mod types;
 
-#[cfg(test)]
-mod ts_binding_tests {
-    use ts_rs::{Config, TS as _};
-
-    use crate::types::{
-        Account, AccountType, AlertDirection, AssetType, ColumnMapping, CountryWeight,
-        CreateAccountRequest, Dividend, DividendInput, ExportPayload, FxRate, Holding,
-        HoldingInput, HoldingWithPrice, ImportCommitRequest, ImportCommitResult, ImportContext,
-        ImportError, ImportPlan, ImportResult, NormalizedImportRow, PerformancePoint,
-        PortfolioAnalytics, PortfolioRiskMetrics, PortfolioSnapshot, PreviewImportResult,
-        PreviewRow, PriceAlert, PriceAlertInput, PriceData, RealizedGainsSummary, RealizedLot,
-        RebalanceSuggestion, RefreshResult, RowAction, SectorWeight, StressResult, StressScenario,
-        SymbolMetadata, SymbolResult, Transaction, TransactionInput, TransactionType,
-    };
-    // StressHoldingResult is only reachable via portfolio-core in this crate (it's
-    // nested inside StressResult, not referenced standalone) — import it directly
-    // for TS binding export.
-    use portfolio_core::types::StressHoldingResult;
-
-    #[test]
-    fn export_typescript_bindings() {
-        let out_dir = "../frontend/types/bindings";
-        std::fs::create_dir_all(out_dir).expect("Failed to create bindings directory");
-        let cfg = Config::new().with_out_dir(out_dir);
-
-        Account::export_all(&cfg).expect("Account");
-        AccountType::export_all(&cfg).expect("AccountType");
-        AlertDirection::export_all(&cfg).expect("AlertDirection");
-        AssetType::export_all(&cfg).expect("AssetType");
-        ColumnMapping::export_all(&cfg).expect("ColumnMapping");
-        CountryWeight::export_all(&cfg).expect("CountryWeight");
-        CreateAccountRequest::export_all(&cfg).expect("CreateAccountRequest");
-        Dividend::export_all(&cfg).expect("Dividend");
-        DividendInput::export_all(&cfg).expect("DividendInput");
-        ExportPayload::export_all(&cfg).expect("ExportPayload");
-        FxRate::export_all(&cfg).expect("FxRate");
-        Holding::export_all(&cfg).expect("Holding");
-        HoldingInput::export_all(&cfg).expect("HoldingInput");
-        HoldingWithPrice::export_all(&cfg).expect("HoldingWithPrice");
-        ImportCommitRequest::export_all(&cfg).expect("ImportCommitRequest");
-        ImportCommitResult::export_all(&cfg).expect("ImportCommitResult");
-        ImportContext::export_all(&cfg).expect("ImportContext");
-        ImportError::export_all(&cfg).expect("ImportError");
-        ImportPlan::export_all(&cfg).expect("ImportPlan");
-        ImportResult::export_all(&cfg).expect("ImportResult");
-        NormalizedImportRow::export_all(&cfg).expect("NormalizedImportRow");
-        PerformancePoint::export_all(&cfg).expect("PerformancePoint");
-        PortfolioAnalytics::export_all(&cfg).expect("PortfolioAnalytics");
-        PortfolioRiskMetrics::export_all(&cfg).expect("PortfolioRiskMetrics");
-        PortfolioSnapshot::export_all(&cfg).expect("PortfolioSnapshot");
-        PreviewImportResult::export_all(&cfg).expect("PreviewImportResult");
-        PreviewRow::export_all(&cfg).expect("PreviewRow");
-        PriceAlert::export_all(&cfg).expect("PriceAlert");
-        PriceAlertInput::export_all(&cfg).expect("PriceAlertInput");
-        PriceData::export_all(&cfg).expect("PriceData");
-        RealizedGainsSummary::export_all(&cfg).expect("RealizedGainsSummary");
-        RealizedLot::export_all(&cfg).expect("RealizedLot");
-        RebalanceSuggestion::export_all(&cfg).expect("RebalanceSuggestion");
-        RefreshResult::export_all(&cfg).expect("RefreshResult");
-        RowAction::export_all(&cfg).expect("RowAction");
-        SectorWeight::export_all(&cfg).expect("SectorWeight");
-        StressHoldingResult::export_all(&cfg).expect("StressHoldingResult");
-        StressResult::export_all(&cfg).expect("StressResult");
-        StressScenario::export_all(&cfg).expect("StressScenario");
-        SymbolMetadata::export_all(&cfg).expect("SymbolMetadata");
-        SymbolResult::export_all(&cfg).expect("SymbolResult");
-        Transaction::export_all(&cfg).expect("Transaction");
-        TransactionInput::export_all(&cfg).expect("TransactionInput");
-        TransactionType::export_all(&cfg).expect("TransactionType");
-    }
-}
-
 use commands::{
     BackupLockState, DbState, HttpClient, RateLimiterState, RealizedGainsCacheState,
     SearchCacheState,
@@ -276,5 +204,77 @@ pub fn run() {
     if let Err(e) = result {
         tracing::error!("error while running tauri application: {e}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod ts_binding_tests {
+    use ts_rs::{Config, TS as _};
+
+    use crate::types::{
+        Account, AccountType, AlertDirection, AssetType, ColumnMapping, CountryWeight,
+        CreateAccountRequest, Dividend, DividendInput, ExportPayload, FxRate, Holding,
+        HoldingInput, HoldingWithPrice, ImportCommitRequest, ImportCommitResult, ImportContext,
+        ImportError, ImportPlan, ImportResult, NormalizedImportRow, PerformancePoint,
+        PortfolioAnalytics, PortfolioRiskMetrics, PortfolioSnapshot, PreviewImportResult,
+        PreviewRow, PriceAlert, PriceAlertInput, PriceData, RealizedGainsSummary, RealizedLot,
+        RebalanceSuggestion, RefreshResult, RowAction, SectorWeight, StressResult, StressScenario,
+        SymbolMetadata, SymbolResult, Transaction, TransactionInput, TransactionType,
+    };
+    // StressHoldingResult is only reachable via portfolio-core in this crate (it's
+    // nested inside StressResult, not referenced standalone) — import it directly
+    // for TS binding export.
+    use portfolio_core::types::StressHoldingResult;
+
+    #[test]
+    fn export_typescript_bindings() {
+        let out_dir = "../frontend/types/bindings";
+        std::fs::create_dir_all(out_dir).expect("Failed to create bindings directory");
+        let cfg = Config::new().with_out_dir(out_dir);
+
+        Account::export_all(&cfg).expect("Account");
+        AccountType::export_all(&cfg).expect("AccountType");
+        AlertDirection::export_all(&cfg).expect("AlertDirection");
+        AssetType::export_all(&cfg).expect("AssetType");
+        ColumnMapping::export_all(&cfg).expect("ColumnMapping");
+        CountryWeight::export_all(&cfg).expect("CountryWeight");
+        CreateAccountRequest::export_all(&cfg).expect("CreateAccountRequest");
+        Dividend::export_all(&cfg).expect("Dividend");
+        DividendInput::export_all(&cfg).expect("DividendInput");
+        ExportPayload::export_all(&cfg).expect("ExportPayload");
+        FxRate::export_all(&cfg).expect("FxRate");
+        Holding::export_all(&cfg).expect("Holding");
+        HoldingInput::export_all(&cfg).expect("HoldingInput");
+        HoldingWithPrice::export_all(&cfg).expect("HoldingWithPrice");
+        ImportCommitRequest::export_all(&cfg).expect("ImportCommitRequest");
+        ImportCommitResult::export_all(&cfg).expect("ImportCommitResult");
+        ImportContext::export_all(&cfg).expect("ImportContext");
+        ImportError::export_all(&cfg).expect("ImportError");
+        ImportPlan::export_all(&cfg).expect("ImportPlan");
+        ImportResult::export_all(&cfg).expect("ImportResult");
+        NormalizedImportRow::export_all(&cfg).expect("NormalizedImportRow");
+        PerformancePoint::export_all(&cfg).expect("PerformancePoint");
+        PortfolioAnalytics::export_all(&cfg).expect("PortfolioAnalytics");
+        PortfolioRiskMetrics::export_all(&cfg).expect("PortfolioRiskMetrics");
+        PortfolioSnapshot::export_all(&cfg).expect("PortfolioSnapshot");
+        PreviewImportResult::export_all(&cfg).expect("PreviewImportResult");
+        PreviewRow::export_all(&cfg).expect("PreviewRow");
+        PriceAlert::export_all(&cfg).expect("PriceAlert");
+        PriceAlertInput::export_all(&cfg).expect("PriceAlertInput");
+        PriceData::export_all(&cfg).expect("PriceData");
+        RealizedGainsSummary::export_all(&cfg).expect("RealizedGainsSummary");
+        RealizedLot::export_all(&cfg).expect("RealizedLot");
+        RebalanceSuggestion::export_all(&cfg).expect("RebalanceSuggestion");
+        RefreshResult::export_all(&cfg).expect("RefreshResult");
+        RowAction::export_all(&cfg).expect("RowAction");
+        SectorWeight::export_all(&cfg).expect("SectorWeight");
+        StressHoldingResult::export_all(&cfg).expect("StressHoldingResult");
+        StressResult::export_all(&cfg).expect("StressResult");
+        StressScenario::export_all(&cfg).expect("StressScenario");
+        SymbolMetadata::export_all(&cfg).expect("SymbolMetadata");
+        SymbolResult::export_all(&cfg).expect("SymbolResult");
+        Transaction::export_all(&cfg).expect("Transaction");
+        TransactionInput::export_all(&cfg).expect("TransactionInput");
+        TransactionType::export_all(&cfg).expect("TransactionType");
     }
 }


### PR DESCRIPTION
## Summary
- Moved `mod ts_binding_tests` in `src-tauri/src/lib.rs` to the end of the file, after all other items, to satisfy `clippy::items_after_test_module`
- Replaced `std::iter::repeat('日').take(200).collect()` with `"日".repeat(200)` in a `csv.rs` test to satisfy `clippy::manual_str_repeat`

Neither issue surfaces in CI today, since `.github/workflows/ci.yml` runs plain `cargo clippy -- -D warnings` (no `--tests`/`--all-targets`), but both block the stricter `cargo clippy --all-targets -- -D warnings` when run locally.

## Test plan
- [x] `cargo clippy --all-targets -p portfolio-tracker -- -D warnings` — clean
- [x] Pre-push hook (lint, typecheck, format, frontend build, backend build, frontend tests, backend tests, clippy) — all passed