### PR TITLE
fix: validate boolean config keys accept only true/false

### DIFF
--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -361,6 +361,14 @@ pub fn validate_config_value(key: &str, value: &str) -> Result<(), McpError> {
                 ));
             }
         }
+        "notifications_enabled" | "auto_refresh_market_hours_only" => {
+            if !["true", "false"].contains(&value) {
+                return Err(McpError::invalid_params(
+                    format!("{key} must be one of: true, false (got: {value})"),
+                    None,
+                ));
+            }
+        }
         _ => {
             if value.len() > MAX_CONFIG_VALUE_LEN {
                 return Err(McpError::invalid_params(

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -111,6 +111,13 @@ pub(crate) fn validate_config_value(key: &str, value: &str) -> Result<(), AppErr
                 )));
             }
         }
+        "notifications_enabled" | "auto_refresh_market_hours_only" => {
+            if !["true", "false"].contains(&value) {
+                return Err(AppError::Validation(format!(
+                    "{key} must be one of: true, false (got: {value})"
+                )));
+            }
+        }
         _ => {
             if value.len() > MAX_CONFIG_VALUE_LEN {
                 return Err(AppError::Validation(format!(


### PR DESCRIPTION
`notifications_enabled` and `auto_refresh_market_hours_only` were accepted with any non-empty string (up to 500 chars) through the generic validation arm.

## Changes

- **`src-tauri/src/commands/config.rs`**: Add explicit match arm restricting these two keys to `"true" | "false"`
- **`portfolio-mcp/src/validation.rs`**: Mirror the same fix (kept in sync with config.rs per the pattern established for `cost_basis_method`)

Both files now validate these keys consistently. A value like `"banana"` returns a `Validation` error with a descriptive message.

Closes #740