### PR TITLE
fix: resolve real filesystem paths for Import wizard file selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3007,6 +3007,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3546,6 +3547,7 @@ dependencies = [
  "sqlx",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tokio",
  "tracing",
@@ -4002,6 +4004,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5266,6 +5292,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.1+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,6 +5740,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -6636,6 +6719,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6682,11 +6774,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6726,6 +6835,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6742,6 +6857,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6762,10 +6883,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6786,6 +6919,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6802,6 +6941,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6822,6 +6967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,6 +6989,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/frontend/components/import/FilePickerStep.tsx
+++ b/frontend/components/import/FilePickerStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Account } from '../../types/portfolio';
 import { ACCOUNT_TYPE_CONFIG } from '../../lib/constants';
@@ -16,7 +16,10 @@ interface Props {
   fileSize: number | null;
   parsing: boolean;
   parseError: string | null;
-  onFileSelected: (file: File) => void;
+  /** Filesystem path of the selected file — Tauri v2 File objects from the webview
+   * (input[type=file] or HTML5 drag-drop) never expose a real path, so both entry
+   * points below resolve one via the dialog plugin / native drag-drop event instead. */
+  onFileSelected: (path: string) => void;
 }
 
 function accountTypeLabel(type: string): string {
@@ -45,15 +48,66 @@ export function FilePickerStep({
   }));
 
   const canPickFile = !!selectedAccountId && !parsing;
+  // The drag-drop listener below is registered once; it reads this ref rather than
+  // the `canPickFile` closure so it always sees the latest value.
+  const canPickFileRef = useRef(canPickFile);
+  useEffect(() => {
+    canPickFileRef.current = canPickFile;
+  }, [canPickFile]);
 
-  function acceptFile(file: File) {
-    if (!file.name.toLowerCase().endsWith('.csv')) {
+  function acceptPath(path: string) {
+    if (!path.toLowerCase().endsWith('.csv')) {
       setExtensionError(t('importWizard.file.onlyCsv'));
       return;
     }
     setExtensionError(null);
-    onFileSelected(file);
+    onFileSelected(path);
   }
+
+  async function browseForFile() {
+    if (!canPickFileRef.current) return;
+    const { open } = await import('@tauri-apps/plugin-dialog');
+    const path = await open({
+      multiple: false,
+      directory: false,
+      filters: [{ name: 'CSV', extensions: ['csv'] }],
+    });
+    if (typeof path === 'string') acceptPath(path);
+  }
+
+  // Tauri v2 intercepts native OS drag-and-drop at the webview level, so the
+  // browser's HTML5 DataTransfer API never sees real files here — the drop target
+  // must listen for the webview's own drag-drop event instead, which carries real
+  // filesystem paths.
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+      const stopListening = await getCurrentWebview().onDragDropEvent((event) => {
+        if (event.payload.type === 'over') {
+          if (canPickFileRef.current) setDragActive(true);
+        } else if (event.payload.type === 'drop') {
+          setDragActive(false);
+          if (!canPickFileRef.current) return;
+          const path = event.payload.paths[0];
+          if (path) acceptPath(path);
+        } else {
+          setDragActive(false);
+        }
+      });
+      if (cancelled) {
+        stopListening();
+      } else {
+        unlisten = stopListening;
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- registered once; reads canPickFileRef for freshness
+  }, []);
 
   return (
     <div>
@@ -84,54 +138,42 @@ export function FilePickerStep({
         )}
       </div>
 
-      <label style={{ display: 'block', marginBottom: 12 }}>
-        <div
-          onDragOver={(e) => {
+      <div
+        role="button"
+        tabIndex={canPickFile ? 0 : -1}
+        aria-label={t('importWizard.file.dropzone')}
+        data-testid="file-dropzone"
+        onClick={() => void browseForFile()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            if (canPickFile) setDragActive(true);
-          }}
-          onDragLeave={() => setDragActive(false)}
-          onDrop={(e) => {
-            e.preventDefault();
-            setDragActive(false);
-            if (!canPickFile) return;
-            const file = e.dataTransfer.files?.[0];
-            if (file) acceptFile(file);
-          }}
-          style={{
-            border: `1px dashed ${dragActive ? 'var(--color-accent)' : 'var(--border-primary)'}`,
-            background: dragActive ? 'var(--bg-surface-hover)' : 'var(--bg-primary)',
-            padding: '28px 20px',
-            color: canPickFile ? 'var(--text-secondary)' : 'var(--text-muted)',
-            ...MONO,
-            fontSize: 12,
-            textAlign: 'center',
-            cursor: canPickFile ? 'pointer' : 'not-allowed',
-            opacity: canPickFile ? 1 : 0.6,
-          }}
-        >
-          <div>{fileName || t('importWizard.file.dropzone')}</div>
-          {fileName && fileSize != null ? (
-            <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
-              {formatFileSize(fileSize)}
-            </div>
-          ) : null}
-          <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
-            {t('importWizard.file.hint', { maxRows: 500 })}
+            void browseForFile();
+          }
+        }}
+        style={{
+          display: 'block',
+          marginBottom: 12,
+          border: `1px dashed ${dragActive ? 'var(--color-accent)' : 'var(--border-primary)'}`,
+          background: dragActive ? 'var(--bg-surface-hover)' : 'var(--bg-primary)',
+          padding: '28px 20px',
+          color: canPickFile ? 'var(--text-secondary)' : 'var(--text-muted)',
+          ...MONO,
+          fontSize: 12,
+          textAlign: 'center',
+          cursor: canPickFile ? 'pointer' : 'not-allowed',
+          opacity: canPickFile ? 1 : 0.6,
+        }}
+      >
+        <div>{fileName || t('importWizard.file.dropzone')}</div>
+        {fileName && fileSize != null ? (
+          <div style={{ marginTop: 4, fontSize: 11, color: 'var(--text-muted)' }}>
+            {formatFileSize(fileSize)}
           </div>
+        ) : null}
+        <div style={{ marginTop: 6, fontSize: 11, color: 'var(--text-muted)' }}>
+          {t('importWizard.file.hint', { maxRows: 500 })}
         </div>
-        <input
-          type="file"
-          accept=".csv,text/csv"
-          disabled={!canPickFile}
-          style={{ display: 'none' }}
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            e.target.value = '';
-            if (file) acceptFile(file);
-          }}
-        />
-      </label>
+      </div>
 
       {extensionError ? (
         <div style={{ ...MONO, fontSize: 12, color: 'var(--color-loss)', marginBottom: 8 }}>

--- a/frontend/components/import/ImportWizardModal.tsx
+++ b/frontend/components/import/ImportWizardModal.tsx
@@ -13,7 +13,7 @@ import { ColumnMappingStep } from './ColumnMappingStep';
 import { FilePickerStep } from './FilePickerStep';
 import { PreviewStep } from './PreviewStep';
 import { ResultStep } from './ResultStep';
-import { MONO } from './constants';
+import { fileNameFromPath, MONO } from './constants';
 
 type Step = 'file' | 'mapping' | 'preview' | 'result';
 
@@ -146,14 +146,11 @@ export function ImportWizardModal({ isOpen, onClose, onImported }: Props) {
     }
   }
 
-  function handleFileSelected(file: File) {
-    const path = (file as File & { path?: string }).path;
-    if (!path) {
-      setParseError(t('importWizard.file.noPath'));
-      return;
-    }
-    setFileName(file.name);
-    setFileSize(file.size);
+  function handleFileSelected(path: string) {
+    setFileName(fileNameFromPath(path));
+    // The dialog/drag-drop path only gives us a filesystem path, not a File
+    // object, so the size shown in Step 1 is unknown until the plan comes back.
+    setFileSize(null);
     setFilePath(path);
     void runParse(path, {});
   }

--- a/frontend/components/import/__tests__/ImportWizardModal.test.tsx
+++ b/frontend/components/import/__tests__/ImportWizardModal.test.tsx
@@ -26,6 +26,20 @@ vi.mock('../../../lib/tauri', () => ({
   },
 }));
 
+// Real Tauri v2 File objects never expose a filesystem path, so file selection
+// goes through the native dialog plugin (click) and the webview's own drag-drop
+// event (drop) instead of the browser File/DataTransfer APIs — see FilePickerStep.
+const mockDialogOpen = vi.fn();
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: (...args: unknown[]) => mockDialogOpen(...args),
+}));
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn().mockResolvedValue(() => {}),
+  }),
+}));
+
 const ACCOUNT: Account = {
   id: 'acct-1',
   name: 'TD Taxable',
@@ -81,10 +95,11 @@ function makePlan(overrides: Partial<ImportPlan> = {}): ImportPlan {
   };
 }
 
-function csvFileWithPath(path: string, name = 'holdings.csv'): File {
-  const file = new File(['symbol\nAAPL'], name, { type: 'text/csv' });
-  Object.defineProperty(file, 'path', { value: path, configurable: true });
-  return file;
+/** Clicks the dropzone, which opens the (mocked) native file dialog resolving to `path`. */
+async function selectFile(path: string) {
+  mockDialogOpen.mockResolvedValueOnce(path);
+  fireEvent.click(screen.getByTestId('file-dropzone'));
+  await waitFor(() => expect(mockDialogOpen).toHaveBeenCalled());
 }
 
 const mockOnClose = vi.fn();
@@ -138,8 +153,7 @@ describe('ImportWizardModal', () => {
     await selectAccount();
 
     mockParseImportFile.mockResolvedValue(makePlan());
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [csvFileWithPath('/tmp/holdings.csv')] } });
+    await selectFile('/tmp/holdings.csv');
 
     await waitFor(() =>
       expect(mockParseImportFile).toHaveBeenCalledWith({
@@ -170,8 +184,7 @@ describe('ImportWizardModal', () => {
       ],
     });
     mockParseImportFile.mockResolvedValueOnce(planWithUnmapped);
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [csvFileWithPath('/tmp/holdings.csv')] } });
+    await selectFile('/tmp/holdings.csv');
 
     expect(await screen.findByText('Weird Column')).toBeTruthy();
 
@@ -188,8 +201,7 @@ describe('ImportWizardModal', () => {
     await selectAccount();
 
     mockParseImportFile.mockResolvedValue(makePlan());
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [csvFileWithPath('/tmp/holdings.csv')] } });
+    await selectFile('/tmp/holdings.csv');
     await screen.findByText('AAPL');
 
     const commitResult: ImportCommitResult = {
@@ -225,8 +237,7 @@ describe('ImportWizardModal', () => {
     await selectAccount();
 
     mockParseImportFile.mockResolvedValue(makePlan());
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [csvFileWithPath('/tmp/holdings.csv')] } });
+    await selectFile('/tmp/holdings.csv');
     await screen.findByText('AAPL');
 
     mockCommitImport.mockRejectedValue(new Error('Database is locked'));
@@ -241,10 +252,7 @@ describe('ImportWizardModal', () => {
     await waitFor(() => expect(mockGetAccounts).toHaveBeenCalled());
     await selectAccount();
 
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    const badFile = new File(['x'], 'holdings.xlsx', { type: 'application/vnd.ms-excel' });
-    Object.defineProperty(badFile, 'path', { value: '/tmp/holdings.xlsx', configurable: true });
-    fireEvent.change(input, { target: { files: [badFile] } });
+    await selectFile('/tmp/holdings.xlsx');
 
     expect(await screen.findByText(/only \.csv files are supported/i)).toBeTruthy();
     expect(mockParseImportFile).not.toHaveBeenCalled();

--- a/frontend/components/import/constants.ts
+++ b/frontend/components/import/constants.ts
@@ -42,8 +42,7 @@ export function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-/** Non-standard Tauri v2 property present on File objects sourced from the webview
- * (both <input type="file"> selection and drag-drop), giving the real filesystem path. */
-export function extractFilePath(file: File): string | undefined {
-  return (file as File & { path?: string }).path;
+/** Last path segment, for display when all we have is a filesystem path (no File object). */
+export function fileNameFromPath(path: string): string {
+  return path.split(/[\\/]/).pop() || path;
 }

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -419,7 +419,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
 
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",

--- a/frontend/locales/es/translation.json
+++ b/frontend/locales/es/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/fr/translation.json
+++ b/frontend/locales/fr/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/ja/translation.json
+++ b/frontend/locales/ja/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/pl/translation.json
+++ b/frontend/locales/pl/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/pt/translation.json
+++ b/frontend/locales/pt/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/frontend/locales/zh/translation.json
+++ b/frontend/locales/zh/translation.json
@@ -405,7 +405,6 @@
   "importWizard.file.dropzone": "Drag and drop a .csv file, or click to browse",
   "importWizard.file.hint": "Max {{maxRows}} rows · .csv only",
   "importWizard.file.onlyCsv": "Only .csv files are supported right now.",
-  "importWizard.file.noPath": "Could not resolve a filesystem path for this file.",
   "importWizard.file.parsing": "Reading file…",
   "importWizard.mapping.description": "Some columns in this file couldn't be recognized automatically. Map them to a field below, or leave them ignored.",
   "importWizard.mapping.columns.source": "Source column",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "i18next": "^26.2.0",
         "lucide-react": "^1.28.0",
@@ -686,9 +687,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +704,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,9 +721,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -746,9 +738,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -766,9 +755,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,9 +772,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1001,9 +984,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,9 +1001,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,9 +1018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1061,9 +1035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1288,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1337,9 +1305,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1322,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1377,9 +1339,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1397,9 +1356,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1458,6 +1414,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.2.tgz",
+      "integrity": "sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {
@@ -4779,9 +4744,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4803,9 +4765,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4827,9 +4786,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4851,9 +4807,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "i18next": "^26.2.0",
     "lucide-react": "^1.28.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 portfolio-core = { path = "../portfolio-core", features = ["ts"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["json"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ struct LogGuard(#[allow(dead_code)] tracing_appender::non_blocking::WorkerGuard)
 pub fn run() {
     let result = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             let log_dir = app.path().app_log_dir()?;
             std::fs::create_dir_all(&log_dir)?;


### PR DESCRIPTION
## Summary
- Fixes #776 — selecting a file in Step 1 of the Import wizard always failed with "Could not resolve a filesystem path for this file."
- Root cause: Tauri v2 `File` objects handed to the webview (via `<input type="file">` selection or HTML5 drag-drop) never expose a real filesystem `.path` — that property only ever existed in Tauri v1. `ImportWizardModal.handleFileSelected` relied on it, so every selection failed before `parse_import_file` was ever invoked.
- Replaced the click-to-browse flow with `tauri-plugin-dialog`'s native `open()` picker, which returns a real OS path directly and needs no backend changes (`parse_import_file` already takes a `file_path: String`).
- Replaced the HTML5 drag-drop handler with the webview's own `onDragDropEvent` — Tauri v2 intercepts native OS drag-and-drop at the webview level by default, so `DataTransfer.files` never carried real files here either.
- Removed the now-dead `extractFilePath`/`.path` fallback and the `importWizard.file.noPath` error string (across all 8 locales) that only ever fired due to this bug.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npx vitest run` (421 tests, including rewritten `ImportWizardModal.test.tsx` which now mocks the dialog plugin and drag-drop event instead of faking a `.path` property on a browser `File`)
- [x] `cargo test -p portfolio-tracker import` (122 import-pipeline tests, unchanged and passing — backend contract untouched)
- [x] `cargo check` / `cargo clippy` with `tauri-plugin-dialog` registered in `lib.rs` and `dialog:allow-open` added to `capabilities/default.json`
- [ ] Manual click-to-browse and drag-and-drop verification in the packaged Tauri app (native dialog/webview APIs aren't exercisable from an automated browser preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)