### PR TITLE
fix: append counter to PDF export filename instead of overwriting same-day exports

### DIFF
--- a/src-tauri/src/commands/pdf.rs
+++ b/src-tauri/src/commands/pdf.rs
@@ -10,10 +10,12 @@ use super::portfolio::get_portfolio_impl;
 use super::{DbState, RealizedGainsCacheState};
 
 /// Builds a PDF snapshot of the current portfolio and saves it to
-/// `~/Downloads/portfolio-YYYY-MM-DD.pdf`, overwriting an existing file from the
-/// same day (consistent with `backup_database`'s same-day behavior). No
-/// destination path is accepted from the frontend — there is nothing here for
-/// `tauri-plugin-dialog` to add and no user-supplied path to validate.
+/// `~/Downloads/portfolio-YYYY-MM-DD.pdf`. If a file from the same day already
+/// exists, a `_1`, `_2`, ... counter is appended rather than silently
+/// overwriting it (unlike `backup_database`, which intentionally overwrites
+/// same-day backups). No destination path is accepted from the frontend —
+/// there is nothing here for `tauri-plugin-dialog` to add and no user-supplied
+/// path to validate.
 #[tauri::command]
 pub async fn export_portfolio_pdf(
     db: State<'_, DbState>,
@@ -33,13 +35,38 @@ pub async fn export_portfolio_pdf(
 /// Computes the save path and its display form from a home directory. Takes
 /// `home` as a parameter (rather than calling `dirs::home_dir()` itself) so it
 /// can be tested without touching the real filesystem or process environment.
+/// Appends a `_N` counter to the filename when today's export already exists,
+/// so repeated same-day exports never overwrite an earlier one.
 fn resolve_pdf_destination(home: &Path) -> (PathBuf, String) {
-    let filename = format!("portfolio-{}.pdf", Utc::now().format("%Y-%m-%d"));
-    let dest = home.join("Downloads").join(&filename);
+    let dir = home.join("Downloads");
+    let date = Utc::now().format("%Y-%m-%d").to_string();
+    let (filename, dest) = unique_pdf_path(&dir, &date, |path| path.exists());
     // Displayed directly in the frontend's success toast — showing `~/Downloads/...`
     // instead of the resolved absolute path avoids leaking the full home directory.
     let display_path = format!("~/Downloads/{filename}");
     (dest, display_path)
+}
+
+/// Finds the first available `portfolio-{date}[_N].pdf` filename in `dir`,
+/// starting from the bare date and counting up from `_1` once that's taken.
+/// `exists` is injected so this can be tested without touching the real
+/// filesystem.
+fn unique_pdf_path(dir: &Path, date: &str, exists: impl Fn(&Path) -> bool) -> (String, PathBuf) {
+    let base_filename = format!("portfolio-{date}.pdf");
+    let base_dest = dir.join(&base_filename);
+    if !exists(&base_dest) {
+        return (base_filename, base_dest);
+    }
+
+    let mut counter = 1u32;
+    loop {
+        let filename = format!("portfolio-{date}_{counter}.pdf");
+        let dest = dir.join(&filename);
+        if !exists(&dest) {
+            return (filename, dest);
+        }
+        counter += 1;
+    }
 }
 
 fn write_pdf_file(dest: &Path, bytes: &[u8]) -> Result<(), String> {
@@ -91,6 +118,70 @@ mod tests {
             ))
         );
         assert_eq!(display_path, format!("~/Downloads/portfolio-{today}.pdf"));
+    }
+
+    #[test]
+    fn resolve_pdf_destination_appends_a_counter_when_todays_export_already_exists() {
+        let scratch = ScratchDir::new("resolve-pdf-destination-counter");
+        let downloads = scratch.0.join("Downloads");
+        std::fs::create_dir_all(&downloads).expect("create Downloads dir");
+        let today = Utc::now().format("%Y-%m-%d");
+        std::fs::write(
+            downloads.join(format!("portfolio-{today}.pdf")),
+            b"first export",
+        )
+        .expect("seed first export");
+
+        let (dest, display_path) = resolve_pdf_destination(&scratch.0);
+
+        assert_eq!(dest, downloads.join(format!("portfolio-{today}_1.pdf")));
+        assert_eq!(display_path, format!("~/Downloads/portfolio-{today}_1.pdf"));
+    }
+
+    #[test]
+    fn resolve_pdf_destination_counts_past_multiple_existing_exports() {
+        let scratch = ScratchDir::new("resolve-pdf-destination-counter-multi");
+        let downloads = scratch.0.join("Downloads");
+        std::fs::create_dir_all(&downloads).expect("create Downloads dir");
+        let today = Utc::now().format("%Y-%m-%d");
+        std::fs::write(downloads.join(format!("portfolio-{today}.pdf")), b"first").unwrap();
+        std::fs::write(
+            downloads.join(format!("portfolio-{today}_1.pdf")),
+            b"second",
+        )
+        .unwrap();
+        std::fs::write(downloads.join(format!("portfolio-{today}_2.pdf")), b"third").unwrap();
+
+        let (dest, display_path) = resolve_pdf_destination(&scratch.0);
+
+        assert_eq!(dest, downloads.join(format!("portfolio-{today}_3.pdf")));
+        assert_eq!(display_path, format!("~/Downloads/portfolio-{today}_3.pdf"));
+    }
+
+    #[test]
+    fn unique_pdf_path_returns_bare_date_filename_when_nothing_exists() {
+        let dir = Path::new("/home/example-user/Downloads");
+
+        let (filename, dest) = unique_pdf_path(dir, "2026-08-09", |_| false);
+
+        assert_eq!(filename, "portfolio-2026-08-09.pdf");
+        assert_eq!(dest, dir.join("portfolio-2026-08-09.pdf"));
+    }
+
+    #[test]
+    fn unique_pdf_path_appends_first_available_counter() {
+        let dir = Path::new("/home/example-user/Downloads");
+        let taken = [
+            dir.join("portfolio-2026-08-09.pdf"),
+            dir.join("portfolio-2026-08-09_1.pdf"),
+        ];
+
+        let (filename, dest) = unique_pdf_path(dir, "2026-08-09", |path| {
+            taken.contains(&path.to_path_buf())
+        });
+
+        assert_eq!(filename, "portfolio-2026-08-09_2.pdf");
+        assert_eq!(dest, dir.join("portfolio-2026-08-09_2.pdf"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Exporting to PDF more than once on the same day silently overwrote `~/Downloads/portfolio-YYYY-MM-DD.pdf` from the earlier export.
- `resolve_pdf_destination` now checks whether today's file already exists and, if so, appends `_1`, `_2`, ... until it finds a filename that isn't taken (`portfolio-2026-08-09_1.pdf`, `portfolio-2026-08-09_2.pdf`, ...).
- The success toast already displays whatever path `export_portfolio_pdf` returns, so it now shows the actual saved filename with no frontend changes required.

## Test plan
- [x] `cargo test -p portfolio-tracker --lib commands::pdf` — new unit tests for `unique_pdf_path` and `resolve_pdf_destination` covering: no existing file, one existing file, multiple existing files
- [x] `cargo test -p portfolio-tracker --lib` — full suite (447 tests) passes
- [x] `cargo clippy -p portfolio-tracker --lib -- -D warnings` — clean
- [x] `cargo fmt -p portfolio-tracker -- --check` — clean
- [x] Pre-push hook (lint, typecheck, frontend build, backend build, backend tests, clippy) — all passed

Closes #780