### PR TITLE
fix: hide Export to PDF button until table formatting is production-ready

### DIFF
--- a/frontend/components/Holdings.tsx
+++ b/frontend/components/Holdings.tsx
@@ -766,27 +766,30 @@ export function Holdings({ onOpenAddModal, onExportRef }: HoldingsProps) {
             <Download size={12} />
             {t('holdings.exportCsv')}
           </button>
-          <button
-            onClick={() => void handleExportPdf()}
-            disabled={isExportingPdf}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              padding: '6px 12px',
-              background: 'var(--bg-surface)',
-              border: '1px solid var(--border-primary)',
-              color: 'var(--text-primary)',
-              borderRadius: '2px',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              cursor: isExportingPdf ? 'not-allowed' : 'pointer',
-              opacity: isExportingPdf ? 0.6 : 1,
-            }}
-          >
-            <FileText size={12} />
-            {t('holdings.exportPdf')}
-          </button>
+          {/* TODO(#785): re-enable once the PDF table formatting is production-ready. */}
+          {import.meta.env.DEV && (
+            <button
+              onClick={() => void handleExportPdf()}
+              disabled={isExportingPdf}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                padding: '6px 12px',
+                background: 'var(--bg-surface)',
+                border: '1px solid var(--border-primary)',
+                color: 'var(--text-primary)',
+                borderRadius: '2px',
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                cursor: isExportingPdf ? 'not-allowed' : 'pointer',
+                opacity: isExportingPdf ? 0.6 : 1,
+              }}
+            >
+              <FileText size={12} />
+              {t('holdings.exportPdf')}
+            </button>
+          )}
           <button
             onClick={() => setImportOpen(true)}
             style={{


### PR DESCRIPTION
## Summary
- Gate the Holdings toolbar "Export PDF" button behind `import.meta.env.DEV` so it disappears in production builds, while remaining available for continued development.
- The button, its click handler, and in-flight state (`isExportingPdf`) are fully dead-code-eliminated from the production bundle (verified via `vite build`).
- No backend/Rust changes — `export_portfolio_pdf` and the underlying PDF generation command are untouched.
- Added a `TODO(#785)` comment marking where to re-enable the button once table formatting is production-ready.

Closes #785

## Test plan
- [x] `npx vitest run frontend/components/__tests__/HoldingsExportPdf.test.tsx` — 3/3 pass (DEV=true in Vitest, so existing button-behavior tests are unaffected)
- [x] `npx vitest run` — full suite, 422/422 tests pass
- [x] `npm run lint` / `tsc --noEmit` — clean
- [x] `vite build` (production mode) — confirmed `handleExportPdf` / `isExportingPdf` are absent from the output bundle
- [x] Pre-push hook (lint, typecheck, format, frontend+backend build, frontend+backend tests, clippy) — all passed