### PR TITLE
ci: run CI checks against the entire Cargo workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
               - 'index.html'
             backend:
               - 'src-tauri/**'
+              - 'portfolio-core/**'
+              - 'portfolio-mcp/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
 
   # ── Frontend: Lint + Type Check + Format + Test + Build ────
   frontend:
@@ -98,9 +102,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src-tauri
 
     steps:
       - uses: actions/checkout@v7
@@ -110,8 +111,6 @@ jobs:
           components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
 
       # Tauri system dependencies
       - name: Install system deps
@@ -126,16 +125,16 @@ jobs:
             libgtk-3-dev
 
       - name: Format check
-        run: cargo fmt --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test --workspace --locked
 
       - name: Build
-        run: cargo build --locked
+        run: cargo build --workspace --locked
 
   # ── E2E: Playwright against Vite dev server (browser/mock mode) ──
   e2e:

--- a/portfolio-core/src/fx.rs
+++ b/portfolio-core/src/fx.rs
@@ -6,7 +6,12 @@ use crate::types::FxRate;
 /// matching rate exists in the cache. Callers should treat `None` as a signal
 /// that the conversion is unreliable and surface a stale-FX warning to the
 /// user rather than silently falling back to a 1:1 rate.
-pub fn convert_to_base(amount: f64, from_currency: &str, base: &str, rates: &[FxRate]) -> Option<f64> {
+pub fn convert_to_base(
+    amount: f64,
+    from_currency: &str,
+    base: &str,
+    rates: &[FxRate],
+) -> Option<f64> {
     let from_upper = from_currency.to_uppercase();
     let base_upper = base.to_uppercase();
     if from_upper == base_upper {

--- a/portfolio-mcp/src/tools/alerts.rs
+++ b/portfolio-mcp/src/tools/alerts.rs
@@ -113,13 +113,7 @@ mod tests {
     async fn delete_alert_rejects_empty_id() {
         // Regression guard for #685.
         let pool = test_pool().await;
-        let result = delete_alert(
-            &pool,
-            DeleteAlertParams {
-                id: "".to_string(),
-            },
-        )
-        .await;
+        let result = delete_alert(&pool, DeleteAlertParams { id: "".to_string() }).await;
         assert!(result.is_err(), "empty ID must be rejected");
     }
 
@@ -139,13 +133,7 @@ mod tests {
     #[tokio::test]
     async fn reset_alert_rejects_empty_id() {
         let pool = test_pool().await;
-        let result = reset_alert(
-            &pool,
-            ResetAlertParams {
-                id: "".to_string(),
-            },
-        )
-        .await;
+        let result = reset_alert(&pool, ResetAlertParams { id: "".to_string() }).await;
         assert!(result.is_err(), "empty ID must be rejected");
     }
 

--- a/portfolio-mcp/src/tools/config.rs
+++ b/portfolio-mcp/src/tools/config.rs
@@ -57,6 +57,29 @@ pub async fn get_config(
     })
 }
 
+pub async fn set_config(
+    pool: &SqlitePool,
+    params: SetConfigParams,
+) -> Result<SetConfigResult, McpError> {
+    validation::validate_config_key(&params.key)?;
+    let value = if params.key == "cost_basis_method" {
+        params.value.to_lowercase()
+    } else {
+        params.value
+    };
+    validation::validate_config_value(&params.key, &value)?;
+
+    db::set_config(pool, &params.key, &value)
+        .await
+        .map_err(PortfolioMcpServer::tool_error)?;
+
+    Ok(SetConfigResult {
+        key: params.key,
+        value,
+        ok: true,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,27 +125,4 @@ mod tests {
         .await;
         assert!(result.is_ok());
     }
-}
-
-pub async fn set_config(
-    pool: &SqlitePool,
-    params: SetConfigParams,
-) -> Result<SetConfigResult, McpError> {
-    validation::validate_config_key(&params.key)?;
-    let value = if params.key == "cost_basis_method" {
-        params.value.to_lowercase()
-    } else {
-        params.value
-    };
-    validation::validate_config_value(&params.key, &value)?;
-
-    db::set_config(pool, &params.key, &value)
-        .await
-        .map_err(PortfolioMcpServer::tool_error)?;
-
-    Ok(SetConfigResult {
-        key: params.key,
-        value,
-        ok: true,
-    })
 }

--- a/portfolio-mcp/src/tools/dividends.rs
+++ b/portfolio-mcp/src/tools/dividends.rs
@@ -158,13 +158,7 @@ mod tests {
     #[tokio::test]
     async fn delete_dividend_rejects_empty_id() {
         let pool = test_pool().await;
-        let result = delete_dividend(
-            &pool,
-            DeleteDividendParams {
-                id: "".to_string(),
-            },
-        )
-        .await;
+        let result = delete_dividend(&pool, DeleteDividendParams { id: "".to_string() }).await;
         assert!(result.is_err(), "empty ID must be rejected");
     }
 
@@ -237,14 +231,9 @@ mod tests {
             .expect("add_dividend should succeed");
         assert_eq!(created.symbol, "AAPL");
 
-        let all = list_dividends(
-            &pool,
-            ListDividendsParams {
-                holding_id: None,
-            },
-        )
-        .await
-        .expect("list_dividends should succeed");
+        let all = list_dividends(&pool, ListDividendsParams { holding_id: None })
+            .await
+            .expect("list_dividends should succeed");
         assert_eq!(all.len(), 1);
 
         let filtered = list_dividends(

--- a/portfolio-mcp/src/tools/holdings.rs
+++ b/portfolio-mcp/src/tools/holdings.rs
@@ -247,13 +247,7 @@ mod tests {
         // Regression guard for #685: an empty/malformed ID must be rejected
         // before it ever reaches the database, mirroring the Tauri command.
         let pool = test_pool().await;
-        let result = delete_holding(
-            &pool,
-            DeleteHoldingParams {
-                id: "".to_string(),
-            },
-        )
-        .await;
+        let result = delete_holding(&pool, DeleteHoldingParams { id: "".to_string() }).await;
         assert!(result.is_err(), "empty ID must be rejected");
     }
 

--- a/portfolio-mcp/src/tools/transactions.rs
+++ b/portfolio-mcp/src/tools/transactions.rs
@@ -102,13 +102,8 @@ mod tests {
     async fn delete_transaction_rejects_empty_id() {
         // Regression guard for #685.
         let pool = test_pool().await;
-        let result = delete_transaction(
-            &pool,
-            DeleteTransactionParams {
-                id: "".to_string(),
-            },
-        )
-        .await;
+        let result =
+            delete_transaction(&pool, DeleteTransactionParams { id: "".to_string() }).await;
         assert!(result.is_err(), "empty ID must be rejected");
     }
 

--- a/portfolio-mcp/src/types.rs
+++ b/portfolio-mcp/src/types.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 // and #615. Re-exported here so every other module in this crate can keep
 // using `crate::types::X` unchanged.
 pub use portfolio_core::types::{
-    AccountType, AssetType, FxRate, Holding, HoldingId, PortfolioSnapshot, PriceData,
-    StressResult, StressScenario,
+    AccountType, AssetType, FxRate, Holding, HoldingId, PortfolioSnapshot, PriceData, StressResult,
+    StressScenario,
 };
 
 // ── ID newtypes ───────────────────────────────────────────────────────────────
@@ -202,4 +202,3 @@ pub struct DividendInput {
     pub ex_date: String,
     pub pay_date: String,
 }
-


### PR DESCRIPTION
## Summary
- Expand the backend path filter in `.github/workflows/ci.yml` to include `portfolio-core/**`, `portfolio-mcp/**`, `Cargo.toml`, and `Cargo.lock` — previously only `src-tauri/**` was watched, so changes to the shared core crate or the MCP server binary could merge without triggering any Rust check.
- Change the Rust CI job to run `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, and `cargo build --workspace --locked` from the repo root, instead of `cargo fmt/clippy/test/build` scoped to `src-tauri/`. Previously `portfolio-mcp` and `portfolio-core` were never built, linted, or tested by CI at all.
- Fixed the pre-existing issues the newly-widened checks surfaced (they'd been invisible to CI until now): `cargo fmt` drift in 6 files across `portfolio-core`/`portfolio-mcp`, and a `clippy::items_after_test_module` error in `portfolio-mcp/src/tools/config.rs` (an item was defined after the `mod tests` block).
- Frontend and E2E jobs are untouched; `ci-status` roll-up still gates on the same three job names (`frontend`, `backend`, `e2e`).

Closes #755

## Test plan
- [x] `cargo fmt --all -- --check` passes at workspace level
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes at workspace level
- [x] `cargo test --workspace --locked` passes (393 backend + 16 integration tests)
- [x] `cargo build --workspace --locked` passes
- [x] Frontend lint/typecheck/format/tests/build all pass (verified via pre-push hook)
- [x] YAML parses correctly (`ruby -ryaml`)
- [ ] Confirm the `backend` job now actually runs and passes in CI on this PR (only `.github/workflows/ci.yml`, `portfolio-core/**`, and `portfolio-mcp/**` changed, which should trip both the new backend filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)