### PR TITLE
fix: show first-snapshot state instead of misleading chart in Performance view

### DIFF
--- a/frontend/components/Performance.tsx
+++ b/frontend/components/Performance.tsx
@@ -249,6 +249,21 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
     );
   }
 
+  // A single snapshot (typically the first one, recorded right after an initial
+  // import + price refresh) can't produce a trend line or stats — Recharts draws
+  // nothing meaningful for a one-point area chart. Show an explicit "history is
+  // just starting" message instead of a chart that looks flat/broken.
+  if (data.length === 1) {
+    return (
+      <div style={{ ...PANEL }}>
+        <EmptyState
+          message="Only one snapshot recorded so far. Performance history will build up as prices are refreshed over time."
+          action={onRefresh ? { label: 'Refresh Prices', onClick: onRefresh } : undefined}
+        />
+      </div>
+    );
+  }
+
   if (filteredHoldings.length === 0) {
     return (
       <div style={{ ...PANEL }}>

--- a/frontend/components/__tests__/Performance.test.tsx
+++ b/frontend/components/__tests__/Performance.test.tsx
@@ -8,8 +8,10 @@ import { MOCK_SNAPSHOT } from '../../lib/mockData';
 // Initialize i18n (Performance uses useTranslation for locale-aware number formatting)
 import i18next from '../../lib/i18n';
 
+let mockIsTauri = false;
+
 vi.mock('../../lib/tauri', () => ({
-  isTauri: () => false,
+  isTauri: () => mockIsTauri,
   getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   tauriInvoke: vi.fn().mockResolvedValue([]),
 }));
@@ -19,6 +21,7 @@ beforeEach(() => {
   delete (window as any).__TAURI_INTERNALS__;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (window as any).__TAURI__;
+  mockIsTauri = false;
   vi.clearAllMocks();
 });
 
@@ -83,6 +86,19 @@ describe('Performance component', () => {
     renderPerformance({ portfolio: null, onRefresh });
     // With null portfolio, renders the "No portfolio data" empty state (no action shown)
     expect(screen.getByText(/no portfolio data available/i)).toBeTruthy();
+  });
+
+  it('shows a first-snapshot state instead of a misleading chart when only one snapshot exists', async () => {
+    const { tauriInvoke } = await import('../../lib/tauri');
+    mockIsTauri = true;
+    vi.mocked(tauriInvoke).mockResolvedValue([{ date: '2026-08-08', value: 100_000 }]);
+
+    renderPerformance({ portfolio: MOCK_SNAPSHOT as PortfolioSnapshot });
+
+    // Wait for the async get_performance call to resolve.
+    await screen.findByText(/only one snapshot recorded/i);
+    // The misleading single-point chart (and its now-meaningless stats row) must not render.
+    expect(screen.queryByText('Total Return')).toBeNull();
   });
 
   it('renders Max Drawdown and Annualized Volatility with German locale separators', async () => {


### PR DESCRIPTION
## Summary
- Fixes #787 — Performance view looked wrong immediately after a fresh import (flat/misleading chart).
- Root cause (per systematic investigation): the *recording* side was already correct — `refresh_prices` builds and inserts the portfolio snapshot from the freshly-fetched prices, and `ImportWizardModal`'s `onImported()` already triggers `refreshPrices()` right after `commit_import` succeeds. The bug is on the *rendering* side: `Performance.tsx` only special-cased **zero** snapshots (`perfIsEmpty`). With exactly **one** snapshot (the normal state right after a first import + refresh), it fell through to the full chart path, where a one-point Recharts `AreaChart` draws no visible line/area and `calcStats()` returns `null` (needs ≥2 points) — leaving a panel that looks flat/broken with no explanation and no stats.
- Fix: add an explicit `data.length === 1` branch that shows an `EmptyState` message ("Only one snapshot recorded so far...") with a Refresh Prices action, instead of rendering the misleading single-point chart.

## Test plan
- [x] Added a failing-first (TDD) unit test in `Performance.test.tsx` that mocks `get_performance` to resolve a single snapshot and asserts the new message renders instead of the (now suppressed) `Total Return` stats row.
- [x] `npx vitest run` — 43 files / 422 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] Manually verified in the dev-server browser preview that the normal multi-point Performance view (mock data path) still renders correctly with no console errors — no regression to the existing chart/stats rendering.
- [x] Pre-push hooks (lint, typecheck, frontend build, cargo build, clippy) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)