### PR TITLE
fix: authenticate Yahoo Finance quote requests with cookie+crumb (#789)

### DIFF
--- a/src-tauri/src/commands/watchlists.rs
+++ b/src-tauri/src/commands/watchlists.rs
@@ -52,7 +52,8 @@ async fn fetch_and_store_snapshot(
         }
         Err(e) => {
             tracing::warn!("Failed to fetch watchlist snapshot for {}: {}", symbol, e);
-            db::upsert_watchlist_item_snapshot(pool, item_id, None, Some(&e)).await?
+            let user_message = crate::price::user_safe_watchlist_error(symbol, &e);
+            db::upsert_watchlist_item_snapshot(pool, item_id, None, Some(&user_message)).await?
         }
     }
     Ok(())

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -16,6 +16,17 @@ pub const YAHOO_CHART_URL: &str =
 
 pub const YAHOO_QUOTE_URL: &str = "https://query1.finance.yahoo.com/v7/finance/quote?symbols={}";
 
+/// Endpoint hit once to obtain the session cookie Yahoo Finance requires
+/// before it will issue a crumb token. Any Yahoo Finance host works; this
+/// one returns quickly and needs no query parameters.
+pub const YAHOO_COOKIE_URL: &str = "https://fc.yahoo.com";
+
+/// Exchanges the session cookie from [`YAHOO_COOKIE_URL`] for a crumb token.
+/// The v7 quote endpoint has required a matching cookie + crumb pair since
+/// Yahoo tightened access to it (see #789); the v8 chart endpoint above is
+/// unaffected.
+pub const YAHOO_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getcrumb";
+
 /// Endpoint for per-symbol fundamental metadata (sector, industry, country).
 /// Replace `{}` with the symbol. Returns `quoteSummary.result[0].assetProfile`.
 pub const YAHOO_QUOTE_SUMMARY_URL: &str =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod stress;
 #[cfg(test)]
 mod test_helpers;
 pub mod types;
+mod yahoo_auth;
 
 use commands::{
     BackupLockState, DbState, HttpClient, RateLimiterState, RealizedGainsCacheState,

--- a/src-tauri/src/price.rs
+++ b/src-tauri/src/price.rs
@@ -3,6 +3,7 @@ use reqwest::Client;
 
 use crate::config::{USER_AGENT, YAHOO_CHART_URL, YAHOO_QUOTE_URL};
 use crate::types::PriceData;
+use crate::yahoo_auth::{get_yahoo_crumb, invalidate_yahoo_crumb, YahooCrumb};
 
 /// Validate a ticker symbol before it is interpolated into a Yahoo Finance URL.
 ///
@@ -184,27 +185,45 @@ pub struct WatchlistSnapshotData {
 }
 
 /// Fetch a single symbol's research-watchlist market data snapshot.
+///
+/// The v7 quote endpoint this hits requires a session cookie + crumb token
+/// (see #789); `yahoo_auth` caches that pair process-wide so most calls skip
+/// the handshake. If the cached crumb has gone stale (Yahoo rejects it with
+/// 401), it's refreshed once and the request retried before giving up.
 pub async fn fetch_watchlist_snapshot(
     client: &Client,
     symbol: &str,
 ) -> Result<WatchlistSnapshotData, String> {
-    fetch_watchlist_snapshot_internal(client, symbol, YAHOO_QUOTE_URL).await
+    let crumb = get_yahoo_crumb(client).await?;
+    match fetch_watchlist_snapshot_internal(client, symbol, YAHOO_QUOTE_URL, &crumb).await {
+        Err(e) if e.contains("HTTP 401") => {
+            invalidate_yahoo_crumb().await;
+            let fresh_crumb = get_yahoo_crumb(client).await?;
+            fetch_watchlist_snapshot_internal(client, symbol, YAHOO_QUOTE_URL, &fresh_crumb).await
+        }
+        other => other,
+    }
 }
 
 /// Internal implementation accepting a configurable URL template so tests can
-/// point it at a mock server, mirroring `fetch_price_internal`.
+/// point it at a mock server, mirroring `fetch_price_internal`. Takes an
+/// already-obtained crumb rather than fetching one itself, keeping request
+/// construction independently testable from the crumb handshake.
 async fn fetch_watchlist_snapshot_internal(
     client: &Client,
     symbol: &str,
     url_template: &str,
+    crumb: &YahooCrumb,
 ) -> Result<WatchlistSnapshotData, String> {
     validate_symbol(symbol)?;
     let encoded_symbol = urlencoding::encode(symbol);
-    let url = url_template.replace("{}", &encoded_symbol);
+    let base_url = url_template.replace("{}", &encoded_symbol);
+    let url = format!("{}&crumb={}", base_url, urlencoding::encode(&crumb.crumb));
 
     let response = client
         .get(&url)
         .header("User-Agent", USER_AGENT)
+        .header(reqwest::header::COOKIE, &crumb.cookie)
         .send()
         .await
         .map_err(|e| format!("Request failed for {}: {}", symbol, e))?;
@@ -245,6 +264,29 @@ async fn fetch_watchlist_snapshot_internal(
             .and_then(|v| v.as_f64()),
         pe_ratio: item.get("trailingPE").and_then(|v| v.as_f64()),
     })
+}
+
+/// Translates a raw watchlist snapshot fetch error (network failure, HTTP
+/// status, JSON parse failure) into a message safe to store and show
+/// directly to the user — no raw status codes or endpoint internals they
+/// can't act on. Callers should still log the raw error for diagnosis.
+pub fn user_safe_watchlist_error(symbol: &str, raw_error: &str) -> String {
+    if raw_error.contains("HTTP 401") || raw_error.contains("HTTP 403") {
+        format!(
+            "Unable to fetch market data for {}: the data provider rejected the request. Please try again later.",
+            symbol
+        )
+    } else if raw_error.starts_with("Request failed") {
+        format!(
+            "Unable to fetch market data for {}: network request failed. Check your connection and try again.",
+            symbol
+        )
+    } else {
+        format!(
+            "Unable to fetch market data for {}. Please try again later.",
+            symbol
+        )
+    }
 }
 
 #[cfg(test)]
@@ -548,6 +590,16 @@ mod tests {
         format!("{}/v7/finance/quote?symbols={{}}", server.url())
     }
 
+    /// Stub crumb used by tests that exercise request construction directly,
+    /// bypassing the real cookie/crumb handshake (covered separately in
+    /// `yahoo_auth`'s own tests).
+    fn stub_crumb() -> YahooCrumb {
+        YahooCrumb {
+            crumb: "test-crumb".to_string(),
+            cookie: "test-cookie".to_string(),
+        }
+    }
+
     #[tokio::test]
     async fn fetch_watchlist_snapshot_parses_all_fields() {
         let mut server = mockito::Server::new_async().await;
@@ -572,7 +624,8 @@ mod tests {
         .to_string();
 
         let _mock = server
-            .mock("GET", "/v7/finance/quote?symbols=AAPL")
+            .mock("GET", "/v7/finance/quote?symbols=AAPL&crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(&body)
@@ -581,7 +634,8 @@ mod tests {
 
         let client = make_client();
         let url_template = mock_quote_url_template(&server);
-        let result = fetch_watchlist_snapshot_internal(&client, "AAPL", &url_template).await;
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "AAPL", &url_template, &stub_crumb()).await;
 
         assert!(result.is_ok(), "expected Ok, got {:?}", result);
         let snap = result.unwrap();
@@ -614,7 +668,8 @@ mod tests {
         .to_string();
 
         let _mock = server
-            .mock("GET", "/v7/finance/quote?symbols=VOO")
+            .mock("GET", "/v7/finance/quote?symbols=VOO&crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(&body)
@@ -623,7 +678,8 @@ mod tests {
 
         let client = make_client();
         let url_template = mock_quote_url_template(&server);
-        let result = fetch_watchlist_snapshot_internal(&client, "VOO", &url_template).await;
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "VOO", &url_template, &stub_crumb()).await;
 
         assert!(result.is_ok(), "expected Ok, got {:?}", result);
         let snap = result.unwrap();
@@ -642,7 +698,8 @@ mod tests {
         .to_string();
 
         let _mock = server
-            .mock("GET", "/v7/finance/quote?symbols=INVALID")
+            .mock("GET", "/v7/finance/quote?symbols=INVALID&crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(&body)
@@ -651,7 +708,9 @@ mod tests {
 
         let client = make_client();
         let url_template = mock_quote_url_template(&server);
-        let result = fetch_watchlist_snapshot_internal(&client, "INVALID", &url_template).await;
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "INVALID", &url_template, &stub_crumb())
+                .await;
 
         assert!(result.is_err(), "expected Err on empty result array");
     }
@@ -663,6 +722,7 @@ mod tests {
             &client,
             "../../etc/passwd",
             "https://example.invalid/{}",
+            &stub_crumb(),
         )
         .await;
         assert!(result.is_err());
@@ -673,7 +733,8 @@ mod tests {
     async fn fetch_watchlist_snapshot_http_error_returns_error() {
         let mut server = mockito::Server::new_async().await;
         let _mock = server
-            .mock("GET", "/v7/finance/quote?symbols=TSLA")
+            .mock("GET", "/v7/finance/quote?symbols=TSLA&crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
             .with_status(403)
             .with_body("Forbidden")
             .create_async()
@@ -681,9 +742,84 @@ mod tests {
 
         let client = make_client();
         let url_template = mock_quote_url_template(&server);
-        let result = fetch_watchlist_snapshot_internal(&client, "TSLA", &url_template).await;
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "TSLA", &url_template, &stub_crumb()).await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("403"));
+    }
+
+    /// Regression test for #789: the quote request must carry the crumb as a
+    /// query parameter and the session cookie as a `Cookie` header, and a 401
+    /// response (the exact failure mode from the issue) must surface as a
+    /// clear "HTTP 401" error rather than a parse failure or panic.
+    #[tokio::test]
+    async fn fetch_watchlist_snapshot_401_response_returns_clear_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/v7/finance/quote?symbols=AAPL&crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
+            .with_status(401)
+            .with_body("Unauthorized")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url_template = mock_quote_url_template(&server);
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "AAPL", &url_template, &stub_crumb()).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("401"), "expected 401 in error, got: {}", err);
+
+        // And that raw error maps to a user-safe message rather than being
+        // shown to the user verbatim.
+        let user_message = user_safe_watchlist_error("AAPL", &err);
+        assert!(!user_message.contains("401"));
+        assert!(user_message.contains("AAPL"));
+    }
+
+    #[tokio::test]
+    async fn fetch_watchlist_snapshot_omits_crumb_request_fails_auth_check() {
+        // A request missing the crumb param or cookie header must not match
+        // the mock, proving the real implementation actually sends both
+        // rather than the test passing vacuously.
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/v7/finance/quote?symbols=AAPL")
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let url_template = mock_quote_url_template(&server);
+        let result =
+            fetch_watchlist_snapshot_internal(&client, "AAPL", &url_template, &stub_crumb()).await;
+
+        // No mock matches "?symbols=AAPL&crumb=..." exactly, so mockito's
+        // server falls back to a 501, confirming the crumb is always sent.
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("501"));
+    }
+
+    // ── user_safe_watchlist_error ────────────────────────────────────────────
+
+    #[test]
+    fn user_safe_watchlist_error_maps_401_without_leaking_status_code() {
+        let msg = user_safe_watchlist_error("AAPL", "HTTP 401 for symbol AAPL");
+        assert!(msg.contains("AAPL"));
+        assert!(!msg.contains("401"));
+        assert!(!msg.to_lowercase().contains("http"));
+    }
+
+    #[test]
+    fn user_safe_watchlist_error_maps_network_failure() {
+        let msg = user_safe_watchlist_error("TSLA", "Request failed for TSLA: connect timeout");
+        assert!(msg.contains("TSLA"));
+        assert!(
+            msg.to_lowercase().contains("connection") || msg.to_lowercase().contains("network")
+        );
     }
 }

--- a/src-tauri/src/yahoo_auth.rs
+++ b/src-tauri/src/yahoo_auth.rs
@@ -1,0 +1,264 @@
+//! Yahoo Finance session handshake for endpoints that require a crumb token.
+//!
+//! Yahoo's v7 `/finance/quote` endpoint (used by the Research Watchlist
+//! snapshot fetch) started rejecting unauthenticated requests with HTTP 401
+//! (see #789). A request now needs a session cookie plus a crumb token
+//! derived from that cookie. The v8 `/finance/chart` endpoint used by the
+//! main price-refresh path is unaffected and needs no change.
+//!
+//! The handshake takes two extra HTTP round trips, so the resulting crumb is
+//! cached process-wide and only refreshed when a caller reports it stopped
+//! working (crumbs can expire independently of any TTL we could predict).
+
+use reqwest::Client;
+use tokio::sync::RwLock;
+
+use crate::config::USER_AGENT;
+
+/// Session credentials required by Yahoo Finance's v7 quote endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct YahooCrumb {
+    pub crumb: String,
+    pub cookie: String,
+}
+
+static CRUMB_CACHE: RwLock<Option<YahooCrumb>> = RwLock::const_new(None);
+
+/// Returns the cached crumb, fetching a fresh one on first use.
+pub async fn get_yahoo_crumb(client: &Client) -> Result<YahooCrumb, String> {
+    if let Some(cached) = CRUMB_CACHE.read().await.clone() {
+        return Ok(cached);
+    }
+    refresh_yahoo_crumb(client).await
+}
+
+/// Discards any cached crumb and fetches a fresh one. Call this when a
+/// request made with the cached crumb comes back 401, then retry once.
+pub async fn refresh_yahoo_crumb(client: &Client) -> Result<YahooCrumb, String> {
+    let fresh = fetch_yahoo_crumb(
+        client,
+        crate::config::YAHOO_COOKIE_URL,
+        crate::config::YAHOO_CRUMB_URL,
+    )
+    .await?;
+    *CRUMB_CACHE.write().await = Some(fresh.clone());
+    Ok(fresh)
+}
+
+/// Drops the cached crumb without fetching a replacement. Exposed so a
+/// caller that gets 401 with a stale crumb can invalidate before deciding
+/// whether to retry.
+pub async fn invalidate_yahoo_crumb() {
+    *CRUMB_CACHE.write().await = None;
+}
+
+/// Performs the two-step handshake: fetch a session cookie, then exchange it
+/// for a crumb. `cookie_url`/`crumb_url` are parameterized so tests can point
+/// this at a mock server instead of the real Yahoo Finance hosts.
+async fn fetch_yahoo_crumb(
+    client: &Client,
+    cookie_url: &str,
+    crumb_url: &str,
+) -> Result<YahooCrumb, String> {
+    let cookie_response = client
+        .get(cookie_url)
+        .header("User-Agent", USER_AGENT)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to establish Yahoo Finance session: {}", e))?;
+
+    let cookie = cookie_response
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        // Each Set-Cookie header is "name=value; Path=/; ...";  only the
+        // "name=value" part before the first `;` belongs in a Cookie header.
+        .map(|raw| raw.split(';').next().unwrap_or(raw).trim().to_string())
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    if cookie.is_empty() {
+        return Err("Yahoo Finance did not return a session cookie".to_string());
+    }
+
+    let crumb_response = client
+        .get(crumb_url)
+        .header("User-Agent", USER_AGENT)
+        .header(reqwest::header::COOKIE, &cookie)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch Yahoo Finance crumb: {}", e))?;
+
+    if !crumb_response.status().is_success() {
+        return Err(format!(
+            "HTTP {} fetching Yahoo Finance crumb",
+            crumb_response.status()
+        ));
+    }
+
+    let crumb = crumb_response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Yahoo Finance crumb response: {}", e))?
+        .trim()
+        .to_string();
+
+    if crumb.is_empty() {
+        return Err("Yahoo Finance returned an empty crumb".to_string());
+    }
+
+    Ok(YahooCrumb { crumb, cookie })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_client() -> Client {
+        Client::new()
+    }
+
+    #[tokio::test]
+    async fn fetch_yahoo_crumb_success_returns_cookie_and_crumb() {
+        let mut server = mockito::Server::new_async().await;
+        let _cookie_mock = server
+            .mock("GET", "/cookie")
+            .with_status(200)
+            .with_header("set-cookie", "A3=abc123; Path=/; Domain=.yahoo.com; Secure")
+            .with_body("")
+            .create_async()
+            .await;
+        let _crumb_mock = server
+            .mock("GET", "/crumb")
+            .match_header("cookie", "A3=abc123")
+            .with_status(200)
+            .with_body("a.crumbValue")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let cookie_url = format!("{}/cookie", server.url());
+        let crumb_url = format!("{}/crumb", server.url());
+        let result = fetch_yahoo_crumb(&client, &cookie_url, &crumb_url).await;
+
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        let creds = result.unwrap();
+        assert_eq!(creds.crumb, "a.crumbValue");
+        assert_eq!(creds.cookie, "A3=abc123");
+    }
+
+    #[tokio::test]
+    async fn fetch_yahoo_crumb_missing_cookie_returns_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _cookie_mock = server
+            .mock("GET", "/cookie")
+            .with_status(200)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let cookie_url = format!("{}/cookie", server.url());
+        let result = fetch_yahoo_crumb(&client, &cookie_url, "https://example.invalid/crumb").await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("session cookie"));
+    }
+
+    #[tokio::test]
+    async fn fetch_yahoo_crumb_http_error_on_crumb_request_returns_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _cookie_mock = server
+            .mock("GET", "/cookie")
+            .with_status(200)
+            .with_header("set-cookie", "A3=abc123; Path=/")
+            .with_body("")
+            .create_async()
+            .await;
+        let _crumb_mock = server
+            .mock("GET", "/crumb")
+            .with_status(401)
+            .with_body("Unauthorized")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let cookie_url = format!("{}/cookie", server.url());
+        let crumb_url = format!("{}/crumb", server.url());
+        let result = fetch_yahoo_crumb(&client, &cookie_url, &crumb_url).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("401"));
+    }
+
+    #[tokio::test]
+    async fn fetch_yahoo_crumb_empty_crumb_body_returns_error() {
+        let mut server = mockito::Server::new_async().await;
+        let _cookie_mock = server
+            .mock("GET", "/cookie")
+            .with_status(200)
+            .with_header("set-cookie", "A3=abc123; Path=/")
+            .with_body("")
+            .create_async()
+            .await;
+        let _crumb_mock = server
+            .mock("GET", "/crumb")
+            .with_status(200)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let cookie_url = format!("{}/cookie", server.url());
+        let crumb_url = format!("{}/crumb", server.url());
+        let result = fetch_yahoo_crumb(&client, &cookie_url, &crumb_url).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("empty crumb"));
+    }
+
+    #[tokio::test]
+    async fn get_yahoo_crumb_caches_after_first_fetch() {
+        // Uses the real process-wide cache, so run against real-looking mock
+        // endpoints once, then confirm a second call doesn't need the mocks
+        // (mockito would panic on an unexpected call once `.expect(1)` is hit).
+        invalidate_yahoo_crumb().await;
+
+        let mut server = mockito::Server::new_async().await;
+        let cookie_mock = server
+            .mock("GET", "/cookie-cache-test")
+            .with_status(200)
+            .with_header("set-cookie", "A3=cached; Path=/")
+            .with_body("")
+            .expect(1)
+            .create_async()
+            .await;
+        let crumb_mock = server
+            .mock("GET", "/crumb-cache-test")
+            .with_status(200)
+            .with_body("cached-crumb")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let cookie_url = format!("{}/cookie-cache-test", server.url());
+        let crumb_url = format!("{}/crumb-cache-test", server.url());
+
+        let first = fetch_yahoo_crumb(&client, &cookie_url, &crumb_url)
+            .await
+            .expect("first fetch should succeed");
+        *CRUMB_CACHE.write().await = Some(first.clone());
+
+        let second = get_yahoo_crumb(&client)
+            .await
+            .expect("second call should hit the cache, not the network");
+
+        assert_eq!(first, second);
+        cookie_mock.assert_async().await;
+        crumb_mock.assert_async().await;
+
+        invalidate_yahoo_crumb().await;
+    }
+}


### PR DESCRIPTION
## Summary
- Root cause: Yahoo Finance's `v7/finance/quote` endpoint — used by the Research Watchlist snapshot fetch (`price::fetch_watchlist_snapshot`) — now requires a session cookie + crumb token. Requests with only a `User-Agent` header are rejected with HTTP 401. Confirmed live: `curl` against the endpoint returns 401 unauthenticated and 200 once a cookie + crumb are supplied.
- The main price-refresh path (`refresh_prices` / `fetch_price`) uses the `v8/finance/chart` endpoint instead, which has no such requirement — that's why it kept working while adding a watchlist symbol did not.
- Adds a new `yahoo_auth` module that performs the cookie → crumb handshake, caches the result process-wide (avoiding two extra round trips per request), and refreshes once if a quote request still comes back 401.
- `fetch_watchlist_snapshot_internal` now takes the crumb as an explicit parameter, keeping request construction (crumb query param + `Cookie` header) independently testable from the handshake itself.
- Raw fetch errors are mapped to a user-safe message (`price::user_safe_watchlist_error`) before being stored against the watchlist item, instead of surfacing raw HTTP status text to the UI.

Closes #789

## Changes
- `src-tauri/src/yahoo_auth.rs` (new) — cookie/crumb handshake + process-wide cache, with its own unit tests
- `src-tauri/src/price.rs` — `fetch_watchlist_snapshot` now fetches/retries the crumb; `fetch_watchlist_snapshot_internal` takes a crumb param; adds `user_safe_watchlist_error`
- `src-tauri/src/commands/watchlists.rs` — stores the user-safe error message instead of the raw fetch error
- `src-tauri/src/config.rs` — adds `YAHOO_COOKIE_URL` / `YAHOO_CRUMB_URL` constants

## Test plan
- [x] `cargo test --lib` — 468 passed, including new/updated `price::tests::*` and `yahoo_auth::tests::*` covering: crumb handshake success/failure paths, cached-crumb reuse, request construction (crumb param + Cookie header sent), a 401 regression test with mapping to a user-safe message, and the existing snapshot-parsing tests updated for the new signature
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manually verified the real implementation against **live** Yahoo Finance (temporary `#[ignore]` smoke test hitting `fetch_watchlist_snapshot(&client, "AAPL")`, confirmed it returns a populated snapshot, then removed before commit — not part of the committed test suite)
- [x] Full pre-push pipeline (lint, typecheck, frontend build, backend build, 433 frontend tests, 468 backend tests, clippy) passed
- [ ] Manual click-through in a real Tauri build: open Research tab → add AAPL to a watchlist → confirm it populates instead of showing the 401 error (not run here; no Tauri app window in this environment)