### PR TITLE
fix: reclassify Warning rows with asset_type Other as NeedsFix

### DIFF
--- a/src-tauri/src/import_pipeline/commit.rs
+++ b/src-tauri/src/import_pipeline/commit.rs
@@ -505,6 +505,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn commit_creates_a_holding_from_a_warning_row_with_a_supported_asset_type() {
+        let pool = db::open_test_db().await;
+        db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)
+            .await
+            .unwrap();
+
+        // A row can be classified `Warning` for reasons unrelated to asset
+        // type (e.g. Settlement Currency mismatching Average Cost Currency)
+        // while its asset_type is still one of the four the DB supports.
+        // Such a row is genuinely committable — the warning is informational
+        // only — and must be written to the DB, not treated like `NeedsFix`.
+        let mut row = base_row(8);
+        row.action = RowAction::Warning;
+        row.warnings = vec![
+            "Settlement Currency (CAD) does not match Average Cost Currency (USD)".to_string(),
+        ];
+        let request = ImportCommitRequest {
+            plan_rows: vec![row],
+            account_id: "acct-1".to_string(),
+            include_cash: false,
+        };
+        let result = commit_import_rows(&pool, &request).await.expect("commit");
+
+        assert_eq!(result.created, 1);
+        assert_eq!(result.skipped, 0);
+        assert!(result.errors.is_empty());
+
+        let holdings = db::get_all_holdings(&pool).await.unwrap();
+        assert_eq!(holdings.len(), 1);
+        assert_eq!(holdings[0].symbol, "AAPL");
+    }
+
+    #[tokio::test]
     async fn commit_rejects_unsupported_asset_type_other_with_error() {
         let pool = db::open_test_db().await;
         db::insert_account(&pool, "acct-1", "Taxable", "taxable", None)

--- a/src-tauri/src/import_pipeline/normalize.rs
+++ b/src-tauri/src/import_pipeline/normalize.rs
@@ -120,7 +120,15 @@ pub fn normalize_row(
         errors.push("Missing asset class".to_string());
     }
     if let Some(w) = asset_type_warning {
-        warnings.push(w);
+        // `AssetType` (and the DB's CHECK constraint) has no "Other" variant,
+        // so a row that maps here can never actually be committed — treat it
+        // as `NeedsFix` rather than `Warning`, which would falsely imply it's
+        // includable in a "commit clean rows including warnings" action.
+        if asset_type.as_deref() == Some("Other") {
+            errors.push(w);
+        } else {
+            warnings.push(w);
+        }
     }
 
     // ── Quantity ──
@@ -375,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn warning_when_asset_class_is_fixed_income() {
+    fn needs_fix_when_asset_class_is_fixed_income() {
         let normalized = normalize(
             &[
                 ("Symbol", "GIC123"),
@@ -387,10 +395,10 @@ mod tests {
             8,
             &context(),
         );
-        assert_eq!(normalized.action, RowAction::Warning);
+        assert_eq!(normalized.action, RowAction::NeedsFix);
         assert_eq!(normalized.asset_type, Some("Other".to_string()));
         assert!(normalized
-            .warnings
+            .errors
             .iter()
             .any(|w| w.contains("no live pricing")));
     }

--- a/src-tauri/tests/import_integration.rs
+++ b/src-tauri/tests/import_integration.rs
@@ -195,7 +195,7 @@ async fn test_blank_symbol_is_needs_fix() {
 }
 
 #[tokio::test]
-async fn test_fixed_income_is_warning() {
+async fn test_fixed_income_is_needs_fix() {
     let pool = unused_pool().await;
     let dir = std::env::temp_dir().join(format!("import-it-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).unwrap();
@@ -210,9 +210,12 @@ async fn test_fixed_income_is_warning() {
         .iter()
         .find(|r| r.symbol.as_deref() == Some("CA135087J546"))
         .expect("bond row");
-    assert_eq!(bond.action, RowAction::Warning);
+    // `AssetType` has no "Other" variant and the DB's CHECK constraint
+    // rejects it outright, so this row can never actually be committed —
+    // it must be `NeedsFix`, not `Warning` (see #733).
+    assert_eq!(bond.action, RowAction::NeedsFix);
     assert_eq!(bond.asset_type, Some("Other".to_string()));
-    assert!(bond.warnings.iter().any(|w| w.contains("pricing")));
+    assert!(bond.errors.iter().any(|w| w.contains("pricing")));
 
     std::fs::remove_dir_all(&dir).ok();
 }
@@ -259,13 +262,14 @@ async fn test_full_plan_counts() {
         .await
         .expect("plan should build");
 
-    // 6 create (4 clean holdings + 2 cash rows), 1 warning (Fixed Income
-    // bond), 2 needs_fix (blank symbol, and Market-Value-only with no
-    // derivable cost basis). No updates/skips — nothing pre-exists in the DB
-    // and there are no intra-file duplicate symbols.
+    // 6 create (4 clean holdings + 2 cash rows), 0 warning, 3 needs_fix
+    // (blank symbol, Market-Value-only with no derivable cost basis, and the
+    // Fixed Income bond — asset_type "Other" can never commit, see #733).
+    // No updates/skips — nothing pre-exists in the DB and there are no
+    // intra-file duplicate symbols.
     assert_eq!(plan.count_create, 6);
-    assert_eq!(plan.count_warning, 1);
-    assert_eq!(plan.count_needs_fix, 2);
+    assert_eq!(plan.count_warning, 0);
+    assert_eq!(plan.count_needs_fix, 3);
     assert_eq!(plan.count_update, 0);
     assert_eq!(plan.count_skip, 0);
 


### PR DESCRIPTION
## Summary
- `AssetType` has no `Other` variant and `holdings.asset_type` has a `CHECK (asset_type IN ('stock','etf','crypto','cash'))` constraint, so a row that `map_asset_class` resolves to `Other` (Fixed Income, GIC, Money Market, or any unrecognized asset class) could never actually be committed — `commit_import_rows` always rejected it with "not yet supported", even though the plan preview labeled it `Warning`, implying it was includable in a "commit clean rows including warnings" action.
- `normalize_row` now routes the asset-class message to `errors` instead of `warnings` when the resolved `asset_type` is `"Other"`, so these rows classify as `NeedsFix` — consistent with what the schema can actually support today (per the issue's primary suggested fix). Warning rows with a real, committable asset type (e.g. a Settlement Currency mismatch) are unaffected and still commit as before.

Closes #733

## Test plan
- [x] `needs_fix_when_asset_class_is_fixed_income` (normalize.rs) updated: Fixed Income now asserts `NeedsFix` + error, not `Warning`
- [x] `test_fixed_income_is_needs_fix` (import_integration.rs) updated to match
- [x] `test_full_plan_counts` updated: `count_warning` 1→0, `count_needs_fix` 2→3
- [x] New test `commit_creates_a_holding_from_a_warning_row_with_a_supported_asset_type` (commit.rs) proves a genuine Warning row with a real asset type still commits
- [x] `cargo test` — 403 + 13 + 76 tests pass, 0 failures
- [x] `NODE_ENV=development npm run typecheck` — clean
- [x] Pre-push hook (lint, build, frontend+backend tests, clippy) — all green