### PR TITLE
Fix import wizard dropdown height and rename final step title

### DIFF
--- a/frontend/components/import/__tests__/ImportWizardModal.test.tsx
+++ b/frontend/components/import/__tests__/ImportWizardModal.test.tsx
@@ -131,7 +131,7 @@ beforeEach(async () => {
 describe('ImportWizardModal', () => {
   it('renders nothing when isOpen=false', () => {
     renderModal({ isOpen: false });
-    expect(screen.queryByText('Import Plus Insights')).toBeNull();
+    expect(screen.queryByText('Import Summary')).toBeNull();
   });
 
   it('shows the desktop-only notice in browser mode', () => {
@@ -145,6 +145,14 @@ describe('ImportWizardModal', () => {
     await waitFor(() => expect(mockGetAccounts).toHaveBeenCalled());
     fireEvent.click(screen.getByRole('combobox'));
     expect(await screen.findByText('TD Taxable (Taxable)')).toBeTruthy();
+  });
+
+  it('keeps the account picker trigger non-empty before an account is selected', async () => {
+    renderModal();
+    const combobox = await screen.findByRole('combobox');
+    // Regression test for #774: an empty trigger label collapses the button's
+    // line box, making it shorter than once an account is picked.
+    expect(combobox.textContent).toBe(' ');
   });
 
   it('parses the file and auto-advances to preview when every column is mapped', async () => {

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -21,7 +21,10 @@ export function Select({ value, onChange, options, style }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const selectedOption = options.find((o) => o.value === value);
-  const selectedLabel = selectedOption?.label ?? value;
+  // Falls back to a non-breaking space (never a bare empty string) so the trigger's
+  // line box height stays constant whether or not a value is selected — an empty
+  // inline child collapses to zero height inside the flex trigger, shrinking the button.
+  const selectedLabel = selectedOption?.label || value || ' ';
 
   // Close on outside click
   useEffect(() => {

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -405,7 +405,7 @@
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
 
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/es/translation.json
+++ b/frontend/locales/es/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/fr/translation.json
+++ b/frontend/locales/fr/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/ja/translation.json
+++ b/frontend/locales/ja/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/pl/translation.json
+++ b/frontend/locales/pl/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/pt/translation.json
+++ b/frontend/locales/pt/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",

--- a/frontend/locales/zh/translation.json
+++ b/frontend/locales/zh/translation.json
@@ -392,7 +392,7 @@
   "import.status.checkFailed": "Check failed",
   "import.status.currencyMismatch": "Currency mismatch",
   "import.status.currencyMismatchDetail": "Currency mismatch — file: {{actual}}, holding: {{expected}}",
-  "importWizard.title": "Import Plus Insights",
+  "importWizard.title": "Import Summary",
   "importWizard.back": "Back",
   "importWizard.continue": "Continue",
   "importWizard.desktopOnly": "Import is only available in the desktop app.",


### PR DESCRIPTION
## Summary
- Fix `Select`'s trigger falling back to a bare empty string when no option is selected — an empty inline child collapses the flex trigger's line box, making the "Import into account" dropdown shorter than every other populated dropdown in the app. Falls back to a non-breaking space instead, matching the height of a populated selection.
- Rename the import wizard's title from "Import Plus Insights" to "Import Summary" across all locale files.

## Test plan
- [x] `npx vitest run` — 423 tests pass, including a new regression test asserting the account-picker trigger keeps non-empty content before selection
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Pre-push hook (lint, typecheck, format, frontend+backend build, frontend+backend tests, clippy) — all passed

Closes #774
Closes #775