### PR TITLE
fix: make stale-price and offline banners dismissible (#798)

### DIFF
--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -186,12 +186,29 @@ export function TopBar({
   const showFailedBanner =
     failedSymbolsKey !== null && failedSymbolsKey !== dismissedFailedSymbolsKey;
 
+  // Offline banner dismiss — resets when connectivity is restored so the banner
+  // reappears on the next offline period (#798).
+  const [dismissedOffline, setDismissedOffline] = useState(false);
+  useEffect(() => {
+    if (!isOffline) setDismissedOffline(false);
+  }, [isOffline]);
+  const showOfflineBanner = isOffline && !dismissedOffline;
+
+  // Stale-price banner dismiss — keyed on lastUpdated so a completed refresh
+  // resets the key and the banner reappears if prices remain stale (#798).
+  const hasStaleHoldings =
+    !isOffline && !isRefreshing && (portfolio?.holdings.some((h) => h.priceIsStale) ?? false);
+  const stalePriceKey = hasStaleHoldings ? (portfolio?.lastUpdated ?? 'stale') : null;
+  const [dismissedStalePriceKey, setDismissedStalePriceKey] = useState<string | null>(null);
+  const showStalePriceBanner = stalePriceKey !== null && stalePriceKey !== dismissedStalePriceKey;
+
   return (
     <div style={{ position: 'sticky', top: 0, zIndex: 5 }}>
       <div
         style={{
           background: 'var(--bg-primary)',
-          borderBottom: showFailedBanner || isOffline ? 'none' : '1px solid var(--border-primary)',
+          borderBottom:
+            showFailedBanner || showOfflineBanner ? 'none' : '1px solid var(--border-primary)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'space-between',
@@ -280,7 +297,7 @@ export function TopBar({
       </div>
 
       {/* Offline banner */}
-      {isOffline && (
+      {showOfflineBanner && (
         <div
           style={{
             background: 'rgba(59,130,246,0.08)',
@@ -320,6 +337,23 @@ export function TopBar({
             }}
           >
             Retry
+          </button>
+          <button
+            onClick={() => setDismissedOffline(true)}
+            aria-label="Dismiss"
+            title="Dismiss"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-accent)',
+              cursor: 'pointer',
+              padding: 2,
+              display: 'flex',
+              alignItems: 'center',
+              opacity: 0.8,
+            }}
+          >
+            <X size={12} />
           </button>
         </div>
       )}
@@ -380,8 +414,9 @@ export function TopBar({
         </div>
       )}
 
-      {/* Stale price warning banner — shown when any holding has a price older than 24h */}
-      {!isOffline && !isRefreshing && portfolio?.holdings.some((h) => h.priceIsStale) && (
+      {/* Stale price warning banner — shown when any holding has a price older than 24h.
+           Keyed on lastUpdated so a completed refresh resets dismissal (#798). */}
+      {showStalePriceBanner && (
         <div
           style={{
             background: 'rgba(251,191,36,0.06)',
@@ -398,6 +433,41 @@ export function TopBar({
         >
           <AlertTriangle size={12} />
           <span>Some prices may be outdated (&gt;24h old) — click Refresh to update</span>
+          <button
+            onClick={onRefresh}
+            disabled={isBusy}
+            style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: '1px solid var(--color-warning)',
+              color: 'var(--color-warning)',
+              fontSize: 10,
+              fontFamily: 'var(--font-mono)',
+              padding: '2px 8px',
+              cursor: 'pointer',
+              borderRadius: '2px',
+              opacity: isBusy ? 0.5 : 1,
+            }}
+          >
+            Refresh
+          </button>
+          <button
+            onClick={() => setDismissedStalePriceKey(stalePriceKey)}
+            aria-label="Dismiss"
+            title="Dismiss"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: 'var(--color-warning)',
+              cursor: 'pointer',
+              padding: 2,
+              display: 'flex',
+              alignItems: 'center',
+              opacity: 0.8,
+            }}
+          >
+            <X size={12} />
+          </button>
         </div>
       )}
     </div>

--- a/frontend/components/__tests__/TopBar.test.tsx
+++ b/frontend/components/__tests__/TopBar.test.tsx
@@ -125,3 +125,155 @@ describe('TopBar failed-symbols banner dismiss (#786)', () => {
     expect(document.activeElement).toBe(dismissButton);
   });
 });
+
+describe('TopBar stale-price banner dismiss (#798)', () => {
+  const stalePortfolio: PortfolioSnapshot = {
+    ...mockPortfolio,
+    lastUpdated: '2024-03-05T14:30:00Z',
+    holdings: [
+      {
+        id: 'h1',
+        symbol: 'AAPL',
+        name: 'Apple',
+        assetType: 'stock' as const,
+        account: 'taxable' as const,
+        quantity: 1,
+        costBasis: 100,
+        currency: 'CAD',
+        exchange: '',
+        currentPrice: 150,
+        currentPriceCad: 150,
+        marketValueCad: 150,
+        costValueCad: 100,
+        gainLoss: 50,
+        gainLossPercent: 50,
+        weight: 100,
+        targetWeight: null,
+        targetValue: 0,
+        targetDeltaValue: 0,
+        targetDeltaPercent: 0,
+        dailyChangePercent: 0,
+        fxStale: false,
+        priceIsStale: true,
+        indicatedAnnualDividend: null,
+        indicatedAnnualDividendCurrency: null,
+        dividendFrequency: null,
+        maturityDate: null,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      },
+    ],
+  };
+
+  it('shows Refresh and Dismiss buttons on the stale-price banner', () => {
+    renderTopBar({ isOffline: false, portfolio: stalePortfolio });
+
+    expect(screen.getByText(/Some prices may be outdated/)).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Refresh' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
+  });
+
+  it('dismiss hides the stale-price banner without calling onRefresh', () => {
+    const onRefresh = vi.fn();
+    renderTopBar({ isOffline: false, portfolio: stalePortfolio, onRefresh });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByText(/Some prices may be outdated/)).toBeNull();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('stale-price banner reappears after a refresh changes lastUpdated', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderTopBar({ isOffline: false, portfolio: stalePortfolio, onRefresh });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByText(/Some prices may be outdated/)).toBeNull();
+
+    // Simulate a completed refresh: lastUpdated changes
+    const freshButStillStalePortfolio: PortfolioSnapshot = {
+      ...stalePortfolio,
+      lastUpdated: '2024-03-05T15:00:00Z',
+    };
+
+    rerender(
+      <MemoryRouter>
+        <TopBar
+          portfolio={freshButStillStalePortfolio}
+          loading={false}
+          isOffline={false}
+          onRefresh={onRefresh}
+          baseCurrency="CAD"
+          onBaseCurrencyChange={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Some prices may be outdated/)).toBeTruthy();
+  });
+
+  it('stale-price Dismiss is keyboard-accessible', () => {
+    renderTopBar({ isOffline: false, portfolio: stalePortfolio });
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    expect(dismissButton.tagName).toBe('BUTTON');
+    dismissButton.focus();
+    expect(document.activeElement).toBe(dismissButton);
+  });
+});
+
+describe('TopBar offline banner dismiss (#798)', () => {
+  it('shows a Dismiss button on the offline banner', () => {
+    renderTopBar({ isOffline: true });
+
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
+  });
+
+  it('dismiss hides the offline banner without calling onRefresh', () => {
+    const onRefresh = vi.fn();
+    renderTopBar({ isOffline: true, onRefresh });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    expect(screen.queryByText(/Offline/)).toBeNull();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('offline banner reappears when going offline again after reconnecting', async () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderTopBar({ isOffline: true, onRefresh });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(screen.queryByText(/Offline/)).toBeNull();
+
+    // Go back online — dismissal state is reset
+    rerender(
+      <MemoryRouter>
+        <TopBar
+          portfolio={mockPortfolio}
+          loading={false}
+          isOffline={false}
+          onRefresh={onRefresh}
+          baseCurrency="CAD"
+          onBaseCurrencyChange={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    // Go offline again — banner should reappear
+    rerender(
+      <MemoryRouter>
+        <TopBar
+          portfolio={mockPortfolio}
+          loading={false}
+          isOffline={true}
+          onRefresh={onRefresh}
+          baseCurrency="CAD"
+          onBaseCurrencyChange={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Offline/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- **Stale-price banner** — was missing any dismiss control. Now has a Dismiss (X) button and a Refresh shortcut button. Keyed on `portfolio.lastUpdated` so dismissal resets after each completed refresh: if prices remain stale after the user refreshes, the banner reappears.
- **Offline banner** — also gained a Dismiss (X) button. Dismiss state resets via `useEffect` when `isOffline` returns to `false`, so the next offline period shows the banner again.
- **Failed-symbols banner** — already had dismiss from #786; no change.

## Technical approach

Stale-price keying:
```typescript
const stalePriceKey = hasStaleHoldings ? (portfolio?.lastUpdated ?? 'stale') : null;
const [dismissedStalePriceKey, setDismissedStalePriceKey] = useState<string | null>(null);
const showStalePriceBanner = stalePriceKey !== null && stalePriceKey !== dismissedStalePriceKey;
```

Offline dismiss reset:
```typescript
const [dismissedOffline, setDismissedOffline] = useState(false);
useEffect(() => { if (!isOffline) setDismissedOffline(false); }, [isOffline]);
```

## Tests added (8)

Stale-price banner:
- Shows Refresh and Dismiss buttons when prices are stale
- Dismiss hides banner without calling onRefresh
- Banner reappears after a refresh changes lastUpdated
- Dismiss is keyboard-accessible

Offline banner:
- Shows a Dismiss button
- Dismiss hides banner without calling onRefresh
- Banner reappears when going offline again after reconnecting

Closes #798

## Test plan
- [ ] Stale-price banner: appears when holding price is >24h old; Dismiss hides it; Refresh (the shortcut in the banner) calls refresh; after a new refresh the banner reappears if still stale
- [ ] Offline banner: appears when offline; Dismiss hides it; reconnect then go offline again → banner reappears
- [ ] 447 frontend tests pass