### PR TITLE
fix: exclude pre-import snapshot history and limit account filter to present accounts

### DIFF
--- a/frontend/components/Performance.tsx
+++ b/frontend/components/Performance.tsx
@@ -167,6 +167,14 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
     });
   }, [portfolio, accountFilter, assetFilter]);
 
+  // Account filter options limited to account types actually present in the
+  // portfolio, matching the same fix already applied to the Dashboard (#784).
+  const availableAccountOptions = useMemo(() => {
+    if (!portfolio) return [];
+    const present = new Set(portfolio.holdings.map((h) => h.account));
+    return ACCOUNT_OPTIONS.filter((opt) => present.has(opt.value));
+  }, [portfolio]);
+
   const filteredValue = useMemo(
     () => filteredHoldings.reduce((sum, holding) => sum + holding.marketValueCad, 0),
     [filteredHoldings]
@@ -274,7 +282,10 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
               onChange={(value) => updateParam('account', value)}
               options={[
                 { value: 'all', label: 'All Accounts' },
-                ...ACCOUNT_OPTIONS.map((option) => ({ value: option.value, label: option.label })),
+                ...availableAccountOptions.map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                })),
               ]}
             />
           </div>
@@ -319,7 +330,7 @@ export function Performance({ portfolio, onRefresh }: PerformanceProps) {
                 onChange={(value) => updateParam('account', value)}
                 options={[
                   { value: 'all', label: 'All Accounts' },
-                  ...ACCOUNT_OPTIONS.map((option) => ({
+                  ...availableAccountOptions.map((option) => ({
                     value: option.value,
                     label: option.label,
                   })),

--- a/frontend/components/__tests__/Performance.test.tsx
+++ b/frontend/components/__tests__/Performance.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { Performance } from '../Performance';
 import type { PortfolioSnapshot } from '../../types/portfolio';
@@ -99,6 +99,26 @@ describe('Performance component', () => {
     await screen.findByText(/only one snapshot recorded/i);
     // The misleading single-point chart (and its now-meaningless stats row) must not render.
     expect(screen.queryByText('Total Return')).toBeNull();
+  });
+
+  it('limits the account filter to account types actually present in the portfolio (#787)', () => {
+    renderPerformance({ portfolio: MOCK_SNAPSHOT as PortfolioSnapshot });
+
+    // MOCK_SNAPSHOT only has tfsa/rrsp/taxable/cash holdings — fhsa/crypto/other
+    // must not appear as selectable options.
+    const accountCombobox = screen.getAllByRole('combobox')[0]!;
+    fireEvent.click(accountCombobox);
+    const listbox = screen.getByRole('listbox');
+    const optionLabels = within(listbox)
+      .getAllByRole('option')
+      .map((el) => el.textContent);
+
+    expect(optionLabels).toEqual(
+      expect.arrayContaining(['All Accounts', 'TFSA', 'RRSP', 'Taxable', 'Cash'])
+    );
+    expect(optionLabels).not.toEqual(expect.arrayContaining(['FHSA']));
+    expect(optionLabels).not.toEqual(expect.arrayContaining(['Crypto']));
+    expect(optionLabels).not.toEqual(expect.arrayContaining(['Other']));
   });
 
   it('renders Max Drawdown and Annualized Volatility with German locale separators', async () => {

--- a/src-tauri/src/commands/prices.rs
+++ b/src-tauri/src/commands/prices.rs
@@ -323,9 +323,34 @@ pub async fn get_performance(
     };
 
     let pool = &db.0;
-    let snapshots = db::get_snapshots_in_range(pool, &start, &end).await?;
+    let holdings = db::get_all_holdings(pool).await?;
 
-    // Deduplicate by calendar date, keeping only the latest snapshot per day.
+    // A snapshot recorded before the oldest currently-held position existed
+    // describes a holdings composition that has since been fully replaced —
+    // e.g. leftover snapshots from earlier dev/test holdings, recorded
+    // before a from-scratch CSV import — and would otherwise splice a
+    // misleading cliff into what should read as "this portfolio's" history
+    // immediately after that import. See #787.
+    let earliest_holding_date: Option<String> = holdings
+        .iter()
+        .map(|h| h.created_at.clone())
+        .min()
+        .and_then(|s| s.get(..10).map(str::to_string));
+
+    let snapshots = db::get_snapshots_in_range(pool, &start, &end).await?;
+    Ok(dedupe_and_filter_snapshots(
+        snapshots,
+        earliest_holding_date.as_deref(),
+    ))
+}
+
+/// Deduplicates snapshot points by calendar date (keeping the latest
+/// snapshot per day) and drops any that predate `earliest_holding_date`
+/// (`YYYY-MM-DD`), when given — see the doc comment on `get_performance`.
+fn dedupe_and_filter_snapshots(
+    snapshots: Vec<PerformancePoint>,
+    earliest_holding_date: Option<&str>,
+) -> Vec<PerformancePoint> {
     let mut by_date: std::collections::BTreeMap<String, PerformancePoint> =
         std::collections::BTreeMap::new();
     for point in snapshots {
@@ -340,7 +365,76 @@ pub async fn get_performance(
                 continue;
             }
         };
+        if let Some(cutoff) = earliest_holding_date {
+            if date_key.as_str() < cutoff {
+                continue;
+            }
+        }
         by_date.insert(date_key, point);
     }
-    Ok(by_date.into_values().collect())
+    by_date.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn point(date: &str, value: f64) -> PerformancePoint {
+        PerformancePoint {
+            date: date.to_string(),
+            value,
+        }
+    }
+
+    #[test]
+    fn keeps_only_latest_snapshot_per_calendar_day() {
+        let snapshots = vec![
+            point("2026-08-01T09:00:00", 100.0),
+            point("2026-08-01T15:00:00", 110.0),
+            point("2026-08-02T09:00:00", 120.0),
+        ];
+        let result = dedupe_and_filter_snapshots(snapshots, None);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].value, 110.0);
+        assert_eq!(result[1].value, 120.0);
+    }
+
+    #[test]
+    fn drops_snapshots_recorded_before_the_oldest_holding() {
+        // Stale snapshots from before a from-scratch import (e.g. leftover
+        // dev/test data worth millions) must not be spliced onto the
+        // current portfolio's history. See #787.
+        let snapshots = vec![
+            point("2026-01-01T09:00:00", 4_000_000.0),
+            point("2026-08-09T09:00:00", 420_000.0),
+        ];
+        let result = dedupe_and_filter_snapshots(snapshots, Some("2026-08-09"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 420_000.0);
+    }
+
+    #[test]
+    fn keeps_snapshot_recorded_on_the_same_day_the_holding_was_created() {
+        let snapshots = vec![point("2026-08-09T09:00:00", 420_000.0)];
+        let result = dedupe_and_filter_snapshots(snapshots, Some("2026-08-09"));
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn no_cutoff_keeps_full_history() {
+        let snapshots = vec![
+            point("2020-01-01T09:00:00", 50_000.0),
+            point("2026-08-09T09:00:00", 420_000.0),
+        ];
+        let result = dedupe_and_filter_snapshots(snapshots, None);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn skips_malformed_date_without_panicking() {
+        let snapshots = vec![point("bad", 1.0), point("2026-08-09T09:00:00", 420_000.0)];
+        let result = dedupe_and_filter_snapshots(snapshots, None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 420_000.0);
+    }
 }


### PR DESCRIPTION
## Summary
An earlier fix (#788) addressed the single-snapshot "misleading chart" case, but two residual symptoms were reported after that shipped:

1. **Performance shows values in the millions after importing ~420k in real holdings.** `get_performance` returned every `portfolio_snapshots` row in the requested date range regardless of whether it reflected the *currently-held* positions. A snapshot recorded before the oldest currently-held position existed — e.g. leftover dev/test snapshots recorded before a from-scratch CSV import — got spliced into the series, producing a misleading cliff/jump that doesn't represent this portfolio's actual history.
2. **The Performance account filter lists every supported account type** (TFSA/RRSP/FHSA/Taxable/Crypto/Cash/Other) instead of only the ones actually present in the portfolio — the same bug already fixed on the Dashboard for #784.

## Fix
- `get_performance` now computes the oldest active holding's `created_at` and drops any snapshot dated earlier than that, before deduplicating by calendar day. The filtering logic was extracted into a pure `dedupe_and_filter_snapshots` helper for direct unit testing.
- `Performance.tsx` now derives its account filter options from `portfolio.holdings` (same `present accounts` pattern already used in `Dashboard.tsx`) instead of the static `ACCOUNT_OPTIONS` list.

## Test plan
- [x] `cargo test -p portfolio-tracker --lib commands::prices` — 5 new tests covering: keeps latest-per-day, drops pre-cutoff snapshots (explicit millions-vs-420k regression case), keeps same-day-as-holding-creation snapshot, no-cutoff keeps full history, malformed date doesn't panic.
- [x] `cargo test -p portfolio-tracker --lib` — full backend suite, 473/473 pass.
- [x] `npx vitest run frontend/components/__tests__/Performance.test.tsx` — 10/10 pass, including a new test asserting FHSA/Crypto/Other are excluded from the account filter when absent from the portfolio.
- [x] `tsc --noEmit`, `eslint`, `cargo fmt --check`, `cargo clippy -- -D warnings` — all clean.

Closes #787