### PR TITLE
fix: persist exchange and target_weight on import commit

### DIFF
--- a/frontend/types/bindings/NormalizedImportRow.ts
+++ b/frontend/types/bindings/NormalizedImportRow.ts
@@ -8,7 +8,7 @@ export type NormalizedImportRow = { rowNumber: number, action: RowAction, symbol
 /**
  * e.g. "average_cost", "derived:total_cost/qty"
  */
-costBasisSource: string | null, currency: string | null, bookValue: number | null, marketValue: number | null, accountType: string, accountName: string | null, warnings: Array<string>, errors: Array<string>, 
+costBasisSource: string | null, currency: string | null, bookValue: number | null, marketValue: number | null, exchange: string | null, targetWeight: number | null, accountType: string, accountName: string | null, warnings: Array<string>, errors: Array<string>, 
 /**
  * Original CSV values for this row, keyed by source header.
  */

--- a/frontend/types/portfolio.ts
+++ b/frontend/types/portfolio.ts
@@ -326,6 +326,8 @@ export interface NormalizedImportRow {
   currency: string | null;
   bookValue: number | null;
   marketValue: number | null;
+  exchange: string | null;
+  targetWeight: number | null;
   accountType: string;
   accountName: string | null;
   warnings: string[];

--- a/src-tauri/src/import_pipeline/aliases.rs
+++ b/src-tauri/src/import_pipeline/aliases.rs
@@ -43,6 +43,8 @@ pub fn canonical_field(header: &str) -> Option<&'static str> {
         "asset class" | "asset type" | "type" | "security type" | "category"
         | "investment type" | "product type" => Some("asset_type"),
         "exchange" | "market" | "listing exchange" | "market code" => Some("exchange"),
+        "target weight" | "target weight (%)" | "target allocation" | "target %"
+        | "target_weight" => Some("target_weight"),
         "settled cash" | "trade cash" | "cash balance" | "cash" | "cash position" | "balance" => {
             Some("cash_balance")
         }
@@ -173,6 +175,14 @@ mod tests {
     fn canonical_field_matches_exchange_aliases() {
         assert_eq!(canonical_field("Exchange"), Some("exchange"));
         assert_eq!(canonical_field("Listing Exchange"), Some("exchange"));
+    }
+
+    #[test]
+    fn canonical_field_matches_target_weight_aliases() {
+        assert_eq!(canonical_field("Target Weight"), Some("target_weight"));
+        assert_eq!(canonical_field("Target Weight (%)"), Some("target_weight"));
+        assert_eq!(canonical_field("Target Allocation"), Some("target_weight"));
+        assert_eq!(canonical_field("target_weight"), Some("target_weight"));
     }
 
     #[test]

--- a/src-tauri/src/import_pipeline/commit.rs
+++ b/src-tauri/src/import_pipeline/commit.rs
@@ -173,8 +173,11 @@ pub async fn commit_import_rows(
                 quantity,
                 cost_basis,
                 currency,
-                exchange: existing.exchange.clone(),
-                target_weight: existing.target_weight,
+                exchange: row
+                    .exchange
+                    .clone()
+                    .unwrap_or_else(|| existing.exchange.clone()),
+                target_weight: row.target_weight.or(existing.target_weight),
                 created_at: existing.created_at.clone(),
                 updated_at: existing.updated_at.clone(),
                 indicated_annual_dividend: existing.indicated_annual_dividend,
@@ -210,8 +213,8 @@ pub async fn commit_import_rows(
                 quantity,
                 cost_basis,
                 currency,
-                exchange: String::new(),
-                target_weight: None,
+                exchange: row.exchange.clone().unwrap_or_default(),
+                target_weight: row.target_weight,
                 indicated_annual_dividend: None,
                 indicated_annual_dividend_currency: None,
                 dividend_frequency: None,
@@ -286,6 +289,8 @@ mod tests {
             currency: Some("USD".to_string()),
             book_value: None,
             market_value: None,
+            exchange: None,
+            target_weight: None,
             account_type: "taxable".to_string(),
             account_name: None,
             warnings: Vec::new(),
@@ -361,6 +366,118 @@ mod tests {
         assert_eq!(result.updated, 1);
         assert_eq!(result.created, 0);
         assert_eq!(result.changed_symbols, vec!["AAPL".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn commit_creates_a_new_holding_with_exchange_and_target_weight_from_the_row() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        let mut row = base_row(8);
+        row.exchange = Some("NASDAQ".to_string());
+        row.target_weight = Some(12.5);
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+        assert_eq!(result.created, 1);
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(holdings[0].exchange, "NASDAQ");
+        assert_eq!(holdings[0].target_weight, Some(12.5));
+    }
+
+    #[tokio::test]
+    async fn commit_update_writes_exchange_and_target_weight_when_row_provides_them() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+        db::insert_holding(
+            &pool,
+            HoldingInput {
+                symbol: "AAPL".to_string(),
+                name: "Apple Inc.".to_string(),
+                asset_type: AssetType::Stock,
+                account: AccountType::Taxable,
+                account_id: Some("acct-1".to_string()),
+                quantity: 5.0,
+                cost_basis: 100.0,
+                currency: "USD".to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut row = base_row(8);
+        row.action = RowAction::Update;
+        row.exchange = Some("NYSE".to_string());
+        row.target_weight = Some(8.0);
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+        assert_eq!(result.updated, 1);
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(holdings[0].exchange, "NYSE");
+        assert_eq!(holdings[0].target_weight, Some(8.0));
+    }
+
+    #[tokio::test]
+    async fn commit_update_preserves_existing_exchange_and_target_weight_when_row_omits_them() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+        db::insert_holding(
+            &pool,
+            HoldingInput {
+                symbol: "AAPL".to_string(),
+                name: "Apple Inc.".to_string(),
+                asset_type: AssetType::Stock,
+                account: AccountType::Taxable,
+                account_id: Some("acct-1".to_string()),
+                quantity: 5.0,
+                cost_basis: 100.0,
+                currency: "USD".to_string(),
+                exchange: "NASDAQ".to_string(),
+                target_weight: Some(20.0),
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut row = base_row(8);
+        row.action = RowAction::Update;
+        row.quantity = Some(10.0);
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+        assert_eq!(result.updated, 1);
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(holdings[0].exchange, "NASDAQ");
+        assert_eq!(holdings[0].target_weight, Some(20.0));
     }
 
     #[tokio::test]

--- a/src-tauri/src/import_pipeline/normalize.rs
+++ b/src-tauri/src/import_pipeline/normalize.rs
@@ -165,6 +165,8 @@ pub fn normalize_row(
     }
 
     let market_value = parse_f64(canonical.get("market_value").map(|s| s.as_str()));
+    let exchange = canonical.get("exchange").cloned();
+    let target_weight = parse_f64(canonical.get("target_weight").map(|s| s.as_str()));
     let dividend_yield = parse_f64(canonical.get("dividend_yield").map(|s| s.as_str()));
     let annualized_income = parse_f64(canonical.get("annualized_income").map(|s| s.as_str()));
     let ex_dividend_date = canonical.get("ex_dividend_date").cloned();
@@ -190,6 +192,8 @@ pub fn normalize_row(
         currency,
         book_value,
         market_value,
+        exchange,
+        target_weight,
         account_type: context.account_type.clone(),
         account_name: context.account_name.clone(),
         warnings,
@@ -244,6 +248,8 @@ pub fn normalize_cash_row(raw: &RawRow, context: &ImportContext) -> NormalizedIm
         currency: currency.clone(),
         book_value: None,
         market_value: None,
+        exchange: None,
+        target_weight: None,
         account_type: context.account_type.clone(),
         account_name: context.account_name.clone(),
         warnings,
@@ -527,6 +533,42 @@ mod tests {
         );
         assert_eq!(a.book_value, Some(100.0));
         assert_eq!(b.book_value, Some(200.0));
+    }
+
+    #[test]
+    fn exchange_and_target_weight_are_captured_from_canonical_columns() {
+        let normalized = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+                ("Exchange", "NASDAQ"),
+                ("Target Weight", "12.5"),
+            ],
+            8,
+            &context(),
+        );
+        assert_eq!(normalized.exchange, Some("NASDAQ".to_string()));
+        assert_eq!(normalized.target_weight, Some(12.5));
+    }
+
+    #[test]
+    fn exchange_and_target_weight_are_none_when_columns_absent() {
+        let normalized = normalize(
+            &[
+                ("Symbol", "AAPL:US"),
+                ("Asset Class", "Equity"),
+                ("Quantity", "100"),
+                ("Average Cost", "135.50"),
+                ("Currency", "USD"),
+            ],
+            8,
+            &context(),
+        );
+        assert_eq!(normalized.exchange, None);
+        assert_eq!(normalized.target_weight, None);
     }
 
     #[test]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -552,6 +552,8 @@ pub struct NormalizedImportRow {
     pub currency: Option<String>,
     pub book_value: Option<f64>,
     pub market_value: Option<f64>,
+    pub exchange: Option<String>,
+    pub target_weight: Option<f64>,
     pub account_type: String,
     pub account_name: Option<String>,
     pub warnings: Vec<String>,


### PR DESCRIPTION
## Summary
- `commit_import_rows` hardcoded `exchange` to `""` and `target_weight` to `None` for both created and updated holdings, discarding whatever values the import pipeline had for the row.
- `NormalizedImportRow` never actually carried those values in the first place: `exchange` was a recognized column alias in `aliases::canonical_field` but had no struct field to land in, and `target_weight` wasn't a recognized alias at all.
- Wired the full path: alias registry → row normalization → commit persistence.
- On update, row-provided values win; when the row omits them, the existing holding's values are preserved (matches the existing fallback pattern used for `name`).

## Changes
- `types.rs`: added `exchange: Option<String>` and `target_weight: Option<f64>` to `NormalizedImportRow`.
- `import_pipeline/aliases.rs`: added `target_weight` canonical-field aliases ("Target Weight", "Target Weight (%)", "Target Allocation", "Target %", "target_weight").
- `import_pipeline/normalize.rs`: populate `exchange`/`target_weight` from the canonical column map.
- `import_pipeline/commit.rs`: use `row.exchange`/`row.target_weight` on insert; fall back to the existing holding's values on update when the row omits them.
- `frontend/types/portfolio.ts` + `frontend/types/bindings/NormalizedImportRow.ts`: mirrored the new fields (ts-rs regenerated).

Closes #731

## Test plan
- [x] New unit tests in `commit.rs` (create + update with row values, update preserving existing values when row omits them) — verified RED before the fix, GREEN after.
- [x] New unit tests in `aliases.rs` and `normalize.rs` for `target_weight` alias matching and column capture — verified RED before the fix, GREEN after.
- [x] `cargo test` — 402 unit tests + 13 import integration tests pass.
- [x] `NODE_ENV=development npm run typecheck` — clean.
- [x] `NODE_ENV=development npm run lint` — clean.
- [x] Full pre-push suite (build, 364 frontend tests, cargo test, clippy) — all green.