### PR TITLE
fix: invalidate realized-gains cache on holding currency change and deletion

### DIFF
--- a/src-tauri/src/analytics.rs
+++ b/src-tauri/src/analytics.rs
@@ -200,12 +200,14 @@ pub fn aggregate_summaries(summaries: Vec<RealizedGainsSummary>) -> RealizedGain
 ///
 /// FX conversion uses the current/cached rate, not the historical rate at
 /// time of sale — acceptable for a live dashboard snapshot figure, but not a
-/// substitute for a proper tax/accounting record. A holding that maps to no
-/// known holding (e.g. a deleted holding) is treated as already being in
-/// base currency. But if a *non-base* holding currency has no cached FX
-/// rate, conversion is unreliable — silently returning a 1:1 rate would
-/// display the raw foreign-currency figure as if it were base currency, so
-/// this returns an error instead of guessing (#766).
+/// substitute for a proper tax/accounting record. `holding_currencies` is
+/// expected to include soft-deleted holdings (see `db::get_all_holding_currencies`)
+/// so a holding sold and later deleted still resolves to its real currency
+/// here; a holding genuinely absent from the map (e.g. hard-deleted test data)
+/// is treated as already being in base currency. But if a *non-base* holding
+/// currency has no cached FX rate, conversion is unreliable — silently
+/// returning a 1:1 rate would display the raw foreign-currency figure as if
+/// it were base currency, so this returns an error instead of guessing (#766).
 pub fn compute_realized_gains_grouped(
     transactions: &[Transaction],
     method: &str,

--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -474,12 +474,8 @@ pub async fn get_realized_gains(
     };
 
     let base_currency = get_base_currency(pool).await;
-    let holdings = db::get_all_holdings(pool).await?;
     let cached_fx = db::get_fx_rates(pool).await?;
-    let holding_currencies: HashMap<HoldingId, String> = holdings
-        .iter()
-        .map(|h| (h.id.clone(), h.currency.clone()))
-        .collect();
+    let holding_currencies = db::get_all_holding_currencies(pool).await?;
 
     let summary = compute_realized_gains_grouped(
         &transactions,

--- a/src-tauri/src/commands/portfolio.rs
+++ b/src-tauri/src/commands/portfolio.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::Utc;
 use tauri::State;
 
@@ -47,10 +45,7 @@ pub(crate) async fn get_portfolio_impl(
             cached
         } else {
             let transactions = db::get_all_transactions(pool).await?;
-            let holding_currencies: HashMap<HoldingId, String> = holdings
-                .iter()
-                .map(|h| (h.id.clone(), h.currency.clone()))
-                .collect();
+            let holding_currencies = db::get_all_holding_currencies(pool).await?;
             match compute_realized_gains_grouped(
                 &transactions,
                 &cost_basis_method,
@@ -156,12 +151,17 @@ async fn add_holding_impl(
 }
 
 #[tauri::command]
-pub async fn update_holding(db: State<'_, DbState>, holding: Holding) -> Result<Holding, AppError> {
-    update_holding_impl(&db.0, holding).await
+pub async fn update_holding(
+    db: State<'_, DbState>,
+    gains_cache: State<'_, RealizedGainsCacheState>,
+    holding: Holding,
+) -> Result<Holding, AppError> {
+    update_holding_impl(&db.0, &gains_cache, holding).await
 }
 
 async fn update_holding_impl(
     pool: &sqlx::SqlitePool,
+    gains_cache: &RealizedGainsCacheState,
     holding: Holding,
 ) -> Result<Holding, AppError> {
     let currency =
@@ -188,16 +188,45 @@ async fn update_holding_impl(
             }
         }
     }
-    db::update_holding(pool, holding)
+    // Realized-gains transactions are converted using the holding's *current*
+    // currency (see compute_realized_gains_grouped), so a cached summary from
+    // before a currency change would silently apply the wrong FX rate (#767).
+    let previous_currency = db::get_holding_symbol_and_currency(pool, holding.id.0.as_str())
+        .await?
+        .map(|(_, currency)| currency);
+    let new_currency = holding.currency.clone();
+    let updated = db::update_holding(pool, holding)
         .await
-        .map_err(AppError::from)
+        .map_err(AppError::from)?;
+    if previous_currency.as_deref() != Some(new_currency.as_str()) {
+        gains_cache.invalidate();
+    }
+    Ok(updated)
 }
 
 #[tauri::command]
-pub async fn delete_holding(db: State<'_, DbState>, id: HoldingId) -> Result<bool, AppError> {
+pub async fn delete_holding(
+    db: State<'_, DbState>,
+    gains_cache: State<'_, RealizedGainsCacheState>,
+    id: HoldingId,
+) -> Result<bool, AppError> {
     validate_id("holding ID", &id.0)?;
-    let pool = &db.0;
-    db::delete_holding(pool, &id).await.map_err(AppError::from)
+    delete_holding_impl(&db.0, &gains_cache, &id).await
+}
+
+async fn delete_holding_impl(
+    pool: &sqlx::SqlitePool,
+    gains_cache: &RealizedGainsCacheState,
+    id: &HoldingId,
+) -> Result<bool, AppError> {
+    let deleted = db::delete_holding(pool, id).await.map_err(AppError::from)?;
+    if deleted {
+        // The holding's transactions remain in realized-gains history after a
+        // soft-delete; any cached summary computed before this point may have
+        // used a stale holding_currencies map, so force a recompute (#767).
+        gains_cache.invalidate();
+    }
+    Ok(deleted)
 }
 
 #[cfg(test)]
@@ -273,7 +302,8 @@ mod tests {
 
         let mut to_update = inserted.clone();
         to_update.currency = "  usd ".to_string();
-        let updated = super::update_holding_impl(&pool, to_update)
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        let updated = super::update_holding_impl(&pool, &gains_cache, to_update)
             .await
             .expect("update_holding_impl should succeed");
         assert_eq!(updated.currency, "USD");
@@ -285,5 +315,222 @@ mod tests {
             .find(|h| h.id == inserted.id)
             .expect("holding must exist");
         assert_eq!(fetched.currency, "USD");
+    }
+
+    #[tokio::test]
+    async fn update_holding_invalidates_gains_cache_on_currency_change() {
+        // Regression guard for #767: a cached realized-gains summary computed
+        // while the holding was CAD must not survive a currency change to USD,
+        // since the cached figures were converted with the old currency's FX rate.
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "CAD"))
+            .await
+            .expect("add_holding_impl should succeed");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        gains_cache.set(crate::types::RealizedGainsSummary {
+            total_realized_gain: 100.0,
+            total_proceeds: 100.0,
+            total_cost_basis: 0.0,
+            lots: vec![],
+        });
+        assert!(gains_cache.get().is_some(), "sanity check: cache is warm");
+
+        let mut to_update = inserted.clone();
+        to_update.currency = "USD".to_string();
+        super::update_holding_impl(&pool, &gains_cache, to_update)
+            .await
+            .expect("update_holding_impl should succeed");
+
+        assert!(
+            gains_cache.get().is_none(),
+            "changing a holding's currency must invalidate the cached realized-gains summary"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_holding_does_not_invalidate_gains_cache_when_currency_unchanged() {
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "CAD"))
+            .await
+            .expect("add_holding_impl should succeed");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        gains_cache.set(crate::types::RealizedGainsSummary {
+            total_realized_gain: 100.0,
+            total_proceeds: 100.0,
+            total_cost_basis: 0.0,
+            lots: vec![],
+        });
+
+        let mut to_update = inserted.clone();
+        to_update.quantity = 20.0;
+        super::update_holding_impl(&pool, &gains_cache, to_update)
+            .await
+            .expect("update_holding_impl should succeed");
+
+        assert!(
+            gains_cache.get().is_some(),
+            "an unrelated field update must not invalidate the realized-gains cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_holding_invalidates_gains_cache() {
+        // Regression guard for #767: a soft-deleted holding's historical
+        // transactions remain in realized-gains history, so any cached
+        // summary computed before the delete must be recomputed.
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "USD"))
+            .await
+            .expect("add_holding_impl should succeed");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        gains_cache.set(crate::types::RealizedGainsSummary {
+            total_realized_gain: 100.0,
+            total_proceeds: 100.0,
+            total_cost_basis: 0.0,
+            lots: vec![],
+        });
+        assert!(gains_cache.get().is_some(), "sanity check: cache is warm");
+
+        let deleted = super::delete_holding_impl(&pool, &gains_cache, &inserted.id)
+            .await
+            .expect("delete_holding_impl should succeed");
+        assert!(deleted);
+
+        assert!(
+            gains_cache.get().is_none(),
+            "soft-deleting a holding must invalidate the cached realized-gains summary"
+        );
+    }
+
+    async fn buy_sell_transactions(pool: &sqlx::SqlitePool, holding_id: &crate::types::HoldingId) {
+        use crate::types::{TransactionInput, TransactionType};
+        db::insert_transaction(
+            pool,
+            TransactionInput {
+                holding_id: holding_id.clone(),
+                transaction_type: TransactionType::Buy,
+                quantity: 10.0,
+                price: 100.0,
+                transacted_at: "2024-01-01T00:00:00Z".to_string(),
+            },
+        )
+        .await
+        .expect("insert buy transaction");
+        db::insert_transaction(
+            pool,
+            TransactionInput {
+                holding_id: holding_id.clone(),
+                transaction_type: TransactionType::Sell,
+                quantity: 10.0,
+                price: 150.0,
+                transacted_at: "2024-01-02T00:00:00Z".to_string(),
+            },
+        )
+        .await
+        .expect("insert sell transaction");
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_reflects_new_currency_after_holding_currency_change() {
+        // End-to-end regression guard for #767: buy/sell 10 shares for a gain of
+        // 500 in the holding's currency. Verify the reported realized gain
+        // (in CAD) tracks the FX rate of the holding's *current* currency after
+        // an update, not a stale cached figure from the prior currency.
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "USD"))
+            .await
+            .expect("add_holding_impl should succeed");
+        buy_sell_transactions(&pool, &inserted.id).await;
+
+        db::upsert_fx_rate(
+            &pool,
+            &crate::types::FxRate {
+                pair: "USDCAD".to_string(),
+                rate: 1.30,
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+            },
+        )
+        .await
+        .expect("upsert USDCAD rate");
+        db::upsert_fx_rate(
+            &pool,
+            &crate::types::FxRate {
+                pair: "EURCAD".to_string(),
+                rate: 1.45,
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+            },
+        )
+        .await
+        .expect("upsert EURCAD rate");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        let snapshot_before = super::get_portfolio_impl(&pool, &gains_cache)
+            .await
+            .expect("get_portfolio_impl should succeed");
+        // gain = (150 - 100) * 10 = 500 USD -> 500 * 1.30 CAD
+        assert!(
+            (snapshot_before.realized_gains - 650.0).abs() < 0.001,
+            "expected USD-converted realized gain of 650.0, got {}",
+            snapshot_before.realized_gains
+        );
+
+        let mut to_update = inserted.clone();
+        to_update.currency = "EUR".to_string();
+        super::update_holding_impl(&pool, &gains_cache, to_update)
+            .await
+            .expect("update_holding_impl should succeed");
+
+        let snapshot_after = super::get_portfolio_impl(&pool, &gains_cache)
+            .await
+            .expect("get_portfolio_impl should succeed");
+        // gain = (150 - 100) * 10 = 500 EUR -> 500 * 1.45 CAD
+        assert!(
+            (snapshot_after.realized_gains - 725.0).abs() < 0.001,
+            "expected EUR-converted realized gain of 725.0 after currency change, got {}",
+            snapshot_after.realized_gains
+        );
+    }
+
+    #[tokio::test]
+    async fn get_portfolio_converts_deleted_holdings_transactions_using_original_currency() {
+        // End-to-end regression guard for #767: soft-deleting a non-base-currency
+        // holding must not make its historical transactions fall back to a 1:1
+        // base-currency conversion. Without the fix, holding_currencies is built
+        // only from active holdings, so a deleted USD holding's gain would be
+        // reported as 500 (raw) instead of 650 (converted at 1.30 USDCAD).
+        let pool = db::open_test_db().await;
+        let inserted = super::add_holding_impl(&pool, make_input("RY", "USD"))
+            .await
+            .expect("add_holding_impl should succeed");
+        buy_sell_transactions(&pool, &inserted.id).await;
+
+        db::upsert_fx_rate(
+            &pool,
+            &crate::types::FxRate {
+                pair: "USDCAD".to_string(),
+                rate: 1.30,
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+            },
+        )
+        .await
+        .expect("upsert USDCAD rate");
+
+        let gains_cache = crate::commands::RealizedGainsCacheState::new();
+        let deleted = super::delete_holding_impl(&pool, &gains_cache, &inserted.id)
+            .await
+            .expect("delete_holding_impl should succeed");
+        assert!(deleted);
+
+        let snapshot = super::get_portfolio_impl(&pool, &gains_cache)
+            .await
+            .expect("get_portfolio_impl should succeed");
+        assert!(
+            (snapshot.realized_gains - 650.0).abs() < 0.001,
+            "expected the deleted USD holding's gain to still be converted at 1.30 USDCAD (650.0), got {}",
+            snapshot.realized_gains
+        );
     }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -342,6 +342,28 @@ pub async fn get_all_holdings(pool: &SqlitePool) -> Result<Vec<Holding>, String>
     Ok(holdings)
 }
 
+/// Maps every holding id to its currency, *including soft-deleted holdings*.
+///
+/// Realized-gains transactions are never deleted alongside their holding, so
+/// a holding that was soft-deleted after being sold must still resolve to its
+/// original currency here — otherwise `compute_realized_gains_grouped` can't
+/// find it in the map and silently treats its transactions as already being
+/// in base currency (#767).
+pub async fn get_all_holding_currencies(
+    pool: &SqlitePool,
+) -> Result<std::collections::HashMap<HoldingId, String>, String> {
+    use sqlx::Row;
+    let rows = sqlx::query("SELECT id, currency FROM holdings")
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (HoldingId(r.get::<String, _>(0)), r.get::<String, _>(1)))
+        .collect())
+}
+
 /// Look up a holding's symbol and currency by id (single-row lookup, avoids
 /// scanning the full holdings collection just to read one field).
 pub async fn get_holding_symbol_and_currency(


### PR DESCRIPTION
## Summary
- `RealizedGainsCacheState` was invalidated on transaction edits, cost-basis method changes, and base-currency changes, but not when a holding's currency changed or a holding was soft-deleted — stale FX conversion could linger in the cached figure.
- Separately, `holding_currencies` (used by `compute_realized_gains_grouped`) was built only from active holdings. A soft-deleted holding's historical transactions therefore fell out of the map entirely and silently fell back to a 1:1 base-currency conversion instead of the holding's real currency.

## Changes
- `db::get_all_holding_currencies` — new helper that maps every holding id to its currency, *including soft-deleted holdings*. Used in both `get_portfolio_impl` and `get_realized_gains` in place of filtering `get_all_holdings()`.
- `update_holding` now invalidates the gains cache when the holding's currency actually changes (compares against the pre-update stored currency via `db::get_holding_symbol_and_currency`).
- `delete_holding` now invalidates the gains cache unconditionally on a successful soft-delete.
- Updated the stale doc comment on `compute_realized_gains_grouped` that claimed holdings absent from the map were "deleted holdings" treated as base currency — that's no longer the normal case now that deleted holdings are included.

## Test plan
- [x] `update_holding_invalidates_gains_cache_on_currency_change` / `update_holding_does_not_invalidate_gains_cache_when_currency_unchanged` — unit-level cache invalidation behavior
- [x] `delete_holding_invalidates_gains_cache` — unit-level cache invalidation behavior
- [x] `get_portfolio_reflects_new_currency_after_holding_currency_change` — end-to-end: buy/sell a holding, warm the cache, change its currency, verify the *next* `get_portfolio` call reflects the new FX rate rather than the stale cached figure
- [x] `get_portfolio_converts_deleted_holdings_transactions_using_original_currency` — end-to-end: buy/sell a USD holding, soft-delete it, verify realized gains are still converted at the USD→CAD rate (650.0) rather than falling back to the raw USD amount (500.0)
- [x] `cargo test --workspace` — 605 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)