### PR TITLE
feat: historical scenario replay presets for stress test

### DIFF
--- a/frontend/components/PresetScenarioSelector.tsx
+++ b/frontend/components/PresetScenarioSelector.tsx
@@ -1,5 +1,5 @@
 // ─── Preset scenario selector for stress test ─────────────────────────────────
-import { HelpCircle } from 'lucide-react';
+import { Calendar, HelpCircle } from 'lucide-react';
 import { Select } from './ui/Select';
 import type { StressScenarioInfo } from '../types/portfolio';
 
@@ -13,6 +13,33 @@ const SECTION_TITLE: React.CSSProperties = {
   paddingBottom: 6,
   borderBottom: '1px solid var(--border-subtle)',
 };
+
+// ─── "Historical" badge — marks presets whose shocks are real, not hypothetical ──
+function HistoricalBadge() {
+  return (
+    <span
+      title="Shock values are derived from an actual historical event"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 3,
+        borderRadius: '2px',
+        fontSize: 9,
+        fontWeight: 600,
+        padding: '1px 5px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+        fontFamily: 'var(--font-mono)',
+        background: 'var(--color-warning)18',
+        color: 'var(--color-warning)',
+        border: '1px solid var(--color-warning)55',
+      }}
+    >
+      <Calendar size={9} />
+      Historical
+    </span>
+  );
+}
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 export interface PresetScenarioSelectorProps {
@@ -72,7 +99,14 @@ export function PresetScenarioSelector({
       <Select
         value={presetName}
         onChange={onSelect}
-        options={presetNames.map((n) => ({ value: n, label: n }))}
+        options={presetNames.map((n) => {
+          const info = scenarioInfo.find((s) => s.name === n);
+          return {
+            value: n,
+            label: n,
+            badge: info?.isHistorical ? <HistoricalBadge /> : undefined,
+          };
+        })}
       />
       {/* Scenario description */}
       {activePresetInfo && (
@@ -86,6 +120,27 @@ export function PresetScenarioSelector({
           }}
         >
           {activePresetInfo.description}
+        </div>
+      )}
+      {/* Data source footnote, historical presets only */}
+      {activePresetInfo?.isHistorical && activePresetInfo.dataSource && (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 10,
+            color: 'var(--text-secondary)',
+            fontFamily: 'var(--font-mono)',
+            lineHeight: 1.5,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 5,
+          }}
+        >
+          <Calendar
+            size={11}
+            style={{ flexShrink: 0, marginTop: 1, color: 'var(--color-warning)' }}
+          />
+          <span>{activePresetInfo.dataSource}</span>
         </div>
       )}
     </div>

--- a/frontend/components/StressTestInfo.tsx
+++ b/frontend/components/StressTestInfo.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { X } from 'lucide-react';
+import { Calendar, X } from 'lucide-react';
 import { formatPercent } from '../lib/format';
 import type { StressScenarioInfo } from '../types/portfolio';
 
@@ -72,9 +72,34 @@ export function StressTestInfo({ scenario, isOpen, onClose }: Props) {
                 fontFamily: 'var(--font-sans)',
                 fontSize: 18,
                 color: 'var(--text-primary)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
               }}
             >
               {scenario.name}
+              {scenario.isHistorical && (
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 3,
+                    borderRadius: '2px',
+                    fontSize: 9,
+                    fontWeight: 600,
+                    padding: '1px 5px',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.05em',
+                    fontFamily: 'var(--font-mono)',
+                    background: 'var(--color-warning)18',
+                    color: 'var(--color-warning)',
+                    border: '1px solid var(--color-warning)55',
+                  }}
+                >
+                  <Calendar size={9} />
+                  Historical
+                </span>
+              )}
             </h2>
           </div>
           <button
@@ -184,6 +209,33 @@ export function StressTestInfo({ scenario, isOpen, onClose }: Props) {
             {scenario.historicalParallel}
           </div>
         </div>
+
+        {scenario.isHistorical && scenario.dataSource && (
+          <div style={{ marginTop: 18 }}>
+            <div
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 10,
+                color: 'var(--text-muted)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                marginBottom: 6,
+              }}
+            >
+              Data Source
+            </div>
+            <div
+              style={{
+                color: 'var(--text-secondary)',
+                fontSize: 12,
+                fontFamily: 'var(--font-mono)',
+                lineHeight: 1.6,
+              }}
+            >
+              {scenario.dataSource}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/__tests__/StressComponents.test.tsx
+++ b/frontend/components/__tests__/StressComponents.test.tsx
@@ -14,6 +14,8 @@ import { ResilienceSummary } from '../ResilienceSummary';
 import { StressResultsTable } from '../StressResultsTable';
 // ─── PresetScenarioSelector ───────────────────────────────────────────────────
 import { PresetScenarioSelector } from '../PresetScenarioSelector';
+// ─── StressTestInfo ───────────────────────────────────────────────────────────
+import { StressTestInfo } from '../StressTestInfo';
 
 import type { PortfolioSnapshot, HoldingWithPrice, StressResult } from '../../types/portfolio';
 
@@ -266,5 +268,127 @@ describe('PresetScenarioSelector', () => {
       />
     );
     expect(screen.getByText(/A severe market downturn/)).toBeTruthy();
+  });
+
+  // ─── Historical preset distinction ───────────────────────────────────────────
+  const historicalPresetNames = ['Bear Market', '2008 Global Financial Crisis', 'Custom'];
+  const historicalScenarioInfo = [
+    ...scenarioInfo,
+    {
+      name: '2008 Global Financial Crisis',
+      description: 'Replays the 2008 credit crisis.',
+      historicalParallel: 'Global Financial Crisis, Oct 2007 - Mar 2009',
+      shocks: { stock: -0.567 },
+      isHistorical: true,
+      dataSource: 'S&P 500 -56.8% peak-to-trough, Oct 9 2007 - Mar 9 2009',
+    },
+  ];
+
+  it('does not show a Historical badge in the trigger for a hypothetical preset', () => {
+    render(
+      <PresetScenarioSelector
+        presetName="Bear Market"
+        presetNames={historicalPresetNames}
+        scenarioInfo={historicalScenarioInfo}
+        onSelect={vi.fn()}
+        onInfoOpen={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/historical/i)).toBeNull();
+  });
+
+  it('shows a Historical badge in the trigger when a historical preset is selected', () => {
+    render(
+      <PresetScenarioSelector
+        presetName="2008 Global Financial Crisis"
+        presetNames={historicalPresetNames}
+        scenarioInfo={historicalScenarioInfo}
+        onSelect={vi.fn()}
+        onInfoOpen={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/historical/i)).toBeTruthy();
+  });
+
+  it('shows a Historical badge next to the option when the dropdown is opened', () => {
+    render(
+      <PresetScenarioSelector
+        presetName="Bear Market"
+        presetNames={historicalPresetNames}
+        scenarioInfo={historicalScenarioInfo}
+        onSelect={vi.fn()}
+        onInfoOpen={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('option', { name: /2008 global financial crisis/i })).toBeTruthy();
+    expect(screen.getByText(/historical/i)).toBeTruthy();
+  });
+
+  it('shows the data source footnote for a historical preset', () => {
+    render(
+      <PresetScenarioSelector
+        presetName="2008 Global Financial Crisis"
+        presetNames={historicalPresetNames}
+        scenarioInfo={historicalScenarioInfo}
+        onSelect={vi.fn()}
+        onInfoOpen={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/S&P 500 -56.8% peak-to-trough/)).toBeTruthy();
+  });
+
+  it('does not show a data source footnote for a hypothetical preset', () => {
+    render(
+      <PresetScenarioSelector
+        presetName="Bear Market"
+        presetNames={historicalPresetNames}
+        scenarioInfo={historicalScenarioInfo}
+        onSelect={vi.fn()}
+        onInfoOpen={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/peak-to-trough/)).toBeNull();
+  });
+});
+
+// ─── StressTestInfo tests ─────────────────────────────────────────────────────
+describe('StressTestInfo', () => {
+  const hypotheticalScenario = {
+    name: 'Bear Market',
+    description: 'A severe market downturn.',
+    historicalParallel: '2008',
+    shocks: { stock: -0.2 },
+  };
+
+  const historicalScenario = {
+    name: '2008 Global Financial Crisis',
+    description: 'Replays the 2008 credit crisis.',
+    historicalParallel: 'Global Financial Crisis, Oct 2007 - Mar 2009',
+    shocks: { stock: -0.567 },
+    isHistorical: true,
+    dataSource: 'S&P 500 -56.8% peak-to-trough, Oct 9 2007 - Mar 9 2009',
+  };
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <StressTestInfo scenario={historicalScenario} isOpen={false} onClose={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a Historical badge and Data Source section for a historical scenario', () => {
+    render(<StressTestInfo scenario={historicalScenario} isOpen={true} onClose={vi.fn()} />);
+    // "Historical" badge plus the always-present "Historical Parallel" heading
+    expect(screen.getAllByText(/historical/i)).toHaveLength(2);
+    expect(screen.getByText(/data source/i)).toBeTruthy();
+    expect(screen.getByText(/S&P 500 -56.8% peak-to-trough/)).toBeTruthy();
+  });
+
+  it('omits the Historical badge and Data Source section for a hypothetical scenario', () => {
+    render(<StressTestInfo scenario={hypotheticalScenario} isOpen={true} onClose={vi.fn()} />);
+    // Only the always-present "Historical Parallel" heading, no "Historical" badge
+    expect(screen.getAllByText(/historical/i)).toHaveLength(1);
+    expect(screen.queryByText(/data source/i)).toBeNull();
   });
 });

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -4,6 +4,8 @@ import { ChevronDown } from 'lucide-react';
 export interface SelectOption {
   value: string;
   label: string;
+  /** Optional decoration (icon, badge) rendered inline after the label, in the trigger and the list. */
+  badge?: React.ReactNode;
 }
 
 interface Props {
@@ -18,7 +20,8 @@ export function Select({ value, onChange, options, style }: Props) {
   const [activeIndex, setActiveIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const selectedLabel = options.find((o) => o.value === value)?.label ?? value;
+  const selectedOption = options.find((o) => o.value === value);
+  const selectedLabel = selectedOption?.label ?? value;
 
   // Close on outside click
   useEffect(() => {
@@ -123,7 +126,10 @@ export function Select({ value, onChange, options, style }: Props) {
           e.currentTarget.style.borderColor = 'var(--border-primary)';
         }}
       >
-        <span>{selectedLabel}</span>
+        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {selectedLabel}
+          {selectedOption?.badge}
+        </span>
         <ChevronDown
           size={13}
           style={{
@@ -161,9 +167,13 @@ export function Select({ value, onChange, options, style }: Props) {
                   color: isSelected ? 'var(--color-accent)' : 'var(--text-primary)',
                   background: isActive ? 'var(--bg-surface-hover)' : 'transparent',
                   userSelect: 'none',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
                 }}
               >
                 {opt.label}
+                {opt.badge}
               </li>
             );
           })}

--- a/frontend/lib/__tests__/historicalScenarios.test.ts
+++ b/frontend/lib/__tests__/historicalScenarios.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createPresetScenarioInfo, fxShockKey } from '../constants';
+
+const HISTORICAL_NAMES = [
+  '2008 Global Financial Crisis',
+  'COVID-19 Crash',
+  '2022 Rate-Hike Cycle',
+  'Dot-Com Crash',
+  'Black Monday 1987',
+];
+
+describe('historical scenario presets', () => {
+  it('includes all named historical events, each marked isHistorical with a dataSource', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    for (const name of HISTORICAL_NAMES) {
+      const preset = presets.find((p) => p.name === name);
+      expect(preset, `missing preset: ${name}`).toBeTruthy();
+      expect(preset!.isHistorical).toBe(true);
+      expect(preset!.dataSource).toBeTruthy();
+      expect(preset!.dataSource!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('does not mark existing hypothetical presets as historical', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    const bearMarket = presets.find((p) => p.name === 'Bear Market');
+    expect(bearMarket).toBeTruthy();
+    expect(bearMarket!.isHistorical).toBeUndefined();
+    expect(bearMarket!.dataSource).toBeUndefined();
+  });
+
+  it('gives every historical preset at least one non-zero shock', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    for (const name of HISTORICAL_NAMES) {
+      const preset = presets.find((p) => p.name === name)!;
+      const values = Object.values(preset.shocks);
+      expect(values.length).toBeGreaterThan(0);
+      expect(values.some((v) => v !== 0)).toBe(true);
+    }
+  });
+
+  it('omits crypto shocks for events that predate Bitcoin', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    const gfc = presets.find((p) => p.name === '2008 Global Financial Crisis')!;
+    const dotcom = presets.find((p) => p.name === 'Dot-Com Crash')!;
+    const blackMonday = presets.find((p) => p.name === 'Black Monday 1987')!;
+    expect(gfc.shocks.crypto).toBeUndefined();
+    expect(dotcom.shocks.crypto).toBeUndefined();
+    expect(blackMonday.shocks.crypto).toBeUndefined();
+  });
+
+  it('includes a crypto shock for post-2009 historical events', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    const covid = presets.find((p) => p.name === 'COVID-19 Crash')!;
+    const rateHike = presets.find((p) => p.name === '2022 Rate-Hike Cycle')!;
+    expect(covid.shocks.crypto).toBeLessThan(0);
+    expect(rateHike.shocks.crypto).toBeLessThan(0);
+  });
+
+  it('applies FX shocks under the base-currency-specific key', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    const gfc = presets.find((p) => p.name === '2008 Global Financial Crisis')!;
+    expect(gfc.shocks[fxShockKey('USD', 'CAD')]).toBeGreaterThan(0);
+  });
+
+  it('omits the USD/CAD shock entirely when the base currency is USD', () => {
+    const presets = createPresetScenarioInfo('USD');
+    const gfc = presets.find((p) => p.name === '2008 Global Financial Crisis')!;
+    expect(Object.keys(gfc.shocks)).not.toContain(fxShockKey('USD', 'USD'));
+  });
+
+  it('keeps every shock value within the [-1, 1] range', () => {
+    const presets = createPresetScenarioInfo('CAD');
+    for (const name of HISTORICAL_NAMES) {
+      const preset = presets.find((p) => p.name === name)!;
+      for (const value of Object.values(preset.shocks)) {
+        expect(value).toBeGreaterThanOrEqual(-1);
+        expect(value).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+});

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -43,6 +43,23 @@ export function createPresetScenarioInfo(baseCurrency: string): StressScenarioIn
   const commodityRally: Record<string, number> = { stock: 0.03, etf: 0.02 };
   addFxShock(commodityRally, 'USD', -0.04);
 
+  // Historical event replays: shock values are derived from actual peak-to-trough
+  // moves during the named event, not hypothetical estimates. Crypto is omitted
+  // for pre-2009 events since it didn't exist yet.
+  const globalFinancialCrisis: Record<string, number> = { stock: -0.567, etf: -0.567 };
+  addFxShock(globalFinancialCrisis, 'USD', 0.21);
+
+  const covidCrash: Record<string, number> = { stock: -0.339, etf: -0.339, crypto: -0.62 };
+  addFxShock(covidCrash, 'USD', 0.11);
+
+  const rateHike2022: Record<string, number> = { stock: -0.254, etf: -0.24, crypto: -0.78 };
+  addFxShock(rateHike2022, 'USD', 0.1);
+
+  const dotcomCrash: Record<string, number> = { stock: -0.49, etf: -0.45 };
+  addFxShock(dotcomCrash, 'USD', 0.1);
+
+  const blackMonday1987: Record<string, number> = { stock: -0.335, etf: -0.335 };
+
   return [
     {
       name: 'Mild Correction',
@@ -119,6 +136,55 @@ export function createPresetScenarioInfo(baseCurrency: string): StressScenarioIn
       description:
         'Models a commodity-led upswing that helps resource-heavy equities while a stronger CAD offsets some foreign gains.',
       historicalParallel: '2021 energy and materials rally',
+    },
+    {
+      name: '2008 Global Financial Crisis',
+      shocks: globalFinancialCrisis,
+      description:
+        'Replays the 2008 credit crisis using the actual peak-to-trough decline in broad equity markets and CAD depreciation against the US dollar. Crypto is excluded since it did not yet exist.',
+      historicalParallel: 'Global Financial Crisis, Oct 2007 - Mar 2009',
+      isHistorical: true,
+      dataSource:
+        'S&P 500 -56.8% peak-to-trough, Oct 9 2007 - Mar 9 2009; USD/CAD +21% over the same window',
+    },
+    {
+      name: 'COVID-19 Crash',
+      shocks: covidCrash,
+      description:
+        'Replays the fastest bear market on record: a five-week equity collapse alongside a sharp crypto selloff and a weaker CAD as investors rushed into US dollars.',
+      historicalParallel: 'COVID-19 crash, Feb-Mar 2020',
+      isHistorical: true,
+      dataSource:
+        'S&P 500 -33.9% peak-to-trough, Feb 19 2020 - Mar 23 2020; Bitcoin -62% over the same window (incl. Mar 12 2020 "Black Thursday"); USD/CAD +11%',
+    },
+    {
+      name: '2022 Rate-Hike Cycle',
+      shocks: rateHike2022,
+      description:
+        'Replays the 2022 drawdown driven by aggressive Fed tightening: equities fell over the full year while crypto suffered a much deeper collapse amid the Terra/Luna and FTX failures.',
+      historicalParallel: '2022 rate hiking cycle',
+      isHistorical: true,
+      dataSource:
+        'S&P 500 -25.4% peak-to-trough, Jan 3 2022 - Oct 12 2022; Bitcoin -77.6% peak-to-trough, Nov 2021 - Nov 2022; USD/CAD +10%',
+    },
+    {
+      name: 'Dot-Com Crash',
+      shocks: dotcomCrash,
+      description:
+        'Replays the 2000-2002 bear market that followed the internet stock bubble, with a multi-year equity decline and a weaker CAD. Crypto is excluded since it did not yet exist.',
+      historicalParallel: 'Dot-com crash, Mar 2000 - Oct 2002',
+      isHistorical: true,
+      dataSource: 'S&P 500 -49% peak-to-trough, Mar 24 2000 - Oct 9 2002; USD/CAD +10%',
+    },
+    {
+      name: 'Black Monday 1987',
+      shocks: blackMonday1987,
+      description:
+        'Replays the 1987 crash centered on a single catastrophic trading day. FX and crypto shocks are excluded: reliable same-week CAD data is not available and crypto did not yet exist.',
+      historicalParallel: 'Black Monday, Oct 19 1987',
+      isHistorical: true,
+      dataSource:
+        'S&P 500 -33.5% peak-to-trough, Aug 25 1987 - Dec 4 1987 (incl. -20.5% on Oct 19 1987 alone)',
     },
   ];
 }

--- a/frontend/types/portfolio.ts
+++ b/frontend/types/portfolio.ts
@@ -183,6 +183,10 @@ export interface StressScenario {
 export interface StressScenarioInfo extends StressScenario {
   description: string;
   historicalParallel: string;
+  /** True for presets whose shock values are derived from an actual historical event, not a hypothetical. */
+  isHistorical?: boolean;
+  /** Traceable citation for the shock values, e.g. "S&P 500 -56.8% peak-to-trough, Oct 2007-Mar 2009". Present only when isHistorical is true. */
+  dataSource?: string;
 }
 
 export interface StressHoldingResult {


### PR DESCRIPTION
## Summary
- Adds five historical-event stress presets to the existing preset list: 2008 Global Financial Crisis, COVID-19 Crash, 2022 Rate-Hike Cycle, Dot-Com Crash, and Black Monday 1987.
- Shock values are curated from actual peak-to-trough moves in each event (S&P 500 / Bitcoin / USD-CAD), not hypothetical estimates. Crypto shocks are omitted for pre-2009 events since Bitcoin didn't exist yet.
- New presets are marked `isHistorical: true` and carry a `dataSource` citation string.
- Preset picker shows a small amber "Historical" badge (calendar icon) next to historical entries, both in the dropdown trigger and each list option — reusing a new optional `badge` field on `Select`'s `SelectOption`.
- A "Data Source" footnote renders under the scenario description when a historical preset is active, and a matching "Data Source" section was added to the `StressTestInfo` modal alongside a "Historical" badge in its title.
- No backend changes — `run_stress_test_cmd` already accepts arbitrary shock maps, so this is purely additive on the frontend (`frontend/lib/constants.ts`, `frontend/types/portfolio.ts`, `PresetScenarioSelector.tsx`, `StressTestInfo.tsx`, `ui/Select.tsx`).

## Test plan
- [x] `npm run test` — 402 tests pass, including new coverage for the historical presets (`frontend/lib/__tests__/historicalScenarios.test.ts`) and the badge/data-source rendering (`frontend/components/__tests__/StressComponents.test.tsx`)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] Manually verified in the browser preview: preset dropdown shows "Historical" badges, selecting "2008 Global Financial Crisis" applies the shocks, updates the waterfall/breakdown, shows the data-source footnote, and the Info modal shows the Historical badge + Data Source section
- [x] Pre-push hook: frontend build, backend build, frontend tests, backend tests, clippy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)