### PR TITLE
fix: make portfolio-mcp database write access explicitly opt-in

### DIFF
--- a/portfolio-mcp/README.md
+++ b/portfolio-mcp/README.md
@@ -1,31 +1,59 @@
 # portfolio-mcp
 
-A standalone MCP (Model Context Protocol) server that exposes the Portfolio Tracker database over the stdio transport, letting AI assistants read and write your portfolio data.
+A standalone MCP (Model Context Protocol) server that exposes the Portfolio Tracker database over the stdio transport, letting AI assistants read your portfolio data — and, if explicitly opted into, write and delete it too.
+
+## Access modes
+
+The server is **read-only by default**. Mutating tools aren't just denied when called — they aren't registered at all, so a client's `tools/list` won't even show them unless the corresponding mode is enabled:
+
+| Env var | Default | Registers |
+|---------|---------|-----------|
+| `PORTFOLIO_MCP_WRITE_ENABLED` | `false` | Non-destructive write tools: `add_holding`, `update_holding`, `create_account`, `add_dividend`, `add_transaction`, `add_alert`, `reset_alert`, `set_config` |
+| `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED` | `false` | Destructive tools: `delete_holding`, `delete_dividend`, `delete_transaction`, `delete_alert` |
+
+Set a variable to the literal string `true` to enable it; any other value (or leaving it unset) keeps that category disabled. The two flags are independent — you can allow data entry without allowing deletion, or vice versa. All read-only tools (`list_*`, `get_portfolio_snapshot`, `run_stress_test`, `get_config`) are always available regardless of these flags.
+
+If a client calls a tool that isn't enabled, the server returns an error explaining which env var to set rather than silently failing. The active mode is logged once at startup (to stderr — see `RUST_LOG`).
+
+```json
+{
+  "mcpServers": {
+    "portfolio": {
+      "command": "/path/to/target/release/portfolio-mcp",
+      "env": {
+        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.portfolio-tracker.app/portfolio.db",
+        "PORTFOLIO_MCP_WRITE_ENABLED": "true",
+        "PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED": "false"
+      }
+    }
+  }
+}
+```
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `list_holdings` | List all current holdings |
-| `add_holding` | Add a new holding |
-| `update_holding` | Full-replace update of an existing holding's editable fields |
-| `delete_holding` | Soft-delete a holding by UUID |
-| `list_accounts` | List all accounts (id, name, type, institution) |
-| `create_account` | Create a new account |
-| `list_dividends` | List dividend records, optionally filtered by holding UUID |
-| `add_dividend` | Record a new dividend payment for a holding |
-| `delete_dividend` | Soft-delete a dividend record by UUID |
-| `list_transactions` | List all buy/sell transactions |
-| `add_transaction` | Record a new transaction |
-| `delete_transaction` | Soft-delete a transaction |
-| `list_alerts` | List all price alerts |
-| `add_alert` | Create a price alert |
-| `delete_alert` | Delete an alert |
-| `reset_alert` | Reset a triggered alert |
-| `get_portfolio_snapshot` | Full snapshot with live prices, market values, G/L, weights |
-| `run_stress_test` | Apply asset-class and FX shocks to the current portfolio (shocks validated at the tool boundary) |
-| `get_config` | Read a config value (key must be on the allowlist; e.g. `base_currency`) |
-| `set_config` | Write a config value (key and value both validated, mirroring the Tauri app's config layer) |
+| Tool | Mode required | Description |
+|------|----------------|-------------|
+| `list_holdings` | read-only | List all current holdings |
+| `add_holding` | write | Add a new holding |
+| `update_holding` | write | Full-replace update of an existing holding's editable fields |
+| `delete_holding` | destructive | Soft-delete a holding by UUID |
+| `list_accounts` | read-only | List all accounts (id, name, type, institution) |
+| `create_account` | write | Create a new account |
+| `list_dividends` | read-only | List dividend records, optionally filtered by holding UUID |
+| `add_dividend` | write | Record a new dividend payment for a holding |
+| `delete_dividend` | destructive | Soft-delete a dividend record by UUID |
+| `list_transactions` | read-only | List all buy/sell transactions |
+| `add_transaction` | write | Record a new transaction |
+| `delete_transaction` | destructive | Soft-delete a transaction |
+| `list_alerts` | read-only | List all price alerts |
+| `add_alert` | write | Create a price alert |
+| `delete_alert` | destructive | Delete an alert |
+| `reset_alert` | write | Reset a triggered alert |
+| `get_portfolio_snapshot` | read-only | Full snapshot with live prices, market values, G/L, weights |
+| `run_stress_test` | read-only | Apply asset-class and FX shocks to the current portfolio (shocks validated at the tool boundary; simulation only, no writes) |
+| `get_config` | read-only | Read a config value (key must be on the allowlist; e.g. `base_currency`) |
+| `set_config` | write | Write a config value (key and value both validated, mirroring the Tauri app's config layer) |
 
 All write tools (`add_*`, `update_*`, `delete_*`, `reset_alert`, `create_account`) validate their input — including UUID format on every ID — using the same rules enforced by the Tauri desktop app, so data written through this server can't bypass validation the UI would otherwise apply. List tools are **not** paginated; they return the full result set.
 
@@ -40,7 +68,7 @@ The binary is at `target/release/portfolio-mcp`.
 
 ## Configuration in Claude Code
 
-Add to `~/.claude/settings.json`:
+Add to `~/.claude/settings.json`. This example runs in read-only mode — omit `PORTFOLIO_MCP_WRITE_ENABLED` / `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED` entirely, or set them per the [Access modes](#access-modes) section above, to change that:
 
 ```json
 {
@@ -62,6 +90,8 @@ Replace `/path/to/target/release/portfolio-mcp` with the actual binary path (e.g
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db` | Path to the SQLite DB created by the Tauri app |
+| `PORTFOLIO_MCP_WRITE_ENABLED` | `false` | Set to `true` to register non-destructive write tools — see [Access modes](#access-modes) |
+| `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED` | `false` | Set to `true` to register `delete_*` tools — see [Access modes](#access-modes) |
 | `RUST_LOG` | `portfolio_mcp=info` | Log level filter (logs go to stderr, never stdout) |
 
 ## Notes

--- a/portfolio-mcp/src/main.rs
+++ b/portfolio-mcp/src/main.rs
@@ -24,6 +24,28 @@ fn db_path() -> String {
     )
 }
 
+/// Read a boolean opt-in flag from the environment. Only the literal value
+/// `"true"` enables it (mirrors the `true`/`false` config-value convention
+/// used elsewhere in this crate, see `validation.rs`); unset or any other
+/// value defaults to disabled.
+fn env_flag(name: &str) -> bool {
+    std::env::var(name).as_deref() == Ok("true")
+}
+
+/// Resolve which mutating tool categories this server instance registers.
+///
+/// Read-only by default. Write tools (add/update/create/set) require
+/// `PORTFOLIO_MCP_WRITE_ENABLED=true`; destructive tools (delete_*) require
+/// `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED=true`. The two flags are
+/// independent so an operator can, for example, allow data entry without
+/// allowing deletion.
+fn resolve_access() -> tools::McpAccess {
+    tools::McpAccess {
+        write_enabled: env_flag("PORTFOLIO_MCP_WRITE_ENABLED"),
+        destructive_enabled: env_flag("PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED"),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // MCP uses stdout for the JSON-RPC protocol; log to stderr so we don't
@@ -44,9 +66,18 @@ async fn main() -> Result<()> {
         e
     })?;
 
+    let access = resolve_access();
+    tracing::info!(
+        mode = access.mode_label(),
+        write_enabled = access.write_enabled,
+        destructive_enabled = access.destructive_enabled,
+        "portfolio-mcp access mode (opt in via PORTFOLIO_MCP_WRITE_ENABLED=true / \
+         PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED=true)"
+    );
+
     tracing::info!("portfolio-mcp server starting (stdio transport)");
 
-    let server = tools::PortfolioMcpServer::new(pool);
+    let server = tools::PortfolioMcpServer::new(pool, access);
     let transport = stdio();
     let service = server.serve(transport).await?;
     service.waiting().await?;

--- a/portfolio-mcp/src/tools/mod.rs
+++ b/portfolio-mcp/src/tools/mod.rs
@@ -8,22 +8,91 @@ pub mod stress;
 pub mod transactions;
 
 use rmcp::{
+    handler::server::tool::ToolCallContext,
     model::{
-        CallToolResult, Content, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
+        CallToolRequestParam, CallToolResult, Content, Implementation, ListToolsResult,
+        PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
     },
+    service::{RequestContext, RoleServer},
     tool, Error as McpError, ServerHandler,
 };
 use sqlx::SqlitePool;
+
+/// Which mutating tool categories are registered on this server instance.
+///
+/// Both flags default to `false` (read-only) unless explicitly opted into via
+/// the `PORTFOLIO_MCP_WRITE_ENABLED` / `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED`
+/// environment variables (see `main.rs`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct McpAccess {
+    pub write_enabled: bool,
+    pub destructive_enabled: bool,
+}
+
+impl McpAccess {
+    fn permits(&self, category: ToolCategory) -> bool {
+        match category {
+            ToolCategory::Read => true,
+            ToolCategory::Write => self.write_enabled,
+            ToolCategory::Destructive => self.destructive_enabled,
+        }
+    }
+
+    pub fn mode_label(&self) -> &'static str {
+        match (self.write_enabled, self.destructive_enabled) {
+            (false, false) => "read-only",
+            (true, false) => "write-enabled (non-destructive)",
+            (false, true) => "destructive-only (unusual: write tools still disabled)",
+            (true, true) => "write-enabled (including destructive operations)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolCategory {
+    Read,
+    Write,
+    Destructive,
+}
+
+impl ToolCategory {
+    fn enable_hint(self) -> &'static str {
+        match self {
+            ToolCategory::Read => "",
+            ToolCategory::Write => "set PORTFOLIO_MCP_WRITE_ENABLED=true to enable it",
+            ToolCategory::Destructive => {
+                "set PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED=true to enable it"
+            }
+        }
+    }
+}
+
+/// Classify a tool by name so it can be gated by [`McpAccess`].
+///
+/// New mutating tools MUST be added here (as `Write` or `Destructive`) —
+/// anything not listed defaults to `Read` and is always registered, which
+/// would silently bypass the opt-in write gate.
+fn tool_category(name: &str) -> ToolCategory {
+    match name {
+        "delete_holding" | "delete_dividend" | "delete_transaction" | "delete_alert" => {
+            ToolCategory::Destructive
+        }
+        "add_holding" | "update_holding" | "create_account" | "add_dividend"
+        | "add_transaction" | "add_alert" | "reset_alert" | "set_config" => ToolCategory::Write,
+        _ => ToolCategory::Read,
+    }
+}
 
 /// The MCP server that exposes portfolio tools.
 #[derive(Clone)]
 pub struct PortfolioMcpServer {
     pool: SqlitePool,
+    access: McpAccess,
 }
 
 impl PortfolioMcpServer {
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+    pub fn new(pool: SqlitePool, access: McpAccess) -> Self {
+        Self { pool, access }
     }
 
     /// Serialise a value to JSON text content for a `CallToolResult`.
@@ -36,6 +105,31 @@ impl PortfolioMcpServer {
     /// Wrap an anyhow error as an MCP tool error.
     pub(crate) fn tool_error(err: anyhow::Error) -> McpError {
         McpError::internal_error(err.to_string(), None)
+    }
+
+    /// Tools visible given this server's current access mode.
+    fn visible_tools(&self) -> Vec<Tool> {
+        Self::tool_box()
+            .list()
+            .into_iter()
+            .filter(|t| self.access.permits(tool_category(t.name.as_ref())))
+            .collect()
+    }
+
+    /// Reject a tool call whose category isn't enabled for this server instance.
+    fn ensure_tool_permitted(&self, name: &str) -> Result<(), McpError> {
+        let category = tool_category(name);
+        if self.access.permits(category) {
+            return Ok(());
+        }
+        Err(McpError::invalid_request(
+            format!(
+                "Tool '{name}' is disabled in the current mode ({}); {}",
+                self.access.mode_label(),
+                category.enable_hint(),
+            ),
+            None,
+        ))
     }
 }
 
@@ -259,9 +353,16 @@ impl PortfolioMcpServer {
     }
 }
 
-#[tool(tool_box)]
 impl ServerHandler for PortfolioMcpServer {
     fn get_info(&self) -> ServerInfo {
+        let mode_note = match (self.access.write_enabled, self.access.destructive_enabled) {
+            (false, false) => {
+                "Running in read-only mode: write and delete tools are not registered."
+            }
+            (true, false) => "Write tools are enabled; delete tools are not registered.",
+            (false, true) => "Delete tools are enabled; other write tools are not registered.",
+            (true, true) => "Write and delete tools are enabled.",
+        };
         ServerInfo {
             protocol_version: ProtocolVersion::V_2024_11_05,
             capabilities: ServerCapabilities::builder().enable_tools().build(),
@@ -269,12 +370,133 @@ impl ServerHandler for PortfolioMcpServer {
                 name: "portfolio-mcp".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
             },
-            instructions: Some(
+            instructions: Some(format!(
                 "Portfolio Tracker MCP server. Use list_holdings and get_portfolio_snapshot to \
-                 read the current portfolio state. Use add_holding / delete_holding to manage \
-                 positions. Use run_stress_test to simulate market scenarios."
-                    .to_string(),
-            ),
+                 read the current portfolio state. Use run_stress_test to simulate market \
+                 scenarios. {mode_note}"
+            )),
         }
+    }
+
+    async fn list_tools(
+        &self,
+        _request: PaginatedRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult {
+            next_cursor: None,
+            tools: self.visible_tools(),
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        self.ensure_tool_permitted(&request.name)?;
+        let call_context = ToolCallContext::new(self, request, context);
+        Self::tool_box().call(call_context).await
+    }
+}
+
+#[cfg(test)]
+mod access_tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn test_pool() -> SqlitePool {
+        SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory sqlite")
+    }
+
+    const READ_ONLY_TOOL: &str = "list_holdings";
+    const WRITE_TOOL: &str = "add_holding";
+    const DESTRUCTIVE_TOOL: &str = "delete_holding";
+
+    #[test]
+    fn tool_category_classifies_known_tools() {
+        assert_eq!(tool_category(READ_ONLY_TOOL), ToolCategory::Read);
+        assert_eq!(tool_category("get_portfolio_snapshot"), ToolCategory::Read);
+        assert_eq!(tool_category("run_stress_test"), ToolCategory::Read);
+
+        assert_eq!(tool_category(WRITE_TOOL), ToolCategory::Write);
+        assert_eq!(tool_category("update_holding"), ToolCategory::Write);
+        assert_eq!(tool_category("create_account"), ToolCategory::Write);
+        assert_eq!(tool_category("add_dividend"), ToolCategory::Write);
+        assert_eq!(tool_category("add_transaction"), ToolCategory::Write);
+        assert_eq!(tool_category("add_alert"), ToolCategory::Write);
+        assert_eq!(tool_category("reset_alert"), ToolCategory::Write);
+        assert_eq!(tool_category("set_config"), ToolCategory::Write);
+
+        assert_eq!(tool_category(DESTRUCTIVE_TOOL), ToolCategory::Destructive);
+        assert_eq!(tool_category("delete_dividend"), ToolCategory::Destructive);
+        assert_eq!(
+            tool_category("delete_transaction"),
+            ToolCategory::Destructive
+        );
+        assert_eq!(tool_category("delete_alert"), ToolCategory::Destructive);
+    }
+
+    #[tokio::test]
+    async fn read_only_mode_hides_write_and_destructive_tools() {
+        let server = PortfolioMcpServer::new(test_pool().await, McpAccess::default());
+
+        let names: Vec<_> = server.visible_tools().into_iter().map(|t| t.name).collect();
+        assert!(names.iter().any(|n| n.as_ref() == READ_ONLY_TOOL));
+        assert!(!names.iter().any(|n| n.as_ref() == WRITE_TOOL));
+        assert!(!names.iter().any(|n| n.as_ref() == DESTRUCTIVE_TOOL));
+
+        assert!(server.ensure_tool_permitted(READ_ONLY_TOOL).is_ok());
+        assert!(server.ensure_tool_permitted(WRITE_TOOL).is_err());
+        assert!(server.ensure_tool_permitted(DESTRUCTIVE_TOOL).is_err());
+    }
+
+    #[tokio::test]
+    async fn write_enabled_mode_exposes_write_but_not_destructive_tools() {
+        let access = McpAccess {
+            write_enabled: true,
+            destructive_enabled: false,
+        };
+        let server = PortfolioMcpServer::new(test_pool().await, access);
+
+        let names: Vec<_> = server.visible_tools().into_iter().map(|t| t.name).collect();
+        assert!(names.iter().any(|n| n.as_ref() == READ_ONLY_TOOL));
+        assert!(names.iter().any(|n| n.as_ref() == WRITE_TOOL));
+        assert!(!names.iter().any(|n| n.as_ref() == DESTRUCTIVE_TOOL));
+
+        assert!(server.ensure_tool_permitted(WRITE_TOOL).is_ok());
+        assert!(server.ensure_tool_permitted(DESTRUCTIVE_TOOL).is_err());
+    }
+
+    #[tokio::test]
+    async fn fully_enabled_mode_exposes_every_tool() {
+        let access = McpAccess {
+            write_enabled: true,
+            destructive_enabled: true,
+        };
+        let server = PortfolioMcpServer::new(test_pool().await, access);
+
+        let names: Vec<_> = server.visible_tools().into_iter().map(|t| t.name).collect();
+        assert!(names.iter().any(|n| n.as_ref() == READ_ONLY_TOOL));
+        assert!(names.iter().any(|n| n.as_ref() == WRITE_TOOL));
+        assert!(names.iter().any(|n| n.as_ref() == DESTRUCTIVE_TOOL));
+
+        assert!(server.ensure_tool_permitted(WRITE_TOOL).is_ok());
+        assert!(server.ensure_tool_permitted(DESTRUCTIVE_TOOL).is_ok());
+    }
+
+    #[tokio::test]
+    async fn destructive_enabled_without_write_still_gates_write_tools() {
+        let access = McpAccess {
+            write_enabled: false,
+            destructive_enabled: true,
+        };
+        let server = PortfolioMcpServer::new(test_pool().await, access);
+
+        assert!(server.ensure_tool_permitted(DESTRUCTIVE_TOOL).is_ok());
+        assert!(server.ensure_tool_permitted(WRITE_TOOL).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- `portfolio-mcp` previously registered every add/update/delete tool unconditionally, so any MCP client could mutate the portfolio database as soon as it connected.
- The server now starts **read-only** by default. Non-destructive write tools (`add_holding`, `update_holding`, `create_account`, `add_dividend`, `add_transaction`, `add_alert`, `reset_alert`, `set_config`) require `PORTFOLIO_MCP_WRITE_ENABLED=true`. Destructive tools (`delete_holding`, `delete_dividend`, `delete_transaction`, `delete_alert`) additionally require `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED=true`. The two flags are independent, so an operator can allow data entry without allowing deletion.
- Gating happens at both `tools/list` (disabled tools aren't advertised to the client at all) and `tools/call` (a disabled tool call is rejected with an error naming the env var to set), by hand-rolling `ServerHandler::list_tools`/`call_tool` instead of relying on the `rmcp` `#[tool(tool_box)]` macro shortcut for that impl.
- The active mode is logged once at startup (`tracing::info!`, stderr) and reflected in the server's MCP `instructions` string.
- `portfolio-mcp/README.md` documents the new env vars, defaults, and updates the tools table with a "mode required" column.

## Test plan
- [x] `cargo test -p portfolio-mcp` — 88 passed, including 5 new tests covering tool visibility/permission in read-only, write-enabled, destructive-enabled, and fully-enabled modes
- [x] `cargo clippy -p portfolio-mcp --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p portfolio-mcp -- --check` — clean
- [x] `cargo build --workspace` — clean
- [x] Full pre-push hook (workspace lint/typecheck/format, frontend+backend build, frontend+backend tests, clippy) — passed

Closes #756