### PR TITLE
fix: correct portfolio-mcp default database path to match Tauri app identifier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Add to `~/.claude/settings.json`:
     "portfolio": {
       "command": "/absolute/path/to/target/release/portfolio-mcp",
       "env": {
-        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.portfolio-tracker.app/portfolio.db"
+        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db"
       }
     }
   }
@@ -191,7 +191,7 @@ Add to `~/.claude/settings.json`:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db` | Path to the SQLite database |
+| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db` | Path to the SQLite database |
 | `RUST_LOG` | `portfolio_mcp=info` | Log level filter (logs to stderr) |
 
 ### Implementation Notes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -325,7 +325,7 @@ Add to `~/.claude/settings.json`:
     "portfolio": {
       "command": "/absolute/path/to/target/release/portfolio-mcp",
       "env": {
-        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.portfolio-tracker.app/portfolio.db"
+        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db"
       }
     }
   }
@@ -336,7 +336,7 @@ Add to `~/.claude/settings.json`:
 
 | Environment Variable | Default | Description |
 |----------------------|---------|-------------|
-| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db` | Path to the SQLite database |
+| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db` | Path to the SQLite database |
 | `RUST_LOG` | `portfolio_mcp=info` | Log level filter; logs go to stderr, never stdout |
 
 ### Implementation Notes

--- a/portfolio-mcp/README.md
+++ b/portfolio-mcp/README.md
@@ -21,7 +21,7 @@ If a client calls a tool that isn't enabled, the server returns an error explain
     "portfolio": {
       "command": "/path/to/target/release/portfolio-mcp",
       "env": {
-        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.portfolio-tracker.app/portfolio.db",
+        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db",
         "PORTFOLIO_MCP_WRITE_ENABLED": "true",
         "PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED": "false"
       }
@@ -76,7 +76,7 @@ Add to `~/.claude/settings.json`. This example runs in read-only mode — omit `
     "portfolio": {
       "command": "/path/to/target/release/portfolio-mcp",
       "env": {
-        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.portfolio-tracker.app/portfolio.db"
+        "PORTFOLIO_DB_PATH": "/Users/YOU/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db"
       }
     }
   }
@@ -89,7 +89,7 @@ Replace `/path/to/target/release/portfolio-mcp` with the actual binary path (e.g
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db` | Path to the SQLite DB created by the Tauri app |
+| `PORTFOLIO_DB_PATH` | `~/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db` | Path to the SQLite DB created by the Tauri app |
 | `PORTFOLIO_MCP_WRITE_ENABLED` | `false` | Set to `true` to register non-destructive write tools — see [Access modes](#access-modes) |
 | `PORTFOLIO_MCP_DESTRUCTIVE_WRITE_ENABLED` | `false` | Set to `true` to register `delete_*` tools — see [Access modes](#access-modes) |
 | `RUST_LOG` | `portfolio_mcp=info` | Log level filter (logs go to stderr, never stdout) |

--- a/portfolio-mcp/src/main.rs
+++ b/portfolio-mcp/src/main.rs
@@ -8,19 +8,31 @@ mod validation;
 use anyhow::Result;
 use rmcp::{transport::stdio, ServiceExt};
 
+/// Bundle identifier used by the Tauri app (see `src-tauri/tauri.conf.json`'s
+/// `identifier` field), which determines the app data directory the database
+/// lives in on macOS.
+const APP_IDENTIFIER: &str = "com.giterror.portfolio-tracker";
+
 /// Resolve the path to the portfolio SQLite database.
 ///
 /// Priority order:
 /// 1. `PORTFOLIO_DB_PATH` environment variable.
-/// 2. macOS default: `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db`
+/// 2. macOS default: `~/Library/Application Support/<APP_IDENTIFIER>/portfolio.db`
 fn db_path() -> String {
     if let Ok(p) = std::env::var("PORTFOLIO_DB_PATH") {
         return p;
     }
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    default_db_path(&home)
+}
+
+/// Build the default macOS database path for a given home directory.
+/// Pure and independently testable — `db_path()` wraps this with the
+/// `PORTFOLIO_DB_PATH` override and `$HOME` lookup.
+fn default_db_path(home: &str) -> String {
     format!(
-        "{}/Library/Application Support/com.portfolio-tracker.app/portfolio.db",
-        home
+        "{}/Library/Application Support/{}/portfolio.db",
+        home, APP_IDENTIFIER
     )
 }
 
@@ -83,4 +95,22 @@ async fn main() -> Result<()> {
     service.waiting().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_db_path_uses_tauri_app_identifier() {
+        let path = default_db_path("/Users/testuser");
+        assert!(
+            path.contains("com.giterror.portfolio-tracker"),
+            "expected default path to contain the Tauri app identifier, got: {path}"
+        );
+        assert_eq!(
+            path,
+            "/Users/testuser/Library/Application Support/com.giterror.portfolio-tracker/portfolio.db"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `portfolio-mcp`'s `db_path()` defaulted to `~/Library/Application Support/com.portfolio-tracker.app/portfolio.db`, but the Tauri app identifier (`src-tauri/tauri.conf.json`) is `com.giterror.portfolio-tracker` — so without `PORTFOLIO_DB_PATH` set, the MCP server opened a different (possibly empty) database instead of the user's live portfolio.
- Fixed the default path to use `com.giterror.portfolio-tracker`, factored into an `APP_IDENTIFIER` constant and a pure `default_db_path()` helper for testability.
- Added a unit test asserting the default path contains the correct identifier.
- Updated `portfolio-mcp/README.md`, `CLAUDE.md`, and `docs/ARCHITECTURE.md` — all three documented the stale path in example configs and the environment variable table. `docs/privacy.md` already had the correct identifier, so no change was needed there.

Closes #768

## Test plan
- [x] `cargo test -p portfolio-mcp` — 52 tests pass, including new `default_db_path_uses_tauri_app_identifier`
- [x] `cargo fmt -p portfolio-mcp -- --check` and `cargo clippy -p portfolio-mcp --all-targets -- -D warnings` — clean
- [x] Pre-push hook (lint/typecheck/format, frontend+backend build, full test suite, clippy) passed