### PR TITLE
fix: convert realized gains to base currency before aggregating

### DIFF
--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -1,6 +1,10 @@
 use std::collections::{HashMap, VecDeque};
 
-use crate::types::{RealizedGainsSummary, RealizedLot, Transaction, TransactionType};
+use portfolio_core::fx::convert_to_base;
+
+use crate::types::{
+    FxRate, HoldingId, RealizedGainsSummary, RealizedLot, Transaction, TransactionType,
+};
 
 /// Compute realized gains for a slice of transactions using the specified method.
 ///
@@ -185,25 +189,79 @@ pub fn aggregate_summaries(summaries: Vec<RealizedGainsSummary>) -> RealizedGain
 }
 
 /// Group transactions by holding_id, compute realized gains per group,
-/// then aggregate. Uses the given method ("avco" | "fifo").
+/// convert each group's totals into `base_currency`, then aggregate.
+/// Uses the given method ("avco" | "fifo").
+///
+/// `holding_currencies` maps each holding to the currency its transaction
+/// prices are denominated in (see `Transaction::price` doc comment — prices
+/// are always in "the holding's original currency"). Without this conversion
+/// step, gains from holdings in different currencies would be summed as if
+/// they were the same currency (#754).
+///
+/// FX conversion uses the current/cached rate, not the historical rate at
+/// time of sale — acceptable for a live dashboard snapshot figure, but not a
+/// substitute for a proper tax/accounting record. If a holding's currency has
+/// no cached rate (or maps to no known holding, e.g. a deleted holding), the
+/// conversion falls back to a 1:1 rate rather than failing the whole snapshot.
 pub fn compute_realized_gains_grouped(
     transactions: &[Transaction],
     method: &str,
+    holding_currencies: &HashMap<HoldingId, String>,
+    base_currency: &str,
+    fx_rates: &[FxRate],
 ) -> Result<RealizedGainsSummary, String> {
     // Group by holding_id (transactions are already sorted by transacted_at)
-    let mut by_holding: HashMap<&crate::types::HoldingId, Vec<&Transaction>> = HashMap::new();
+    let mut by_holding: HashMap<&HoldingId, Vec<&Transaction>> = HashMap::new();
     for tx in transactions {
         by_holding.entry(&tx.holding_id).or_default().push(tx);
     }
 
     let mut summaries = Vec::new();
-    for txs in by_holding.values() {
+    for (holding_id, txs) in by_holding {
         // Each group is already sorted because get_all_transactions returns ASC order
         let owned: Vec<Transaction> = txs.iter().map(|t| (*t).clone()).collect();
-        summaries.push(compute_realized_gains(&owned, method)?);
+        let summary = compute_realized_gains(&owned, method)?;
+
+        let currency = holding_currencies
+            .get(holding_id)
+            .map(String::as_str)
+            .unwrap_or(base_currency);
+        let fx_rate =
+            convert_to_base(1.0, currency, base_currency, fx_rates).unwrap_or_else(|| {
+                tracing::warn!(
+                    holding_id = %holding_id.0,
+                    currency = %currency,
+                    base = %base_currency,
+                    "FX rate unavailable for realized-gains conversion; using 1:1 rate"
+                );
+                1.0
+            });
+
+        summaries.push(convert_summary_to_base(summary, fx_rate));
     }
 
     Ok(aggregate_summaries(summaries))
+}
+
+/// Scale every monetary field of a `RealizedGainsSummary` (totals and
+/// per-lot amounts) by `fx_rate`. `fx_rate` is 1.0 when already in base
+/// currency, so this is a no-op for the common case.
+fn convert_summary_to_base(summary: RealizedGainsSummary, fx_rate: f64) -> RealizedGainsSummary {
+    RealizedGainsSummary {
+        total_realized_gain: summary.total_realized_gain * fx_rate,
+        total_proceeds: summary.total_proceeds * fx_rate,
+        total_cost_basis: summary.total_cost_basis * fx_rate,
+        lots: summary
+            .lots
+            .into_iter()
+            .map(|lot| RealizedLot {
+                proceeds: lot.proceeds * fx_rate,
+                cost_basis: lot.cost_basis * fx_rate,
+                gain_loss: lot.gain_loss * fx_rate,
+                ..lot
+            })
+            .collect(),
+    }
 }
 
 /// Extract the YYYY-MM-DD portion from an ISO 8601 timestamp.
@@ -246,6 +304,45 @@ mod tests {
             price,
             transacted_at: format!("{}T00:00:00Z", date),
             created_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn buy_for(holding_id: &str, quantity: f64, price: f64, date: &str) -> Transaction {
+        Transaction {
+            id: TransactionId(uuid::Uuid::new_v4().to_string()),
+            holding_id: HoldingId(holding_id.to_string()),
+            transaction_type: TransactionType::Buy,
+            quantity,
+            price,
+            transacted_at: format!("{}T00:00:00Z", date),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn sell_for(holding_id: &str, quantity: f64, price: f64, date: &str) -> Transaction {
+        Transaction {
+            id: TransactionId(uuid::Uuid::new_v4().to_string()),
+            holding_id: HoldingId(holding_id.to_string()),
+            transaction_type: TransactionType::Sell,
+            quantity,
+            price,
+            transacted_at: format!("{}T00:00:00Z", date),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_holding_currencies(pairs: &[(&str, &str)]) -> HashMap<HoldingId, String> {
+        pairs
+            .iter()
+            .map(|(id, currency)| (HoldingId(id.to_string()), currency.to_string()))
+            .collect()
+    }
+
+    fn make_fx_rate(pair: &str, rate: f64) -> FxRate {
+        FxRate {
+            pair: pair.to_string(),
+            rate,
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
         }
     }
 
@@ -436,6 +533,101 @@ mod tests {
         assert_eq!(result.lots.len(), 2);
         // Lots should be sorted by date
         assert!(result.lots[0].sold_at <= result.lots[1].sold_at);
+    }
+
+    // ── Grouped multi-currency tests (#754) ──────────────────────────────────
+
+    #[test]
+    fn grouped_converts_each_holding_to_base_currency_before_aggregating() {
+        // h1 is CAD: buy 10 @ 100, sell 5 @ 150 → gain 250 CAD
+        // h2 is USD: buy 10 @ 100, sell 5 @ 150 → gain 250 USD → 337.5 CAD @ 1.35
+        // A naive raw-currency sum would give 500; the correct base-currency
+        // total is 250 + 337.5 = 587.5.
+        let txs = vec![
+            buy_for("h1", 10.0, 100.0, "2024-01-01"),
+            sell_for("h1", 5.0, 150.0, "2024-02-01"),
+            buy_for("h2", 10.0, 100.0, "2024-01-01"),
+            sell_for("h2", 5.0, 150.0, "2024-02-01"),
+        ];
+        let currencies = make_holding_currencies(&[("h1", "CAD"), ("h2", "USD")]);
+        let fx_rates = vec![make_fx_rate("USDCAD", 1.35)];
+
+        let summary =
+            compute_realized_gains_grouped(&txs, "avco", &currencies, "CAD", &fx_rates).unwrap();
+
+        assert!(
+            (summary.total_realized_gain - 587.5).abs() < 1e-6,
+            "expected 587.5 (250 CAD + 250 USD * 1.35), got {}",
+            summary.total_realized_gain
+        );
+    }
+
+    #[test]
+    fn grouped_same_currency_holdings_unaffected() {
+        let txs = vec![
+            buy_for("h1", 10.0, 100.0, "2024-01-01"),
+            sell_for("h1", 5.0, 150.0, "2024-02-01"),
+            buy_for("h2", 20.0, 50.0, "2024-01-01"),
+            sell_for("h2", 5.0, 80.0, "2024-02-01"),
+        ];
+        let currencies = make_holding_currencies(&[("h1", "CAD"), ("h2", "CAD")]);
+
+        let summary =
+            compute_realized_gains_grouped(&txs, "avco", &currencies, "CAD", &[]).unwrap();
+
+        // h1 gain: 250, h2 gain: 5*(80-50)=150 → total 400
+        assert!((summary.total_realized_gain - 400.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn grouped_missing_fx_rate_falls_back_to_unconverted_rate() {
+        // h2 is EUR but no EUR rate is cached; conversion should fall back to
+        // 1:1 rather than erroring — acceptable for a dashboard snapshot figure.
+        let txs = vec![
+            buy_for("h2", 10.0, 100.0, "2024-01-01"),
+            sell_for("h2", 5.0, 150.0, "2024-02-01"),
+        ];
+        let currencies = make_holding_currencies(&[("h2", "EUR")]);
+
+        let summary =
+            compute_realized_gains_grouped(&txs, "avco", &currencies, "CAD", &[]).unwrap();
+
+        assert!((summary.total_realized_gain - 250.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn grouped_converts_lot_level_fields_too() {
+        let txs = vec![
+            buy_for("h2", 10.0, 100.0, "2024-01-01"),
+            sell_for("h2", 5.0, 150.0, "2024-02-01"),
+        ];
+        let currencies = make_holding_currencies(&[("h2", "USD")]);
+        let fx_rates = vec![make_fx_rate("USDCAD", 1.35)];
+
+        let summary =
+            compute_realized_gains_grouped(&txs, "avco", &currencies, "CAD", &fx_rates).unwrap();
+
+        assert_eq!(summary.lots.len(), 1);
+        assert!((summary.lots[0].proceeds - 750.0 * 1.35).abs() < 1e-6);
+        assert!((summary.lots[0].cost_basis - 500.0 * 1.35).abs() < 1e-6);
+        assert!((summary.lots[0].gain_loss - 250.0 * 1.35).abs() < 1e-6);
+    }
+
+    #[test]
+    fn grouped_unknown_holding_id_falls_back_to_base_currency() {
+        // Transactions referencing a holding absent from the currency map
+        // (e.g. the holding was since deleted) should not error — fall back
+        // to treating the amount as already in base currency.
+        let txs = vec![
+            buy_for("ghost", 10.0, 100.0, "2024-01-01"),
+            sell_for("ghost", 5.0, 150.0, "2024-02-01"),
+        ];
+        let currencies = HashMap::new();
+
+        let summary =
+            compute_realized_gains_grouped(&txs, "avco", &currencies, "CAD", &[]).unwrap();
+
+        assert!((summary.total_realized_gain - 250.0).abs() < 1e-6);
     }
 
     #[test]

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -473,8 +473,22 @@ pub async fn get_realized_gains(
         None => db::get_all_transactions(pool).await?,
     };
 
-    let summary = compute_realized_gains_grouped(&transactions, &cost_basis_method)
-        .map_err(AppError::from)?;
+    let base_currency = get_base_currency(pool).await;
+    let holdings = db::get_all_holdings(pool).await?;
+    let cached_fx = db::get_fx_rates(pool).await?;
+    let holding_currencies: HashMap<HoldingId, String> = holdings
+        .iter()
+        .map(|h| (h.id.clone(), h.currency.clone()))
+        .collect();
+
+    let summary = compute_realized_gains_grouped(
+        &transactions,
+        &cost_basis_method,
+        &holding_currencies,
+        &base_currency,
+        &cached_fx,
+    )
+    .map_err(AppError::from)?;
 
     // Populate the cache only for the full-portfolio case.
     if holding_id.is_none() {

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -146,8 +146,16 @@ pub async fn set_config_cmd(
     key: String,
     value: String,
 ) -> Result<(), AppError> {
+    set_config_cmd_impl(&db.0, &gains_cache, key, value).await
+}
+
+async fn set_config_cmd_impl(
+    pool: &sqlx::SqlitePool,
+    gains_cache: &RealizedGainsCacheState,
+    key: String,
+    value: String,
+) -> Result<(), AppError> {
     validate_config_key(&key)?;
-    let pool = &db.0;
     let value = if key == "cost_basis_method" {
         value.to_lowercase()
     } else {
@@ -159,7 +167,10 @@ pub async fn set_config_cmd(
         .map_err(AppError::from)?;
     // Changing the cost-basis method invalidates any previously cached realized gains
     // because the same transaction history produces a different result under AVCO vs FIFO.
-    if key == "cost_basis_method" {
+    // Changing the base currency invalidates it too (#754): the cached summary's totals
+    // are now converted into base currency at compute time, so a currency change makes
+    // the cached figures wrong until recomputed.
+    if key == "cost_basis_method" || key == "base_currency" {
         gains_cache.invalidate();
     }
     Ok(())
@@ -168,6 +179,65 @@ pub async fn set_config_cmd(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::RealizedGainsSummary;
+
+    #[tokio::test]
+    async fn set_config_cmd_invalidates_gains_cache_on_base_currency_change() {
+        // Regression guard for #754: realized-gains totals are now converted
+        // into base currency at compute time (see analytics::compute_realized_gains_grouped),
+        // so a stale cache entry from before a base-currency change would report
+        // figures in the old currency. Changing base_currency must invalidate
+        // the cache just like cost_basis_method already does.
+        let pool = db::open_test_db().await;
+        let gains_cache = RealizedGainsCacheState::new();
+        gains_cache.set(RealizedGainsSummary {
+            total_realized_gain: 100.0,
+            total_proceeds: 100.0,
+            total_cost_basis: 0.0,
+            lots: vec![],
+        });
+        assert!(gains_cache.get().is_some(), "sanity check: cache is warm");
+
+        set_config_cmd_impl(
+            &pool,
+            &gains_cache,
+            "base_currency".to_string(),
+            "USD".to_string(),
+        )
+        .await
+        .expect("set_config_cmd_impl should succeed");
+
+        assert!(
+            gains_cache.get().is_none(),
+            "changing base_currency must invalidate the cached realized-gains summary"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_config_cmd_does_not_invalidate_gains_cache_for_unrelated_keys() {
+        let pool = db::open_test_db().await;
+        let gains_cache = RealizedGainsCacheState::new();
+        gains_cache.set(RealizedGainsSummary {
+            total_realized_gain: 100.0,
+            total_proceeds: 100.0,
+            total_cost_basis: 0.0,
+            lots: vec![],
+        });
+
+        set_config_cmd_impl(
+            &pool,
+            &gains_cache,
+            "app_theme".to_string(),
+            "dark".to_string(),
+        )
+        .await
+        .expect("set_config_cmd_impl should succeed");
+
+        assert!(
+            gains_cache.get().is_some(),
+            "unrelated config keys must not invalidate the realized-gains cache"
+        );
+    }
 
     #[test]
     fn validate_config_key_accepts_every_allowed_key() {

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::Utc;
 use tauri::State;
 
@@ -45,7 +47,17 @@ async fn get_portfolio_impl(
             cached
         } else {
             let transactions = db::get_all_transactions(pool).await?;
-            match compute_realized_gains_grouped(&transactions, &cost_basis_method) {
+            let holding_currencies: HashMap<HoldingId, String> = holdings
+                .iter()
+                .map(|h| (h.id.clone(), h.currency.clone()))
+                .collect();
+            match compute_realized_gains_grouped(
+                &transactions,
+                &cost_basis_method,
+                &holding_currencies,
+                &base_currency,
+                &cached_fx,
+            ) {
                 Ok(s) => {
                     gains_cache.set(s.clone());
                     s


### PR DESCRIPTION
## Summary
- `compute_realized_gains_grouped` previously summed each holding's realized gain/proceeds/cost-basis directly in the holding's native transaction currency, so a portfolio with mixed CAD/USD holdings added incompatible currencies together as if they were the same currency.
- Each holding's per-currency summary (totals + per-lot proceeds/cost-basis/gain-loss) is now converted into the selected base currency via `convert_to_base` (cached FX rates) before aggregating.
- Uses the current/cached FX rate rather than the historical rate at time of sale — documented as acceptable for a live dashboard snapshot figure, not a tax/accounting record.
- Falls back to a 1:1 rate (with a `tracing::warn!`) when no FX rate is cached for a holding's currency, consistent with how `build_portfolio_snapshot` already handles missing FX.
- Also invalidates the `RealizedGainsCacheState` cache on `base_currency` config changes (previously only invalidated on `cost_basis_method` change) — necessary now that the cached summary is computed relative to the base currency.

## Test plan
- [x] `cargo test -p portfolio-tracker` — 400 passed, 0 failed
- [x] New unit tests in `src-tauri/src/analytics.rs` prove mixed CAD/USD aggregation is base-currency correct (`grouped_converts_each_holding_to_base_currency_before_aggregating`, `grouped_converts_lot_level_fields_too`), plus same-currency, missing-FX-rate, and unknown-holding fallback cases
- [x] New tests in `src-tauri/src/commands/config.rs` prove `base_currency` changes invalidate the realized-gains cache while unrelated keys don't
- [x] `cargo clippy -p portfolio-tracker --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p portfolio-tracker -- --check` — clean
- [x] Pre-push hook (lint, typecheck, format, build, frontend+backend tests, clippy) — all passed

Closes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)