### PR TITLE
refactor: centralize shared validation into portfolio-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,8 +3307,10 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",
+ "serde_json",
  "tracing",
  "ts-rs",
+ "uuid",
 ]
 
 [[package]]

--- a/portfolio-core/Cargo.toml
+++ b/portfolio-core/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 ts-rs = { version = "12", features = ["serde-compat"], optional = true }
+uuid = "1"
 
 [features]
 ts = ["dep:ts-rs"]

--- a/portfolio-core/src/lib.rs
+++ b/portfolio-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod fx;
 pub mod snapshot;
 pub mod stress;
 pub mod types;
+pub mod validation;

--- a/portfolio-core/src/validation/accounts.rs
+++ b/portfolio-core/src/validation/accounts.rs
@@ -1,0 +1,50 @@
+//! Named account field validation.
+
+/// Account types accepted by `create_account`/`add_account`/`update_account`.
+pub const VALID_ACCOUNT_TYPES: &[&str] =
+    &["tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", "other"];
+
+/// Validates an account's name and type, shared by `add_account`/`update_account`.
+/// Returns the trimmed name on success.
+pub fn validate_account_fields(name: &str, account_type: &str) -> Result<String, String> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err("Account name cannot be empty".to_string());
+    }
+    if !VALID_ACCOUNT_TYPES.contains(&account_type) {
+        return Err(format!("Invalid account type: {account_type}"));
+    }
+    Ok(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_account_fields_rejects_empty_and_whitespace_name() {
+        assert!(validate_account_fields("", "tfsa").is_err());
+        assert!(validate_account_fields("   ", "tfsa").is_err());
+    }
+
+    #[test]
+    fn validate_account_fields_rejects_unknown_type() {
+        assert!(validate_account_fields("My Account", "not-a-type").is_err());
+    }
+
+    #[test]
+    fn validate_account_fields_trims_name_and_accepts_valid_input() {
+        let name = validate_account_fields("  My TFSA  ", "tfsa").expect("valid input");
+        assert_eq!(name, "My TFSA");
+    }
+
+    #[test]
+    fn validate_account_fields_accepts_every_valid_type() {
+        for account_type in VALID_ACCOUNT_TYPES {
+            assert!(
+                validate_account_fields("Account", account_type).is_ok(),
+                "{account_type} should be accepted"
+            );
+        }
+    }
+}

--- a/portfolio-core/src/validation/alerts.rs
+++ b/portfolio-core/src/validation/alerts.rs
@@ -1,0 +1,77 @@
+//! Price alert field validation — threshold, currency, and free-text note.
+
+/// Max length for a price alert's free-text note, to prevent abuse.
+pub const MAX_ALERT_NOTE_LEN: usize = 500;
+
+/// Validates a price alert's threshold.
+pub fn validate_alert_threshold(threshold: f64) -> Result<(), String> {
+    if !threshold.is_finite() || threshold <= 0.0 {
+        return Err("threshold must be a positive finite number".to_string());
+    }
+    Ok(())
+}
+
+/// Validates a price alert's currency code (2-3 uppercase letters).
+pub fn validate_alert_currency(currency: &str) -> Result<(), String> {
+    let currency = currency.trim();
+    if !(2..=3).contains(&currency.len()) || !currency.chars().all(|c| c.is_ascii_uppercase()) {
+        return Err("currency must be 2-3 uppercase letters".to_string());
+    }
+    Ok(())
+}
+
+/// Validates a price alert's free-text note against `MAX_ALERT_NOTE_LEN`.
+pub fn validate_alert_note(note: &str) -> Result<(), String> {
+    if note.chars().count() > MAX_ALERT_NOTE_LEN {
+        return Err(format!(
+            "note must be at most {MAX_ALERT_NOTE_LEN} characters"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_alert_threshold_rejects_nan_and_non_positive() {
+        assert!(validate_alert_threshold(f64::NAN).is_err());
+        assert!(validate_alert_threshold(0.0).is_err());
+        assert!(validate_alert_threshold(-10.0).is_err());
+        assert!(validate_alert_threshold(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn validate_alert_threshold_accepts_positive_finite() {
+        assert!(validate_alert_threshold(150.0).is_ok());
+    }
+
+    #[test]
+    fn validate_alert_currency_rejects_malformed() {
+        assert!(validate_alert_currency("").is_err());
+        assert!(validate_alert_currency("A").is_err());
+        assert!(validate_alert_currency("ABCD").is_err());
+        assert!(validate_alert_currency("usd").is_err());
+        assert!(validate_alert_currency("U5D").is_err());
+    }
+
+    #[test]
+    fn validate_alert_currency_accepts_valid() {
+        assert!(validate_alert_currency("CAD").is_ok());
+        assert!(validate_alert_currency("US").is_ok());
+    }
+
+    #[test]
+    fn validate_alert_note_rejects_over_max_length() {
+        let note = "a".repeat(MAX_ALERT_NOTE_LEN + 1);
+        assert!(validate_alert_note(&note).is_err());
+    }
+
+    #[test]
+    fn validate_alert_note_accepts_within_max_length() {
+        let note = "a".repeat(MAX_ALERT_NOTE_LEN);
+        assert!(validate_alert_note(&note).is_ok());
+        assert!(validate_alert_note("").is_ok());
+    }
+}

--- a/portfolio-core/src/validation/common.rs
+++ b/portfolio-core/src/validation/common.rs
@@ -1,0 +1,59 @@
+//! Validation rules with no domain affiliation — shared by holdings,
+//! transactions, alerts, dividends, and accounts.
+
+/// Rejects a blank/whitespace-only required string field.
+pub fn validate_non_empty(field: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    Ok(())
+}
+
+/// Validates that an ID string is non-empty and a syntactically valid UUID.
+/// All IDs in this app are UUID v4 strings generated via `uuid::Uuid::new_v4()`;
+/// a malformed ID would otherwise silently no-op in SQLite (0 rows affected)
+/// instead of surfacing a clear error (see #685).
+pub fn validate_id(field: &str, id: &str) -> Result<(), String> {
+    if id.trim().is_empty() || uuid::Uuid::parse_str(id.trim()).is_err() {
+        return Err(format!("Invalid {field}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_non_empty_rejects_blank_and_whitespace() {
+        assert!(validate_non_empty("symbol", "").is_err());
+        assert!(validate_non_empty("symbol", "   ").is_err());
+        assert!(validate_non_empty("symbol", "AAPL").is_ok());
+    }
+
+    #[test]
+    fn validate_id_rejects_empty_string() {
+        assert!(validate_id("holding ID", "").is_err());
+    }
+
+    #[test]
+    fn validate_id_rejects_whitespace_only() {
+        assert!(validate_id("holding ID", "   ").is_err());
+    }
+
+    #[test]
+    fn validate_id_rejects_malformed_uuid() {
+        assert!(validate_id("holding ID", "not-a-uuid").is_err());
+        assert!(validate_id("holding ID", "12345").is_err());
+    }
+
+    #[test]
+    fn validate_id_accepts_valid_uuid() {
+        assert!(validate_id("holding ID", "550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn validate_id_accepts_uuid_with_surrounding_whitespace() {
+        assert!(validate_id("holding ID", "  550e8400-e29b-41d4-a716-446655440000  ").is_ok());
+    }
+}

--- a/portfolio-core/src/validation/config.rs
+++ b/portfolio-core/src/validation/config.rs
@@ -1,0 +1,261 @@
+//! App config key/value validation — the `set_config`/`get_config` allowlist
+//! and per-key value shape checks.
+
+/// Config keys readable/writable via `get_config`/`set_config`. Shared by both
+/// operations so a key can never be read without also being writable (or vice
+/// versa) — add new config keys here before wiring up a new setting.
+pub const ALLOWED_CONFIG_KEYS: &[&str] = &[
+    "base_currency",
+    "app_language",
+    "app_theme",
+    "auto_refresh_interval_ms",
+    "auto_refresh_market_hours_only",
+    "cost_basis_method",
+    "notifications_enabled",
+    "holdings_hidden_columns",
+];
+
+/// BCP 47 tags this app ships translations for (`frontend/lib/i18n.ts`'s
+/// `SUPPORTED_LNG_CODES`).
+const SUPPORTED_LANGUAGES: &[&str] = &["en", "de", "es", "fr", "ja", "pl", "pt", "zh"];
+
+/// Holdings table columns a user can hide (`frontend/components/Holdings.tsx`'s
+/// `ALL_COLUMNS`), mirrored here so `holdings_hidden_columns` can't be set to
+/// reference a column that doesn't exist.
+const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
+    "symbol",
+    "name",
+    "assetType",
+    "account",
+    "exchange",
+    "quantity",
+    "costBasis",
+    "currentPrice",
+    "marketValueCad",
+    "weight",
+    "targetWeight",
+    "targetDeltaPercent",
+    "targetDeltaValue",
+    "gainLoss",
+    "gainLossPercent",
+    "prevClose",
+    "dayOpen",
+    "openDate",
+    "maturityDate",
+];
+
+/// Keys not otherwise recognized below fall through to this generic bound —
+/// long enough for any legitimate config value, short enough to stop the
+/// allowlisted-key check from being paired with an unbounded value.
+pub const MAX_CONFIG_VALUE_LEN: usize = 500;
+
+/// Validates that `key` is on the config allowlist.
+pub fn validate_config_key(key: &str) -> Result<(), String> {
+    if !ALLOWED_CONFIG_KEYS.contains(&key) {
+        return Err(format!("Unknown config key: {key}"));
+    }
+    Ok(())
+}
+
+/// `validate_config_key` only checks that `key` is allowlisted; it says nothing
+/// about whether `value` is something the app can actually use. A malformed
+/// theme, language, currency code, or hidden-columns list would otherwise be
+/// written to `app_config` and only surface as a confusing failure wherever
+/// it's read back out.
+pub fn validate_config_value(key: &str, value: &str) -> Result<(), String> {
+    match key {
+        "app_theme" => {
+            if !["light", "dark", "system"].contains(&value) {
+                return Err(format!(
+                    "app_theme must be one of: light, dark, system (got: {value})"
+                ));
+            }
+        }
+        "app_language" => {
+            if !SUPPORTED_LANGUAGES.contains(&value) {
+                return Err(format!(
+                    "app_language must be one of: {} (got: {value})",
+                    SUPPORTED_LANGUAGES.join(", ")
+                ));
+            }
+        }
+        "base_currency" => {
+            if value.len() != 3 || !value.bytes().all(|b| b.is_ascii_uppercase()) {
+                return Err(format!(
+                    "base_currency must be a 3-letter uppercase currency code (got: {value})"
+                ));
+            }
+        }
+        "holdings_hidden_columns" => {
+            let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
+                "holdings_hidden_columns must be a JSON array of column names".to_string()
+            })?;
+            if let Some(unknown) = columns
+                .iter()
+                .find(|c| !KNOWN_HOLDINGS_COLUMNS.contains(&c.as_str()))
+            {
+                return Err(format!(
+                    "holdings_hidden_columns contains unknown column: {unknown}"
+                ));
+            }
+        }
+        "cost_basis_method" => {
+            if !value.eq_ignore_ascii_case("avco") && !value.eq_ignore_ascii_case("fifo") {
+                return Err(format!(
+                    "cost_basis_method must be one of: avco, fifo (got: {value})"
+                ));
+            }
+        }
+        "notifications_enabled" | "auto_refresh_market_hours_only" => {
+            if !["true", "false"].contains(&value) {
+                return Err(format!("{key} must be one of: true, false (got: {value})"));
+            }
+        }
+        _ => {
+            if value.len() > MAX_CONFIG_VALUE_LEN {
+                return Err(format!(
+                    "{key} value exceeds max length of {MAX_CONFIG_VALUE_LEN} characters"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_config_key_accepts_every_allowed_key() {
+        for key in ALLOWED_CONFIG_KEYS {
+            assert!(
+                validate_config_key(key).is_ok(),
+                "{key} should be a valid config key"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_config_key_rejects_unknown_key() {
+        // Regression guard for #644: get_config previously had no allowlist
+        // at all, so any key — including internal/sensitive ones — could be
+        // queried.
+        let result = validate_config_key("some_internal_secret");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("some_internal_secret"));
+    }
+
+    #[test]
+    fn validate_config_key_rejects_empty_key() {
+        assert!(validate_config_key("").is_err());
+    }
+
+    #[test]
+    fn validate_config_key_accepts_holdings_hidden_columns() {
+        // Regression guard for #661/#662: the frontend persists which Holdings
+        // table columns are hidden under this key, but it was missing from the
+        // allowlist on both surfaces at different points in time.
+        assert!(validate_config_key("holdings_hidden_columns").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_known_theme_values() {
+        for value in ["light", "dark", "system"] {
+            assert!(validate_config_value("app_theme", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_theme() {
+        // Regression guard for #690: previously any string was accepted for
+        // app_theme regardless of whether the frontend could render it.
+        assert!(validate_config_value("app_theme", "solarized").is_err());
+        assert!(validate_config_value("app_theme", "").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_supported_languages() {
+        for value in ["en", "de", "es", "fr", "ja", "pl", "pt", "zh"] {
+            assert!(validate_config_value("app_language", value).is_ok());
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unsupported_language() {
+        assert!(validate_config_value("app_language", "xx").is_err());
+        assert!(validate_config_value("app_language", "EN").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_base_currency() {
+        assert!(validate_config_value("base_currency", "CAD").is_ok());
+        assert!(validate_config_value("base_currency", "USD").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_malformed_base_currency() {
+        assert!(validate_config_value("base_currency", "cad").is_err());
+        assert!(validate_config_value("base_currency", "CA").is_err());
+        assert!(validate_config_value("base_currency", "CAND").is_err());
+        assert!(validate_config_value("base_currency", "C4D").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", r#"["symbol","weight"]"#).is_ok());
+        assert!(validate_config_value("holdings_hidden_columns", "[]").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_non_json_holdings_hidden_columns() {
+        assert!(validate_config_value("holdings_hidden_columns", "not json").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_column_in_holdings_hidden_columns() {
+        // Regression guard for #690: an unknown column name would previously
+        // be persisted verbatim and silently ignored by the frontend.
+        assert!(validate_config_value("holdings_hidden_columns", r#"["notARealColumn"]"#).is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_other_keys_within_max_length() {
+        assert!(validate_config_value("auto_refresh_interval_ms", "60000").is_ok());
+    }
+
+    #[test]
+    fn validate_config_value_rejects_other_keys_over_max_length() {
+        let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
+        assert!(validate_config_value("auto_refresh_interval_ms", &too_long).is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_avco_and_fifo_case_insensitively() {
+        // Regression guard for #714: cost_basis_method previously fell through
+        // to the generic max-length check, so any string was accepted and would
+        // later fail to parse in compute_realized_gains.
+        for value in ["avco", "fifo", "AVCO", "FIFO", "Avco", "Fifo"] {
+            assert!(
+                validate_config_value("cost_basis_method", value).is_ok(),
+                "{value} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_invalid_cost_basis_method() {
+        assert!(validate_config_value("cost_basis_method", "fefo").is_err());
+        assert!(validate_config_value("cost_basis_method", "").is_err());
+        assert!(validate_config_value("cost_basis_method", "average").is_err());
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_boolean_flags() {
+        for key in ["notifications_enabled", "auto_refresh_market_hours_only"] {
+            assert!(validate_config_value(key, "true").is_ok());
+            assert!(validate_config_value(key, "false").is_ok());
+            assert!(validate_config_value(key, "yes").is_err());
+        }
+    }
+}

--- a/portfolio-core/src/validation/dividends.rs
+++ b/portfolio-core/src/validation/dividends.rs
@@ -1,0 +1,58 @@
+//! Dividend record field validation — amount and ex/pay date ordering.
+
+/// Validates dividend input fields shared by `add_dividend`.
+pub fn validate_dividend_fields(
+    amount_per_unit: f64,
+    ex_date: &str,
+    pay_date: &str,
+) -> Result<(), String> {
+    if !amount_per_unit.is_finite() || amount_per_unit <= 0.0 {
+        return Err("amountPerUnit must be a finite number greater than 0".to_string());
+    }
+    if chrono::NaiveDate::parse_from_str(ex_date.trim(), "%Y-%m-%d").is_err() {
+        return Err("exDate must be a valid ISO date (YYYY-MM-DD)".to_string());
+    }
+    if chrono::NaiveDate::parse_from_str(pay_date.trim(), "%Y-%m-%d").is_err() {
+        return Err("payDate must be a valid ISO date (YYYY-MM-DD)".to_string());
+    }
+    if pay_date < ex_date {
+        return Err("payDate must not be before exDate".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_positive_amount() {
+        assert!(validate_dividend_fields(0.0, "2024-01-01", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(-1.0, "2024-01-01", "2024-01-15").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_finite_amount() {
+        assert!(validate_dividend_fields(f64::NAN, "2024-01-01", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(f64::INFINITY, "2024-01-01", "2024-01-15").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_non_iso_dates() {
+        assert!(validate_dividend_fields(1.0, "01/01/2024", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(1.0, "2024-01-01", "01/15/2024").is_err());
+        assert!(validate_dividend_fields(1.0, "not-a-date", "2024-01-15").is_err());
+        assert!(validate_dividend_fields(1.0, "2024-01-01", "").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_rejects_pay_date_before_ex_date() {
+        assert!(validate_dividend_fields(1.0, "2024-01-15", "2024-01-01").is_err());
+    }
+
+    #[test]
+    fn validate_dividend_fields_accepts_valid_input() {
+        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-15").is_ok());
+        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-01").is_ok());
+    }
+}

--- a/portfolio-core/src/validation/holdings.rs
+++ b/portfolio-core/src/validation/holdings.rs
@@ -1,0 +1,199 @@
+//! Holding field validation — quantity/cost basis/currency, target weight,
+//! and the dividend/maturity fields attached to a holding.
+
+/// Dividend frequencies accepted by the CSV import layer (`src-tauri/src/csv.rs`),
+/// mirrored here so the MCP `add_holding` tool applies the same set.
+pub const VALID_DIVIDEND_FREQUENCIES: &[&str] =
+    &["monthly", "quarterly", "semi-annual", "annual", "irregular"];
+
+/// Tolerance applied to target-weight-sum comparisons against 100%, to absorb
+/// floating-point rounding without letting a materially-over-budget value through.
+pub const WEIGHT_EPSILON: f64 = 0.001;
+
+/// Validates a holding's quantity, cost basis, and currency. Returns the
+/// normalized (uppercase, trimmed) currency code on success.
+pub fn validate_holding_fields(
+    quantity: f64,
+    cost_basis: f64,
+    currency: &str,
+) -> Result<String, String> {
+    if quantity <= 0.0 || !quantity.is_finite() {
+        return Err("quantity must be a positive finite number".to_string());
+    }
+    if cost_basis < 0.0 || !cost_basis.is_finite() {
+        return Err("costBasis must be a non-negative finite number".to_string());
+    }
+    let currency = currency.trim().to_uppercase();
+    if currency.len() != 3 || !currency.chars().all(|c| c.is_ascii_alphabetic()) {
+        return Err("currency must be a 3-letter ISO currency code".to_string());
+    }
+    Ok(currency)
+}
+
+/// Validates an optional target weight: when present, must be a finite
+/// percentage in [0, 100]. A negative or out-of-range value would otherwise
+/// silently persist and produce nonsensical rebalance suggestions.
+pub fn validate_target_weight(target_weight: Option<f64>) -> Result<(), String> {
+    if let Some(weight) = target_weight {
+        if !weight.is_finite() || !(0.0..=100.0).contains(&weight) {
+            return Err("targetWeight must be a finite number between 0 and 100".to_string());
+        }
+    }
+    Ok(())
+}
+
+/// Returns true when adding/updating a holding with `new_weight` would push the
+/// portfolio's total target weight (across all other holdings, summing to
+/// `existing_sum`) over 100%. Non-positive weights never consume budget.
+pub fn exceeds_target_weight_budget(new_weight: f64, existing_sum: f64) -> bool {
+    new_weight > 0.0 && existing_sum + new_weight > 100.0 + WEIGHT_EPSILON
+}
+
+/// Validates the optional dividend/maturity fields shared by `add_holding`/`update_holding`.
+/// Mirrors the checks the CSV import layer applies in `src-tauri/src/csv.rs`.
+pub fn validate_holding_dividend_fields(
+    indicated_annual_dividend: Option<f64>,
+    dividend_frequency: Option<&str>,
+    maturity_date: Option<&str>,
+) -> Result<(), String> {
+    if let Some(amount) = indicated_annual_dividend {
+        if !amount.is_finite() || amount < 0.0 {
+            return Err("indicatedAnnualDividend must be a non-negative finite number".to_string());
+        }
+    }
+    if let Some(freq) = dividend_frequency {
+        let normalized = freq.trim().to_lowercase();
+        if !VALID_DIVIDEND_FREQUENCIES.contains(&normalized.as_str()) {
+            return Err(format!(
+                "dividendFrequency must be one of: {}",
+                VALID_DIVIDEND_FREQUENCIES.join(", ")
+            ));
+        }
+    }
+    if let Some(date) = maturity_date {
+        if chrono::NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").is_err() {
+            return Err("maturityDate must be a valid ISO date (YYYY-MM-DD)".to_string());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_holding_fields_rejects_nan_quantity() {
+        assert!(validate_holding_fields(f64::NAN, 100.0, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_infinite_cost_basis() {
+        assert!(validate_holding_fields(1.0, f64::INFINITY, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_non_positive_quantity() {
+        assert!(validate_holding_fields(0.0, 100.0, "USD").is_err());
+        assert!(validate_holding_fields(-5.0, 100.0, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_negative_cost_basis() {
+        assert!(validate_holding_fields(1.0, -1.0, "USD").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_rejects_malformed_currency() {
+        assert!(validate_holding_fields(1.0, 100.0, "US").is_err());
+        assert!(validate_holding_fields(1.0, 100.0, "USDD").is_err());
+        assert!(validate_holding_fields(1.0, 100.0, "U5D").is_err());
+    }
+
+    #[test]
+    fn validate_holding_fields_normalizes_currency_case_and_whitespace() {
+        let currency = validate_holding_fields(1.0, 100.0, " usd ").expect("valid input");
+        assert_eq!(currency, "USD");
+    }
+
+    #[test]
+    fn validate_holding_fields_accepts_valid_input() {
+        assert!(validate_holding_fields(10.0, 150.25, "CAD").is_ok());
+    }
+
+    #[test]
+    fn validate_target_weight_rejects_out_of_range_and_nan() {
+        assert!(validate_target_weight(Some(-1.0)).is_err());
+        assert!(validate_target_weight(Some(100.001)).is_err());
+        assert!(validate_target_weight(Some(f64::NAN)).is_err());
+        assert!(validate_target_weight(Some(f64::INFINITY)).is_err());
+        assert!(validate_target_weight(Some(50.0)).is_ok());
+        assert!(validate_target_weight(Some(0.0)).is_ok());
+        assert!(validate_target_weight(Some(100.0)).is_ok());
+        assert!(validate_target_weight(None).is_ok());
+    }
+
+    #[test]
+    fn exceeds_target_weight_budget_rejects_when_total_exceeds_100() {
+        assert!(exceeds_target_weight_budget(50.0, 60.0));
+        assert!(!exceeds_target_weight_budget(40.0, 60.0));
+        // Non-positive weights don't consume budget and are always allowed.
+        assert!(!exceeds_target_weight_budget(0.0, 99.0));
+        assert!(!exceeds_target_weight_budget(-5.0, 99.0));
+    }
+
+    #[test]
+    fn exceeds_target_weight_budget_allows_exactly_100() {
+        assert!(!exceeds_target_weight_budget(40.0, 60.0));
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_nan_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(f64::NAN), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_infinite_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(f64::INFINITY), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_negative_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(-1.0), None, None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_zero_indicated_annual_dividend() {
+        assert!(validate_holding_dividend_fields(Some(0.0), None, None).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_unknown_dividend_frequency() {
+        assert!(validate_holding_dividend_fields(None, Some("biannual"), None).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_known_dividend_frequencies() {
+        for freq in ["monthly", "quarterly", "semi-annual", "annual", "irregular"] {
+            assert!(
+                validate_holding_dividend_fields(None, Some(freq), None).is_ok(),
+                "expected {freq} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_non_iso_maturity_date() {
+        assert!(validate_holding_dividend_fields(None, None, Some("01/30/2030")).is_err());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_iso_maturity_date() {
+        assert!(validate_holding_dividend_fields(None, None, Some("2030-01-01")).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_accepts_all_none() {
+        assert!(validate_holding_dividend_fields(None, None, None).is_ok());
+    }
+}

--- a/portfolio-core/src/validation/mod.rs
+++ b/portfolio-core/src/validation/mod.rs
@@ -1,0 +1,25 @@
+//! Transport-neutral validation and domain policy shared by the Tauri command
+//! layer (`src-tauri/src/commands/`) and the MCP server
+//! (`portfolio-mcp/src/validation.rs`).
+//!
+//! Every function here returns `Result<T, String>`: the `String` is the exact
+//! user-facing error message. Callers adapt it to their own error type —
+//! `AppError::Validation` for Tauri, `McpError::invalid_params` for MCP —
+//! so both surfaces reject the same input with the same message, and a rule
+//! change here applies to both automatically.
+
+mod accounts;
+mod alerts;
+mod common;
+mod config;
+mod dividends;
+mod holdings;
+mod transactions;
+
+pub use accounts::*;
+pub use alerts::*;
+pub use common::*;
+pub use config::*;
+pub use dividends::*;
+pub use holdings::*;
+pub use transactions::*;

--- a/portfolio-core/src/validation/transactions.rs
+++ b/portfolio-core/src/validation/transactions.rs
@@ -1,0 +1,37 @@
+//! Buy/sell transaction field validation.
+
+/// Validates transaction quantity/price for `add_transaction`.
+pub fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), String> {
+    if quantity <= 0.0 || !quantity.is_finite() {
+        return Err("Transaction quantity must be a positive finite number".to_string());
+    }
+    if price < 0.0 || !price.is_finite() {
+        return Err("Transaction price must be a non-negative finite number".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_transaction_fields_rejects_nan_and_non_positive_quantity() {
+        assert!(validate_transaction_fields(f64::NAN, 10.0).is_err());
+        assert!(validate_transaction_fields(0.0, 10.0).is_err());
+        assert!(validate_transaction_fields(-1.0, 10.0).is_err());
+    }
+
+    #[test]
+    fn validate_transaction_fields_rejects_negative_or_infinite_price() {
+        assert!(validate_transaction_fields(1.0, -1.0).is_err());
+        assert!(validate_transaction_fields(1.0, f64::INFINITY).is_err());
+        assert!(validate_transaction_fields(5.0, f64::NAN).is_err());
+    }
+
+    #[test]
+    fn validate_transaction_fields_accepts_valid_input() {
+        assert!(validate_transaction_fields(5.0, 0.0).is_ok());
+        assert!(validate_transaction_fields(5.0, 120.5).is_ok());
+    }
+}

--- a/portfolio-mcp/src/validation.rs
+++ b/portfolio-mcp/src/validation.rs
@@ -1,13 +1,19 @@
 //! Input validation for MCP write tools.
 //!
 //! The MCP server writes directly to the SQLite database, bypassing the
-//! Tauri command layer entirely. These checks mirror the validation enforced
-//! by the corresponding Tauri commands (see `src-tauri/src/commands/mod.rs`,
-//! `commands/alerts.rs`, `commands/transactions.rs`, and `commands/config.rs`)
-//! so the MCP layer cannot be used to write data the desktop app itself would
-//! reject.
+//! Tauri command layer entirely. The actual rules live in
+//! `portfolio_core::validation` (shared with `src-tauri/src/commands/`, see
+//! #758) so the MCP layer cannot be used to write data the desktop app itself
+//! would reject, and a rule change in one place can't drift out of sync with
+//! the other. Every function here is a thin adapter: it calls the shared
+//! rule and converts the `Result<T, String>` it returns into the `McpError`
+//! shape the rmcp tool handlers expect, preserving the exact message text.
 
 use rmcp::Error as McpError;
+
+fn invalid(message: String) -> McpError {
+    McpError::invalid_params(message, None)
+}
 
 /// Mirrors `validate_holding_fields` in `src-tauri/src/commands/mod.rs`.
 /// Returns the normalized (uppercase, trimmed) currency code.
@@ -16,62 +22,24 @@ pub fn validate_holding_fields(
     cost_basis: f64,
     currency: &str,
 ) -> Result<String, McpError> {
-    if quantity <= 0.0 || !quantity.is_finite() {
-        return Err(McpError::invalid_params(
-            "quantity must be a positive finite number",
-            None,
-        ));
-    }
-    if cost_basis < 0.0 || !cost_basis.is_finite() {
-        return Err(McpError::invalid_params(
-            "costBasis must be a non-negative finite number",
-            None,
-        ));
-    }
-    let currency = currency.trim().to_uppercase();
-    if currency.len() != 3 || !currency.chars().all(|c| c.is_ascii_alphabetic()) {
-        return Err(McpError::invalid_params(
-            "currency must be a 3-letter ISO currency code",
-            None,
-        ));
-    }
-    Ok(currency)
+    portfolio_core::validation::validate_holding_fields(quantity, cost_basis, currency)
+        .map_err(invalid)
 }
 
-/// Mirrors `validate_id` in `src-tauri/src/commands/mod.rs`. All IDs in this app
-/// are UUID v4 strings generated via `uuid::Uuid::new_v4()`; a malformed ID would
-/// otherwise silently no-op in SQLite (0 rows affected) instead of surfacing a
-/// clear error (see #685).
+/// Mirrors `validate_id` in `src-tauri/src/commands/mod.rs`.
 pub fn validate_id(field: &str, id: &str) -> Result<(), McpError> {
-    if id.trim().is_empty() || uuid::Uuid::parse_str(id.trim()).is_err() {
-        return Err(McpError::invalid_params(format!("Invalid {field}"), None));
-    }
-    Ok(())
+    portfolio_core::validation::validate_id(field, id).map_err(invalid)
 }
 
 /// Rejects a blank/whitespace-only required string field.
 pub fn validate_non_empty(field: &str, value: &str) -> Result<(), McpError> {
-    if value.trim().is_empty() {
-        return Err(McpError::invalid_params(
-            format!("{field} must not be empty"),
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_non_empty(field, value).map_err(invalid)
 }
 
 /// Mirrors the `target_weight` bounds check applied by the CSV import layer
 /// (`src-tauri/src/csv.rs`) and implicitly required by `add_holding`/`update_holding`.
 pub fn validate_target_weight(target_weight: Option<f64>) -> Result<(), McpError> {
-    if let Some(weight) = target_weight {
-        if !weight.is_finite() || !(0.0..=100.0).contains(&weight) {
-            return Err(McpError::invalid_params(
-                "targetWeight must be a finite number between 0 and 100",
-                None,
-            ));
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_target_weight(target_weight).map_err(invalid)
 }
 
 /// Mirrors the portfolio-wide target-weight guard in `commands/portfolio.rs`:
@@ -81,25 +49,16 @@ pub fn validate_target_weight_budget(
     target_weight: Option<f64>,
     existing_sum: f64,
 ) -> Result<(), McpError> {
-    const WEIGHT_EPSILON: f64 = 0.001;
     if let Some(weight) = target_weight {
-        if weight > 0.0 && existing_sum + weight > 100.0 + WEIGHT_EPSILON {
-            return Err(McpError::invalid_params(
-                format!(
-                    "Total target weight would exceed 100% (currently {existing_sum:.1}%). \
-                     Adjust existing allocations before adding this holding."
-                ),
-                None,
-            ));
+        if portfolio_core::validation::exceeds_target_weight_budget(weight, existing_sum) {
+            return Err(invalid(format!(
+                "Total target weight would exceed 100% (currently {existing_sum:.1}%). \
+                 Adjust existing allocations before adding this holding."
+            )));
         }
     }
     Ok(())
 }
-
-/// Dividend frequencies accepted by the CSV import layer (`src-tauri/src/csv.rs`),
-/// mirrored here so the MCP `add_holding` tool applies the same set.
-pub const VALID_DIVIDEND_FREQUENCIES: &[&str] =
-    &["monthly", "quarterly", "semi-annual", "annual", "irregular"];
 
 /// Mirrors `validate_holding_dividend_fields` in `src-tauri/src/commands/mod.rs`.
 pub fn validate_holding_dividend_fields(
@@ -107,168 +66,43 @@ pub fn validate_holding_dividend_fields(
     dividend_frequency: Option<&str>,
     maturity_date: Option<&str>,
 ) -> Result<(), McpError> {
-    if let Some(amount) = indicated_annual_dividend {
-        if !amount.is_finite() || amount < 0.0 {
-            return Err(McpError::invalid_params(
-                "indicatedAnnualDividend must be a non-negative finite number",
-                None,
-            ));
-        }
-    }
-    if let Some(freq) = dividend_frequency {
-        let normalized = freq.trim().to_lowercase();
-        if !VALID_DIVIDEND_FREQUENCIES.contains(&normalized.as_str()) {
-            return Err(McpError::invalid_params(
-                format!(
-                    "dividendFrequency must be one of: {}",
-                    VALID_DIVIDEND_FREQUENCIES.join(", ")
-                ),
-                None,
-            ));
-        }
-    }
-    if let Some(date) = maturity_date {
-        if chrono::NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").is_err() {
-            return Err(McpError::invalid_params(
-                "maturityDate must be a valid ISO date (YYYY-MM-DD)",
-                None,
-            ));
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_holding_dividend_fields(
+        indicated_annual_dividend,
+        dividend_frequency,
+        maturity_date,
+    )
+    .map_err(invalid)
 }
 
 /// Mirrors the checks in `src-tauri/src/commands/transactions.rs::add_transaction`.
 pub fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), McpError> {
-    if quantity <= 0.0 || !quantity.is_finite() {
-        return Err(McpError::invalid_params(
-            "quantity must be a positive finite number",
-            None,
-        ));
-    }
-    if price < 0.0 || !price.is_finite() {
-        return Err(McpError::invalid_params(
-            "price must be a non-negative finite number",
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_transaction_fields(quantity, price).map_err(invalid)
 }
 
 /// Mirrors the check in `src-tauri/src/commands/alerts.rs::add_alert`.
 pub fn validate_alert_threshold(threshold: f64) -> Result<(), McpError> {
-    if !threshold.is_finite() || threshold <= 0.0 {
-        return Err(McpError::invalid_params(
-            "threshold must be a positive finite number",
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_alert_threshold(threshold).map_err(invalid)
 }
-
-/// Max length for a price alert's free-text note, to prevent abuse.
-/// Mirrors `MAX_ALERT_NOTE_LEN` in `src-tauri/src/commands/mod.rs`.
-pub const MAX_ALERT_NOTE_LEN: usize = 500;
 
 /// Mirrors the currency check in `src-tauri/src/commands/mod.rs::validate_alert_fields`.
 pub fn validate_alert_currency(currency: &str) -> Result<(), McpError> {
-    let currency = currency.trim();
-    if !(2..=3).contains(&currency.len()) || !currency.chars().all(|c| c.is_ascii_uppercase()) {
-        return Err(McpError::invalid_params(
-            "currency must be 2-3 uppercase letters",
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_alert_currency(currency).map_err(invalid)
 }
 
 /// Mirrors the note-length check in `src-tauri/src/commands/mod.rs::validate_alert_fields`.
 pub fn validate_alert_note(note: &str) -> Result<(), McpError> {
-    if note.chars().count() > MAX_ALERT_NOTE_LEN {
-        return Err(McpError::invalid_params(
-            format!("note must be at most {MAX_ALERT_NOTE_LEN} characters"),
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_alert_note(note).map_err(invalid)
 }
-
-/// Config keys the Tauri `set_config_cmd` allowlist accepts
-/// (`src-tauri/src/commands/config.rs::ALLOWED_CONFIG_KEYS`). Kept in sync
-/// manually since the MCP server does not depend on the `src-tauri` crate.
-pub const ALLOWED_CONFIG_KEYS: &[&str] = &[
-    "base_currency",
-    "app_language",
-    "app_theme",
-    "auto_refresh_interval_ms",
-    "auto_refresh_market_hours_only",
-    "cost_basis_method",
-    "notifications_enabled",
-    "holdings_hidden_columns",
-];
 
 /// Mirrors the allowlist check in `src-tauri/src/commands/config.rs::set_config_cmd`.
 pub fn validate_config_key(key: &str) -> Result<(), McpError> {
-    if !ALLOWED_CONFIG_KEYS.contains(&key) {
-        return Err(McpError::invalid_params(
-            format!("Unknown config key: {key}"),
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_config_key(key).map_err(invalid)
 }
-
-/// Mirrors `SUPPORTED_LANGUAGES` in `src-tauri/src/commands/config.rs`.
-const SUPPORTED_LANGUAGES: &[&str] = &["en", "de", "es", "fr", "ja", "pl", "pt", "zh"];
-
-/// Mirrors `KNOWN_HOLDINGS_COLUMNS` in `src-tauri/src/commands/config.rs`.
-const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
-    "symbol",
-    "name",
-    "assetType",
-    "account",
-    "exchange",
-    "quantity",
-    "costBasis",
-    "currentPrice",
-    "marketValueCad",
-    "weight",
-    "targetWeight",
-    "targetDeltaPercent",
-    "targetDeltaValue",
-    "gainLoss",
-    "gainLossPercent",
-    "prevClose",
-    "dayOpen",
-    "openDate",
-    "maturityDate",
-];
-
-/// Mirrors `MAX_CONFIG_VALUE_LEN` in `src-tauri/src/commands/config.rs`.
-const MAX_CONFIG_VALUE_LEN: usize = 500;
-
-/// Account types accepted by `create_account`, mirrors `VALID_ACCOUNT_TYPES`
-/// in `src-tauri/src/commands/accounts.rs`.
-pub const VALID_ACCOUNT_TYPES: &[&str] =
-    &["tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", "other"];
 
 /// Mirrors `validate_account_fields` in `src-tauri/src/commands/accounts.rs`.
 /// Returns the trimmed name on success.
 pub fn validate_account_fields(name: &str, account_type: &str) -> Result<String, McpError> {
-    let name = name.trim().to_string();
-    if name.is_empty() {
-        return Err(McpError::invalid_params(
-            "Account name cannot be empty",
-            None,
-        ));
-    }
-    if !VALID_ACCOUNT_TYPES.contains(&account_type) {
-        return Err(McpError::invalid_params(
-            format!("Invalid account type: {account_type}"),
-            None,
-        ));
-    }
-    Ok(name)
+    portfolio_core::validation::validate_account_fields(name, account_type).map_err(invalid)
 }
 
 /// Mirrors `validate_dividend_fields` in `src-tauri/src/commands/mod.rs`.
@@ -277,142 +111,29 @@ pub fn validate_dividend_fields(
     ex_date: &str,
     pay_date: &str,
 ) -> Result<(), McpError> {
-    if !amount_per_unit.is_finite() || amount_per_unit <= 0.0 {
-        return Err(McpError::invalid_params(
-            "amountPerUnit must be a finite number greater than 0",
-            None,
-        ));
-    }
-    if chrono::NaiveDate::parse_from_str(ex_date.trim(), "%Y-%m-%d").is_err() {
-        return Err(McpError::invalid_params(
-            "exDate must be a valid ISO date (YYYY-MM-DD)",
-            None,
-        ));
-    }
-    if chrono::NaiveDate::parse_from_str(pay_date.trim(), "%Y-%m-%d").is_err() {
-        return Err(McpError::invalid_params(
-            "payDate must be a valid ISO date (YYYY-MM-DD)",
-            None,
-        ));
-    }
-    if pay_date < ex_date {
-        return Err(McpError::invalid_params(
-            "payDate must not be before exDate",
-            None,
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_dividend_fields(amount_per_unit, ex_date, pay_date)
+        .map_err(invalid)
 }
 
 /// Mirrors `validate_config_value` in `src-tauri/src/commands/config.rs::set_config_cmd`.
 pub fn validate_config_value(key: &str, value: &str) -> Result<(), McpError> {
-    match key {
-        "app_theme" => {
-            if !["light", "dark", "system"].contains(&value) {
-                return Err(McpError::invalid_params(
-                    format!("app_theme must be one of: light, dark, system (got: {value})"),
-                    None,
-                ));
-            }
-        }
-        "app_language" => {
-            if !SUPPORTED_LANGUAGES.contains(&value) {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "app_language must be one of: {} (got: {value})",
-                        SUPPORTED_LANGUAGES.join(", ")
-                    ),
-                    None,
-                ));
-            }
-        }
-        "base_currency" => {
-            if value.len() != 3 || !value.bytes().all(|b| b.is_ascii_uppercase()) {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "base_currency must be a 3-letter uppercase currency code (got: {value})"
-                    ),
-                    None,
-                ));
-            }
-        }
-        "holdings_hidden_columns" => {
-            let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
-                McpError::invalid_params(
-                    "holdings_hidden_columns must be a JSON array of column names",
-                    None,
-                )
-            })?;
-            if let Some(unknown) = columns
-                .iter()
-                .find(|c| !KNOWN_HOLDINGS_COLUMNS.contains(&c.as_str()))
-            {
-                return Err(McpError::invalid_params(
-                    format!("holdings_hidden_columns contains unknown column: {unknown}"),
-                    None,
-                ));
-            }
-        }
-        "cost_basis_method" => {
-            if !value.eq_ignore_ascii_case("avco") && !value.eq_ignore_ascii_case("fifo") {
-                return Err(McpError::invalid_params(
-                    format!("cost_basis_method must be one of: avco, fifo (got: {value})"),
-                    None,
-                ));
-            }
-        }
-        "notifications_enabled" | "auto_refresh_market_hours_only" => {
-            if !["true", "false"].contains(&value) {
-                return Err(McpError::invalid_params(
-                    format!("{key} must be one of: true, false (got: {value})"),
-                    None,
-                ));
-            }
-        }
-        _ => {
-            if value.len() > MAX_CONFIG_VALUE_LEN {
-                return Err(McpError::invalid_params(
-                    format!("{key} value exceeds max length of {MAX_CONFIG_VALUE_LEN} characters"),
-                    None,
-                ));
-            }
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_config_value(key, value).map_err(invalid)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn validate_holding_fields_rejects_nan_quantity() {
-        let err = validate_holding_fields(f64::NAN, 100.0, "USD");
-        assert!(err.is_err(), "NaN quantity must be rejected");
-    }
+    // These tests exercise the McpError adaptation at this layer (message
+    // text, invalid_params variant), not the underlying rules — those are
+    // fully covered by portfolio-core/src/validation/*. A representative
+    // invalid/valid pair per function is enough to prove the adapter works;
+    // exhaustive edge cases live with the shared rule.
 
     #[test]
-    fn validate_holding_fields_rejects_infinite_cost_basis() {
-        let err = validate_holding_fields(1.0, f64::INFINITY, "USD");
-        assert!(err.is_err(), "infinite cost_basis must be rejected");
-    }
-
-    #[test]
-    fn validate_holding_fields_rejects_non_positive_quantity() {
-        assert!(validate_holding_fields(0.0, 100.0, "USD").is_err());
-        assert!(validate_holding_fields(-5.0, 100.0, "USD").is_err());
-    }
-
-    #[test]
-    fn validate_holding_fields_rejects_negative_cost_basis() {
-        assert!(validate_holding_fields(1.0, -1.0, "USD").is_err());
-    }
-
-    #[test]
-    fn validate_holding_fields_rejects_malformed_currency() {
-        assert!(validate_holding_fields(1.0, 100.0, "US").is_err());
-        assert!(validate_holding_fields(1.0, 100.0, "USDD").is_err());
-        assert!(validate_holding_fields(1.0, 100.0, "U5D").is_err());
+    fn validate_holding_fields_adapts_rejection_to_invalid_params() {
+        let err = validate_holding_fields(0.0, 100.0, "USD").expect_err("must reject");
+        assert!(err.message.contains("quantity"));
     }
 
     #[test]
@@ -422,159 +143,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_holding_fields_accepts_valid_input() {
-        assert!(validate_holding_fields(10.0, 150.25, "CAD").is_ok());
-    }
-
-    #[test]
-    fn validate_non_empty_rejects_blank_and_whitespace() {
-        assert!(validate_non_empty("symbol", "").is_err());
-        assert!(validate_non_empty("symbol", "   ").is_err());
-        assert!(validate_non_empty("symbol", "AAPL").is_ok());
-    }
-
-    #[test]
-    fn validate_target_weight_rejects_out_of_range_and_nan() {
-        assert!(validate_target_weight(Some(-1.0)).is_err());
-        assert!(validate_target_weight(Some(100.001)).is_err());
-        assert!(validate_target_weight(Some(f64::NAN)).is_err());
-        assert!(validate_target_weight(Some(50.0)).is_ok());
-        assert!(validate_target_weight(None).is_ok());
-    }
-
-    #[test]
-    fn validate_target_weight_budget_rejects_when_total_exceeds_100() {
-        assert!(validate_target_weight_budget(Some(50.0), 60.0).is_err());
-        assert!(validate_target_weight_budget(Some(40.0), 60.0).is_ok());
-        // Non-positive weights don't consume budget and are always allowed here.
-        assert!(validate_target_weight_budget(Some(0.0), 99.0).is_ok());
-        assert!(validate_target_weight_budget(None, 99.0).is_ok());
-    }
-
-    #[test]
-    fn validate_transaction_fields_rejects_nan_and_non_positive_quantity() {
-        assert!(validate_transaction_fields(f64::NAN, 10.0).is_err());
-        assert!(validate_transaction_fields(0.0, 10.0).is_err());
-        assert!(validate_transaction_fields(-1.0, 10.0).is_err());
-    }
-
-    #[test]
-    fn validate_transaction_fields_rejects_negative_or_infinite_price() {
-        assert!(validate_transaction_fields(1.0, -1.0).is_err());
-        assert!(validate_transaction_fields(1.0, f64::INFINITY).is_err());
-    }
-
-    #[test]
-    fn validate_transaction_fields_accepts_valid_input() {
-        assert!(validate_transaction_fields(5.0, 0.0).is_ok());
-        assert!(validate_transaction_fields(5.0, 120.5).is_ok());
-    }
-
-    #[test]
-    fn validate_alert_threshold_rejects_nan_and_non_positive() {
-        assert!(validate_alert_threshold(f64::NAN).is_err());
-        assert!(validate_alert_threshold(0.0).is_err());
-        assert!(validate_alert_threshold(-10.0).is_err());
-        assert!(validate_alert_threshold(f64::INFINITY).is_err());
-    }
-
-    #[test]
-    fn validate_alert_threshold_accepts_positive_finite() {
-        assert!(validate_alert_threshold(150.0).is_ok());
-    }
-
-    #[test]
-    fn validate_alert_currency_rejects_malformed() {
-        assert!(validate_alert_currency("").is_err());
-        assert!(validate_alert_currency("A").is_err());
-        assert!(validate_alert_currency("ABCD").is_err());
-        assert!(validate_alert_currency("usd").is_err());
-        assert!(validate_alert_currency("U5D").is_err());
-    }
-
-    #[test]
-    fn validate_alert_currency_accepts_valid() {
-        assert!(validate_alert_currency("CAD").is_ok());
-        assert!(validate_alert_currency("US").is_ok());
-    }
-
-    #[test]
-    fn validate_alert_note_rejects_over_max_length() {
-        let note = "a".repeat(MAX_ALERT_NOTE_LEN + 1);
-        assert!(validate_alert_note(&note).is_err());
-    }
-
-    #[test]
-    fn validate_alert_note_accepts_within_max_length() {
-        let note = "a".repeat(MAX_ALERT_NOTE_LEN);
-        assert!(validate_alert_note(&note).is_ok());
-        assert!(validate_alert_note("").is_ok());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_rejects_nan_indicated_annual_dividend() {
-        assert!(validate_holding_dividend_fields(Some(f64::NAN), None, None).is_err());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_rejects_infinite_indicated_annual_dividend() {
-        assert!(validate_holding_dividend_fields(Some(f64::INFINITY), None, None).is_err());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_rejects_negative_indicated_annual_dividend() {
-        assert!(validate_holding_dividend_fields(Some(-1.0), None, None).is_err());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_accepts_zero_indicated_annual_dividend() {
-        assert!(validate_holding_dividend_fields(Some(0.0), None, None).is_ok());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_rejects_unknown_dividend_frequency() {
-        assert!(validate_holding_dividend_fields(None, Some("biannual"), None).is_err());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_accepts_known_dividend_frequencies() {
-        for freq in ["monthly", "quarterly", "semi-annual", "annual", "irregular"] {
-            assert!(
-                validate_holding_dividend_fields(None, Some(freq), None).is_ok(),
-                "expected {freq} to be accepted"
-            );
-        }
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_rejects_non_iso_maturity_date() {
-        assert!(validate_holding_dividend_fields(None, None, Some("01/30/2030")).is_err());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_accepts_iso_maturity_date() {
-        assert!(validate_holding_dividend_fields(None, None, Some("2030-01-01")).is_ok());
-    }
-
-    #[test]
-    fn validate_holding_dividend_fields_accepts_all_none() {
-        assert!(validate_holding_dividend_fields(None, None, None).is_ok());
-    }
-
-    #[test]
-    fn validate_id_rejects_empty_string() {
-        assert!(validate_id("holding ID", "").is_err());
-    }
-
-    #[test]
-    fn validate_id_rejects_whitespace_only() {
-        assert!(validate_id("holding ID", "   ").is_err());
-    }
-
-    #[test]
     fn validate_id_rejects_malformed_uuid() {
         assert!(validate_id("holding ID", "not-a-uuid").is_err());
-        assert!(validate_id("holding ID", "12345").is_err());
     }
 
     #[test]
@@ -583,140 +153,133 @@ mod tests {
     }
 
     #[test]
-    fn validate_id_accepts_uuid_with_surrounding_whitespace() {
-        assert!(validate_id("holding ID", "  550e8400-e29b-41d4-a716-446655440000  ").is_ok());
+    fn validate_non_empty_rejects_blank() {
+        assert!(validate_non_empty("symbol", "   ").is_err());
+        assert!(validate_non_empty("symbol", "AAPL").is_ok());
+    }
+
+    #[test]
+    fn validate_target_weight_rejects_out_of_range() {
+        assert!(validate_target_weight(Some(150.0)).is_err());
+        assert!(validate_target_weight(Some(50.0)).is_ok());
+    }
+
+    #[test]
+    fn validate_target_weight_budget_rejects_when_total_exceeds_100() {
+        let err = validate_target_weight_budget(Some(50.0), 60.0).expect_err("must reject");
+        assert!(err.message.contains("exceed 100%"));
+        assert!(validate_target_weight_budget(Some(40.0), 60.0).is_ok());
+        // Non-positive weights don't consume budget and are always allowed here.
+        assert!(validate_target_weight_budget(Some(0.0), 99.0).is_ok());
+        assert!(validate_target_weight_budget(None, 99.0).is_ok());
+    }
+
+    #[test]
+    fn validate_holding_dividend_fields_rejects_unknown_frequency() {
+        assert!(validate_holding_dividend_fields(None, Some("biannual"), None).is_err());
+        assert!(validate_holding_dividend_fields(None, Some("monthly"), None).is_ok());
+    }
+
+    #[test]
+    fn validate_transaction_fields_rejects_non_positive_quantity() {
+        assert!(validate_transaction_fields(0.0, 10.0).is_err());
+        assert!(validate_transaction_fields(5.0, 120.5).is_ok());
+    }
+
+    #[test]
+    fn validate_alert_threshold_rejects_non_positive() {
+        assert!(validate_alert_threshold(0.0).is_err());
+        assert!(validate_alert_threshold(150.0).is_ok());
+    }
+
+    #[test]
+    fn validate_alert_currency_rejects_malformed() {
+        assert!(validate_alert_currency("usd").is_err());
+        assert!(validate_alert_currency("CAD").is_ok());
+    }
+
+    #[test]
+    fn validate_alert_note_rejects_over_max_length() {
+        let note = "a".repeat(portfolio_core::validation::MAX_ALERT_NOTE_LEN + 1);
+        assert!(validate_alert_note(&note).is_err());
+        assert!(validate_alert_note("").is_ok());
     }
 
     #[test]
     fn validate_config_key_rejects_unknown_keys() {
         assert!(validate_config_key("base_currency").is_ok());
-        assert!(validate_config_key("cost_basis_method").is_ok());
         assert!(validate_config_key("some_arbitrary_key").is_err());
-        assert!(validate_config_key("").is_err());
-    }
-
-    #[test]
-    fn validate_config_value_accepts_known_theme_values() {
-        for value in ["light", "dark", "system"] {
-            assert!(validate_config_value("app_theme", value).is_ok());
-        }
     }
 
     #[test]
     fn validate_config_value_rejects_unknown_theme() {
         assert!(validate_config_value("app_theme", "solarized").is_err());
-    }
-
-    #[test]
-    fn validate_config_value_accepts_supported_languages() {
-        for value in ["en", "de", "es", "fr", "ja", "pl", "pt", "zh"] {
-            assert!(validate_config_value("app_language", value).is_ok());
-        }
-    }
-
-    #[test]
-    fn validate_config_value_rejects_unsupported_language() {
-        assert!(validate_config_value("app_language", "xx").is_err());
-    }
-
-    #[test]
-    fn validate_config_value_accepts_valid_base_currency() {
-        assert!(validate_config_value("base_currency", "CAD").is_ok());
-    }
-
-    #[test]
-    fn validate_config_value_rejects_malformed_base_currency() {
-        assert!(validate_config_value("base_currency", "cad").is_err());
-        assert!(validate_config_value("base_currency", "CA").is_err());
-    }
-
-    #[test]
-    fn validate_config_value_accepts_valid_holdings_hidden_columns() {
-        assert!(validate_config_value("holdings_hidden_columns", r#"["symbol","weight"]"#).is_ok());
-    }
-
-    #[test]
-    fn validate_config_value_rejects_unknown_column_in_holdings_hidden_columns() {
-        assert!(validate_config_value("holdings_hidden_columns", r#"["notARealColumn"]"#).is_err());
-    }
-
-    #[test]
-    fn validate_config_value_rejects_non_json_holdings_hidden_columns() {
-        assert!(validate_config_value("holdings_hidden_columns", "not json").is_err());
-    }
-
-    #[test]
-    fn validate_config_value_accepts_other_keys_within_max_length() {
-        assert!(validate_config_value("auto_refresh_interval_ms", "60000").is_ok());
-    }
-
-    #[test]
-    fn validate_config_value_rejects_other_keys_over_max_length() {
-        let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
-        assert!(validate_config_value("auto_refresh_interval_ms", &too_long).is_err());
+        assert!(validate_config_value("app_theme", "dark").is_ok());
     }
 
     #[test]
     fn validate_config_value_accepts_avco_and_fifo_case_insensitively() {
         // Regression guard for #714: cost_basis_method previously fell through
         // to the generic max-length check, so any string was accepted.
-        for value in ["avco", "fifo", "AVCO", "FIFO", "Avco", "Fifo"] {
+        for value in ["avco", "fifo", "AVCO", "FIFO"] {
             assert!(
                 validate_config_value("cost_basis_method", value).is_ok(),
                 "{value} should be accepted"
             );
         }
-    }
-
-    #[test]
-    fn validate_config_value_rejects_invalid_cost_basis_method() {
         assert!(validate_config_value("cost_basis_method", "fefo").is_err());
-        assert!(validate_config_value("cost_basis_method", "").is_err());
     }
 
     #[test]
-    fn validate_account_fields_rejects_empty_and_whitespace_name() {
-        assert!(validate_account_fields("", "tfsa").is_err());
+    fn validate_account_fields_rejects_empty_name_and_trims_valid_input() {
         assert!(validate_account_fields("   ", "tfsa").is_err());
-    }
-
-    #[test]
-    fn validate_account_fields_rejects_unknown_type() {
-        assert!(validate_account_fields("My Account", "not-a-type").is_err());
-    }
-
-    #[test]
-    fn validate_account_fields_trims_name_and_accepts_valid_input() {
+        assert!(validate_account_fields("not-a-type", "not-a-type").is_err());
         let name = validate_account_fields("  My TFSA  ", "tfsa").expect("valid input");
         assert_eq!(name, "My TFSA");
     }
 
     #[test]
-    fn validate_dividend_fields_rejects_non_positive_amount() {
-        assert!(validate_dividend_fields(0.0, "2024-01-01", "2024-01-15").is_err());
-        assert!(validate_dividend_fields(-1.0, "2024-01-01", "2024-01-15").is_err());
-    }
-
-    #[test]
-    fn validate_dividend_fields_rejects_non_finite_amount() {
-        assert!(validate_dividend_fields(f64::NAN, "2024-01-01", "2024-01-15").is_err());
-        assert!(validate_dividend_fields(f64::INFINITY, "2024-01-01", "2024-01-15").is_err());
-    }
-
-    #[test]
-    fn validate_dividend_fields_rejects_non_iso_dates() {
-        assert!(validate_dividend_fields(1.0, "01/01/2024", "2024-01-15").is_err());
-        assert!(validate_dividend_fields(1.0, "2024-01-01", "01/15/2024").is_err());
-    }
-
-    #[test]
     fn validate_dividend_fields_rejects_pay_date_before_ex_date() {
         assert!(validate_dividend_fields(1.0, "2024-01-15", "2024-01-01").is_err());
+        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-15").is_ok());
     }
 
+    // ── Cross-surface parity ────────────────────────────────────────────────
+    // Regression guard for #758: both the Tauri command layer and this MCP
+    // layer must reject the same representative invalid inputs, because both
+    // now call the identical `portfolio_core::validation` rule.
+
     #[test]
-    fn validate_dividend_fields_accepts_valid_input() {
-        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-15").is_ok());
-        assert!(validate_dividend_fields(1.5, "2024-01-01", "2024-01-01").is_ok());
+    fn representative_invalid_inputs_are_rejected_identically_to_shared_core() {
+        use portfolio_core::validation as core;
+
+        assert_eq!(
+            validate_holding_fields(-1.0, 100.0, "USD").is_err(),
+            core::validate_holding_fields(-1.0, 100.0, "USD").is_err()
+        );
+        assert_eq!(
+            validate_id("id", "not-a-uuid").is_err(),
+            core::validate_id("id", "not-a-uuid").is_err()
+        );
+        assert_eq!(
+            validate_transaction_fields(0.0, 10.0).is_err(),
+            core::validate_transaction_fields(0.0, 10.0).is_err()
+        );
+        assert_eq!(
+            validate_alert_currency("usd").is_err(),
+            core::validate_alert_currency("usd").is_err()
+        );
+        assert_eq!(
+            validate_config_key("some_internal_secret").is_err(),
+            core::validate_config_key("some_internal_secret").is_err()
+        );
+        assert_eq!(
+            validate_account_fields("", "tfsa").is_err(),
+            core::validate_account_fields("", "tfsa").is_err()
+        );
+        assert_eq!(
+            validate_dividend_fields(0.0, "2024-01-01", "2024-01-15").is_err(),
+            core::validate_dividend_fields(0.0, "2024-01-01", "2024-01-15").is_err()
+        );
     }
 }

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -5,25 +5,12 @@ use chrono::Utc;
 
 use super::{validate_id, DbState};
 
-const VALID_ACCOUNT_TYPES: &[&str] =
-    &["tfsa", "rrsp", "fhsa", "taxable", "crypto", "cash", "other"];
-
 /// Validates an account's name and type, shared by `add_account`/`update_account`.
-/// Returns the trimmed name on success.
+/// Returns the trimmed name on success. Delegates to `portfolio_core::validation`
+/// so the MCP server enforces the same rule — see #758.
 pub(crate) fn validate_account_fields(name: &str, account_type: &str) -> Result<String, AppError> {
-    let name = name.trim().to_string();
-    if name.is_empty() {
-        return Err(AppError::Validation(
-            "Account name cannot be empty".to_string(),
-        ));
-    }
-    if !VALID_ACCOUNT_TYPES.contains(&account_type) {
-        return Err(AppError::Validation(format!(
-            "Invalid account type: {}",
-            account_type
-        )));
-    }
-    Ok(name)
+    portfolio_core::validation::validate_account_fields(name, account_type)
+        .map_err(AppError::Validation)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -5,128 +5,19 @@ use crate::error::AppError;
 
 use super::{DbState, RealizedGainsCacheState};
 
-/// Config keys readable/writable via `get_config_cmd`/`set_config_cmd`. Shared
-/// by both commands so a key can never be read without also being writable
-/// (or vice versa) — add new config keys here before wiring up a new setting.
-const ALLOWED_CONFIG_KEYS: &[&str] = &[
-    "base_currency",
-    "app_language",
-    "app_theme",
-    "auto_refresh_interval_ms",
-    "auto_refresh_market_hours_only",
-    "cost_basis_method",
-    "notifications_enabled",
-    "holdings_hidden_columns",
-];
-
+/// Validates that `key` is on the config allowlist (`get_config_cmd`/`set_config_cmd`).
+/// Delegates to `portfolio_core::validation` so the MCP server enforces the
+/// same allowlist — see #758.
 fn validate_config_key(key: &str) -> Result<(), AppError> {
-    if !ALLOWED_CONFIG_KEYS.contains(&key) {
-        return Err(AppError::Validation(format!("Unknown config key: {key}")));
-    }
-    Ok(())
+    portfolio_core::validation::validate_config_key(key).map_err(AppError::Validation)
 }
 
-/// BCP 47 tags this app ships translations for (`frontend/lib/i18n.ts`'s
-/// `SUPPORTED_LNG_CODES`).
-const SUPPORTED_LANGUAGES: &[&str] = &["en", "de", "es", "fr", "ja", "pl", "pt", "zh"];
-
-/// Holdings table columns a user can hide (`frontend/components/Holdings.tsx`'s
-/// `ALL_COLUMNS`), mirrored here so `holdings_hidden_columns` can't be set to
-/// reference a column that doesn't exist.
-const KNOWN_HOLDINGS_COLUMNS: &[&str] = &[
-    "symbol",
-    "name",
-    "assetType",
-    "account",
-    "exchange",
-    "quantity",
-    "costBasis",
-    "currentPrice",
-    "marketValueCad",
-    "weight",
-    "targetWeight",
-    "targetDeltaPercent",
-    "targetDeltaValue",
-    "gainLoss",
-    "gainLossPercent",
-    "prevClose",
-    "dayOpen",
-    "openDate",
-    "maturityDate",
-];
-
-/// Keys not otherwise recognized below fall through to this generic bound —
-/// long enough for any legitimate config value, short enough to stop the
-/// allowlisted-key check from being paired with an unbounded value.
-const MAX_CONFIG_VALUE_LEN: usize = 500;
-
 /// `validate_config_key` only checks that `key` is allowlisted; it says nothing
-/// about whether `value` is something the app can actually use. A malformed
-/// theme, language, currency code, or hidden-columns list would otherwise be
-/// written to `app_config` and only surface as a confusing failure wherever
-/// it's read back out.
+/// about whether `value` is something the app can actually use. Delegates to
+/// `portfolio_core::validation` so the MCP server enforces the same per-key
+/// value shape — see #758.
 pub(crate) fn validate_config_value(key: &str, value: &str) -> Result<(), AppError> {
-    match key {
-        "app_theme" => {
-            if !["light", "dark", "system"].contains(&value) {
-                return Err(AppError::Validation(format!(
-                    "app_theme must be one of: light, dark, system (got: {value})"
-                )));
-            }
-        }
-        "app_language" => {
-            if !SUPPORTED_LANGUAGES.contains(&value) {
-                return Err(AppError::Validation(format!(
-                    "app_language must be one of: {} (got: {value})",
-                    SUPPORTED_LANGUAGES.join(", ")
-                )));
-            }
-        }
-        "base_currency" => {
-            if value.len() != 3 || !value.bytes().all(|b| b.is_ascii_uppercase()) {
-                return Err(AppError::Validation(format!(
-                    "base_currency must be a 3-letter uppercase currency code (got: {value})"
-                )));
-            }
-        }
-        "holdings_hidden_columns" => {
-            let columns: Vec<String> = serde_json::from_str(value).map_err(|_| {
-                AppError::Validation(
-                    "holdings_hidden_columns must be a JSON array of column names".to_string(),
-                )
-            })?;
-            if let Some(unknown) = columns
-                .iter()
-                .find(|c| !KNOWN_HOLDINGS_COLUMNS.contains(&c.as_str()))
-            {
-                return Err(AppError::Validation(format!(
-                    "holdings_hidden_columns contains unknown column: {unknown}"
-                )));
-            }
-        }
-        "cost_basis_method" => {
-            if !value.eq_ignore_ascii_case("avco") && !value.eq_ignore_ascii_case("fifo") {
-                return Err(AppError::Validation(format!(
-                    "cost_basis_method must be one of: avco, fifo (got: {value})"
-                )));
-            }
-        }
-        "notifications_enabled" | "auto_refresh_market_hours_only" => {
-            if !["true", "false"].contains(&value) {
-                return Err(AppError::Validation(format!(
-                    "{key} must be one of: true, false (got: {value})"
-                )));
-            }
-        }
-        _ => {
-            if value.len() > MAX_CONFIG_VALUE_LEN {
-                return Err(AppError::Validation(format!(
-                    "{key} value exceeds max length of {MAX_CONFIG_VALUE_LEN} characters"
-                )));
-            }
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_config_value(key, value).map_err(AppError::Validation)
 }
 
 #[tauri::command]
@@ -241,7 +132,7 @@ mod tests {
 
     #[test]
     fn validate_config_key_accepts_every_allowed_key() {
-        for key in ALLOWED_CONFIG_KEYS {
+        for key in portfolio_core::validation::ALLOWED_CONFIG_KEYS {
             assert!(
                 validate_config_key(key).is_ok(),
                 "{key} should be a valid config key"
@@ -344,7 +235,7 @@ mod tests {
 
     #[test]
     fn validate_config_value_rejects_other_keys_over_max_length() {
-        let too_long = "a".repeat(MAX_CONFIG_VALUE_LEN + 1);
+        let too_long = "a".repeat(portfolio_core::validation::MAX_CONFIG_VALUE_LEN + 1);
         assert!(validate_config_value("auto_refresh_interval_ms", &too_long).is_err());
     }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -206,170 +206,73 @@ pub(crate) async fn validate_symbol(
     Ok(result)
 }
 
+// The functions and constants below are thin adapters over
+// `portfolio_core::validation::*`: they convert the shared `Result<T, String>`
+// into `AppError::Validation`, preserving the exact messages the frontend has
+// always seen. The actual rules live in `portfolio-core` so the MCP server
+// (`portfolio-mcp/src/validation.rs`) enforces them identically — see #758.
+
+pub(crate) use portfolio_core::validation::WEIGHT_EPSILON;
+
 pub(crate) fn validate_holding_fields(
     quantity: f64,
     cost_basis: f64,
     currency: &str,
 ) -> Result<String, AppError> {
-    if quantity <= 0.0 || !quantity.is_finite() {
-        return Err(AppError::Validation(
-            "quantity must be a positive finite number".to_string(),
-        ));
-    }
-    if cost_basis < 0.0 || !cost_basis.is_finite() {
-        return Err(AppError::Validation(
-            "costBasis must be a non-negative finite number".to_string(),
-        ));
-    }
-    let currency = currency.trim().to_uppercase();
-    if currency.len() != 3 || !currency.chars().all(|c| c.is_ascii_alphabetic()) {
-        return Err(AppError::Validation(
-            "currency must be a 3-letter ISO currency code".to_string(),
-        ));
-    }
-    Ok(currency)
+    portfolio_core::validation::validate_holding_fields(quantity, cost_basis, currency)
+        .map_err(AppError::Validation)
 }
 
-pub(crate) const WEIGHT_EPSILON: f64 = 0.001;
-
-/// Validates an optional target weight: when present, must be a finite
-/// percentage in [0, 100]. A negative or out-of-range value would otherwise
-/// silently persist and produce nonsensical rebalance suggestions.
 pub(crate) fn validate_target_weight(target_weight: Option<f64>) -> Result<(), AppError> {
-    if let Some(weight) = target_weight {
-        if !weight.is_finite() || !(0.0..=100.0).contains(&weight) {
-            return Err(AppError::Validation(
-                "targetWeight must be a finite number between 0 and 100".to_string(),
-            ));
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_target_weight(target_weight).map_err(AppError::Validation)
 }
 
-/// Validates dividend input fields shared by `add_dividend`.
 pub(crate) fn validate_dividend_fields(
     amount_per_unit: f64,
     ex_date: &str,
     pay_date: &str,
 ) -> Result<(), AppError> {
-    if !amount_per_unit.is_finite() || amount_per_unit <= 0.0 {
-        return Err(AppError::Validation(
-            "amountPerUnit must be a finite number greater than 0".to_string(),
-        ));
-    }
-    if chrono::NaiveDate::parse_from_str(ex_date.trim(), "%Y-%m-%d").is_err() {
-        return Err(AppError::Validation(
-            "exDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
-        ));
-    }
-    if chrono::NaiveDate::parse_from_str(pay_date.trim(), "%Y-%m-%d").is_err() {
-        return Err(AppError::Validation(
-            "payDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
-        ));
-    }
-    if pay_date < ex_date {
-        return Err(AppError::Validation(
-            "payDate must not be before exDate".to_string(),
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_dividend_fields(amount_per_unit, ex_date, pay_date)
+        .map_err(AppError::Validation)
 }
 
-/// Validates transaction quantity/price. Mirrors `validate_transaction_fields`
-/// in `portfolio-mcp/src/validation.rs`.
 pub(crate) fn validate_transaction_fields(quantity: f64, price: f64) -> Result<(), AppError> {
-    if quantity <= 0.0 || !quantity.is_finite() {
-        return Err(AppError::Validation(
-            "Transaction quantity must be a positive finite number".to_string(),
-        ));
-    }
-    if price < 0.0 || !price.is_finite() {
-        return Err(AppError::Validation(
-            "Transaction price must be a non-negative finite number".to_string(),
-        ));
-    }
-    Ok(())
+    portfolio_core::validation::validate_transaction_fields(quantity, price)
+        .map_err(AppError::Validation)
 }
 
-/// Dividend frequencies accepted by the CSV import layer (`src-tauri/src/csv.rs`).
-pub(crate) const VALID_DIVIDEND_FREQUENCIES: &[&str] =
-    &["monthly", "quarterly", "semi-annual", "annual", "irregular"];
-
-/// Validates the optional dividend/maturity fields shared by `add_holding`/`update_holding`.
-/// Mirrors the checks the CSV import layer applies in `src-tauri/src/csv.rs`.
 pub(crate) fn validate_holding_dividend_fields(
     indicated_annual_dividend: Option<f64>,
     dividend_frequency: Option<&str>,
     maturity_date: Option<&str>,
 ) -> Result<(), AppError> {
-    if let Some(amount) = indicated_annual_dividend {
-        if !amount.is_finite() || amount < 0.0 {
-            return Err(AppError::Validation(
-                "indicatedAnnualDividend must be a non-negative finite number".to_string(),
-            ));
-        }
-    }
-    if let Some(freq) = dividend_frequency {
-        let normalized = freq.trim().to_lowercase();
-        if !VALID_DIVIDEND_FREQUENCIES.contains(&normalized.as_str()) {
-            return Err(AppError::Validation(format!(
-                "dividendFrequency must be one of: {}",
-                VALID_DIVIDEND_FREQUENCIES.join(", ")
-            )));
-        }
-    }
-    if let Some(date) = maturity_date {
-        if chrono::NaiveDate::parse_from_str(date.trim(), "%Y-%m-%d").is_err() {
-            return Err(AppError::Validation(
-                "maturityDate must be a valid ISO date (YYYY-MM-DD)".to_string(),
-            ));
-        }
-    }
-    Ok(())
+    portfolio_core::validation::validate_holding_dividend_fields(
+        indicated_annual_dividend,
+        dividend_frequency,
+        maturity_date,
+    )
+    .map_err(AppError::Validation)
 }
 
-/// Max length for a price alert's free-text note, to prevent abuse.
-pub(crate) const MAX_ALERT_NOTE_LEN: usize = 500;
-
 /// Validates a price alert's symbol, threshold, currency, and note. Shared by
-/// `add_alert`. Mirrors the checks in `portfolio-mcp/src/validation.rs`.
+/// `add_alert`.
 pub(crate) fn validate_alert_fields(
     symbol: &str,
     threshold: f64,
     currency: &str,
     note: &str,
 ) -> Result<(), AppError> {
-    if symbol.trim().is_empty() {
-        return Err(AppError::Validation("symbol must not be empty".to_string()));
-    }
-    if !threshold.is_finite() || threshold <= 0.0 {
-        return Err(AppError::Validation(
-            "threshold must be a positive finite number".to_string(),
-        ));
-    }
-    let currency = currency.trim();
-    if !(2..=3).contains(&currency.len()) || !currency.chars().all(|c| c.is_ascii_uppercase()) {
-        return Err(AppError::Validation(
-            "currency must be 2-3 uppercase letters".to_string(),
-        ));
-    }
-    if note.chars().count() > MAX_ALERT_NOTE_LEN {
-        return Err(AppError::Validation(format!(
-            "note must be at most {MAX_ALERT_NOTE_LEN} characters"
-        )));
-    }
+    portfolio_core::validation::validate_non_empty("symbol", symbol)
+        .map_err(AppError::Validation)?;
+    portfolio_core::validation::validate_alert_threshold(threshold)
+        .map_err(AppError::Validation)?;
+    portfolio_core::validation::validate_alert_currency(currency).map_err(AppError::Validation)?;
+    portfolio_core::validation::validate_alert_note(note).map_err(AppError::Validation)?;
     Ok(())
 }
 
-/// Validates that an ID string is non-empty and a syntactically valid UUID.
-/// All IDs in this app are UUID v4 strings generated via `uuid::Uuid::new_v4()`;
-/// a malformed ID would otherwise silently no-op in SQLite (0 rows affected)
-/// instead of surfacing a clear error.
 pub(crate) fn validate_id(field: &str, id: &str) -> Result<(), AppError> {
-    if id.trim().is_empty() || uuid::Uuid::parse_str(id.trim()).is_err() {
-        return Err(AppError::Validation(format!("Invalid {field}")));
-    }
-    Ok(())
+    portfolio_core::validation::validate_id(field, id).map_err(AppError::Validation)
 }
 
 /// Validates 1-indexed pagination parameters. Shared by every `*_paginated` command.

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -12,7 +12,7 @@ use crate::types::{Holding, HoldingId, HoldingInput, PortfolioSnapshot};
 use super::{
     get_base_currency, normalize_cost_basis_method, validate_holding_dividend_fields,
     validate_holding_fields, validate_id, validate_pagination, validate_target_weight, DbState,
-    HttpClient, RealizedGainsCacheState, WEIGHT_EPSILON,
+    HttpClient, RealizedGainsCacheState,
 };
 
 #[tauri::command]
@@ -141,8 +141,8 @@ async fn add_holding_impl(
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
             let current_sum = db::sum_target_weights(pool, None).await?;
-            let new_total = current_sum + target_weight;
-            if new_total > 100.0 + WEIGHT_EPSILON {
+            if portfolio_core::validation::exceeds_target_weight_budget(target_weight, current_sum)
+            {
                 return Err(AppError::Validation(format!(
                     "Total target weight would exceed 100% (currently {:.1}%). Adjust existing allocations before adding this holding.",
                     current_sum
@@ -179,8 +179,8 @@ async fn update_holding_impl(
     if let Some(target_weight) = holding.target_weight {
         if target_weight > 0.0 {
             let current_sum = db::sum_target_weights(pool, Some(holding.id.0.as_str())).await?;
-            let new_total = current_sum + target_weight;
-            if new_total > 100.0 + WEIGHT_EPSILON {
+            if portfolio_core::validation::exceeds_target_weight_budget(target_weight, current_sum)
+            {
                 return Err(AppError::Validation(format!(
                     "Total target weight would exceed 100% (currently {:.1}% across other holdings). Adjust existing allocations before saving.",
                     current_sum


### PR DESCRIPTION
## Summary
- Business validation was duplicated between `src-tauri/src/commands/` (Tauri) and `portfolio-mcp/src/validation.rs` (MCP) — a rule change in one place wouldn't automatically apply to the other.
- Moved the transport-neutral rules into `portfolio-core/src/validation/` as plain `Result<T, String>` functions, organized by domain (`common`, `holdings`, `transactions`, `alerts`, `dividends`, `accounts`, `config`), each with its own test suite.
- Both surfaces now delegate to `portfolio_core::validation::*` and only adapt the message into their own error type: `AppError::Validation(String)` for Tauri, `McpError::invalid_params(String, None)` for MCP.
- Every existing user-facing error message is preserved exactly (call sites just changed from inline logic to a thin wrapper around the shared function).
- The target-weight-budget check, previously inlined separately in `commands/portfolio.rs` (add/update) and as its own function in MCP's `validation.rs`, now shares one predicate (`exceeds_target_weight_budget`) while each side keeps its own contextual error message.

Closes #758

## Test plan
- [x] `cargo test --workspace` — 583 tests pass (121 portfolio-core, 46 portfolio-mcp, 400 src-tauri, 16 import-integration)
- [x] `cargo clippy --workspace --all-targets` — clean except one pre-existing warning in `portfolio-mcp/src/tools/config.rs` unrelated to this change
- [x] `cargo fmt --all -- --check` — clean on every file this PR touches (remaining diffs are pre-existing drift in untouched files)
- [x] Added `representative_invalid_inputs_are_rejected_identically_to_shared_core` in `portfolio-mcp/src/validation.rs`, a regression guard asserting the MCP adapter and the shared core reject the same invalid inputs identically
- [x] Full pre-push verification (lint, typecheck, frontend build, backend build, frontend tests, backend tests, clippy) passed