### PR TITLE
fix: remove portfolio statistics from sidebar

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -39,7 +39,7 @@ export function Layout({
         background: 'var(--bg-primary)',
       }}
     >
-      <Sidebar portfolio={portfolio} unseenAlertCount={unseenAlertCount} />
+      <Sidebar unseenAlertCount={unseenAlertCount} />
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
         <TopBar
           portfolio={portfolio}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -17,14 +17,10 @@ import {
   ChevronsLeft,
   ChevronsRight,
 } from 'lucide-react';
-import { formatCompact } from '../lib/format';
-import { pnlColor } from '../lib/colors';
-import type { PortfolioSnapshot } from '../types/portfolio';
 
 const STORAGE_KEY = 'sidebar-expanded';
 
 interface SidebarProps {
-  portfolio: PortfolioSnapshot | null;
   unseenAlertCount?: number | undefined;
 }
 
@@ -43,16 +39,13 @@ const NAV_ITEM_DEFS = [
   { to: '/help', key: 'nav.help', Icon: HelpCircle },
 ];
 
-export function Sidebar({ portfolio, unseenAlertCount = 0 }: SidebarProps) {
+export function Sidebar({ unseenAlertCount = 0 }: SidebarProps) {
   const { t } = useTranslation();
   const navItems = NAV_ITEM_DEFS.map((item) => ({ ...item, label: t(item.key) }));
   const [expanded, setExpanded] = useState(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     return stored === null ? false : stored === 'true';
   });
-  const totalValue = portfolio?.totalValue ?? 0;
-  const dailyPnl = portfolio?.dailyPnl ?? 0;
-  const baseCurrency = portfolio?.baseCurrency ?? 'CAD';
 
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, String(expanded));
@@ -192,40 +185,6 @@ export function Sidebar({ portfolio, unseenAlertCount = 0 }: SidebarProps) {
             </NavLink>
           );
         })}
-      </div>
-
-      {/* Portfolio mini value */}
-      <div
-        style={{
-          padding: expanded ? '16px 20px' : '16px 0',
-          borderTop: '1px solid var(--border-subtle)',
-          textAlign: expanded ? 'left' : 'center',
-        }}
-      >
-        <div
-          style={{
-            fontFamily: 'var(--font-mono)',
-            fontSize: 13,
-            fontWeight: 600,
-            color: 'var(--text-primary)',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {formatCompact(totalValue, baseCurrency)}
-        </div>
-        {expanded && (
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: pnlColor(dailyPnl),
-              marginTop: 2,
-            }}
-          >
-            {dailyPnl >= 0 ? '+' : ''}
-            {formatCompact(Math.abs(dailyPnl), baseCurrency)} today
-          </div>
-        )}
       </div>
 
       {/* Toggle button */}


### PR DESCRIPTION
## Summary
- Removes the embedded portfolio value / daily P&L block from the sidebar so it goes back to being a clean, navigation-only panel.
- Drops the now-unused `portfolio` prop and its imports (`formatCompact`, `pnlColor`, `PortfolioSnapshot`) from `Sidebar.tsx`.
- Updates `Layout.tsx` to stop passing `portfolio` into `Sidebar` (it's still passed to `TopBar`, which needs it).
- Portfolio stats remain fully visible on the Dashboard — nothing is removed from the app, just de-duplicated from the sidebar.

Closes #790

## Test plan
- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npx vitest run` — 433/433 tests passing
- [x] Verified visually in a local dev server: sidebar shows nav-only content in both collapsed and expanded states, with no overflow/layout regression; Dashboard still shows total value and daily P&L