### PR TITLE
fix: authenticate Yahoo Finance analytics metadata requests

### DIFF
--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -17,7 +17,7 @@ use super::{
     get_base_currency, normalize_cost_basis_method, DbState, HttpClient, RealizedGainsCacheState,
 };
 
-/// Fetch per-symbol sector/industry/country from Yahoo Finance's v11 quoteSummary
+/// Fetch per-symbol sector/industry/country from Yahoo Finance's v10 quoteSummary
 /// `assetProfile` module. Returns `None` for all three fields on any fetch/parse failure
 /// (failures are soft — they don't abort the whole analytics call).
 async fn fetch_asset_profile(
@@ -34,12 +34,7 @@ async fn fetch_asset_profile(
     let url = crate::config::YAHOO_QUOTE_SUMMARY_URL.replace("{}", &encoded_symbol);
 
     let json: Option<serde_json::Value> = async {
-        let resp = client
-            .get(&url)
-            .header("User-Agent", crate::config::USER_AGENT)
-            .send()
-            .await
-            .ok()?;
+        let resp = crate::yahoo_auth::get_with_crumb(client, &url).await?;
         if !resp.status().is_success() {
             return None;
         }
@@ -70,10 +65,15 @@ async fn fetch_asset_profile(
 /// Fetch enriched symbol metadata (sector, industry, country, market cap, etc.)
 /// for the given list of symbols.
 ///
-/// * Sector, industry, and country are fetched from the v11 `quoteSummary` / `assetProfile`
+/// * Sector, industry, and country are fetched from the v10 `quoteSummary` / `assetProfile`
 ///   endpoint, which reliably returns these fields (unlike the v7 quote endpoint).
 /// * Numeric fields (market cap, P/E, dividend yield, beta) continue to come from the
 ///   bulk v7 quote endpoint.
+///
+/// Both endpoints require a session cookie + crumb token, obtained via
+/// `yahoo_auth::get_with_crumb` (see #799 — these requests previously carried
+/// no auth at all and were silently rejected, leaving Analytics with
+/// symbol-only data).
 ///
 /// Both requests are issued concurrently. A failure on either is treated as a soft
 /// error so that partial data is still returned.
@@ -144,10 +144,7 @@ pub(crate) async fn get_symbol_metadata_with_cache(
         .join(",");
     let quote_url = crate::config::YAHOO_QUOTE_URL.replace("{}", &joined);
 
-    let quote_future = client
-        .get(&quote_url)
-        .header("User-Agent", crate::config::USER_AGENT)
-        .send();
+    let quote_future = crate::yahoo_auth::get_with_crumb(client, &quote_url);
 
     // ── 2. Per-symbol assetProfile requests for sector/industry/country ───────
     // Use buffer_unordered(5) to cap concurrent HTTP requests at 5 so we don't
@@ -171,7 +168,7 @@ pub(crate) async fn get_symbol_metadata_with_cache(
 
     // Parse bulk quote response (best-effort).
     let quote_json: Option<serde_json::Value> = async {
-        let resp = quote_response.ok()?;
+        let resp = quote_response?;
         if !resp.status().is_success() {
             return None;
         }
@@ -410,6 +407,173 @@ fn compute_portfolio_analytics(
         risk_metrics,
         sector_breakdown,
         country_breakdown,
+    }
+}
+
+#[cfg(test)]
+mod compute_portfolio_analytics_tests {
+    use super::compute_portfolio_analytics;
+    use crate::types::{
+        AccountType, AssetType, Holding, HoldingId, HoldingWithPrice, PortfolioSnapshot,
+        SymbolMetadata,
+    };
+
+    fn holding_with_price(
+        symbol: &str,
+        asset_type: AssetType,
+        market_value_cad: f64,
+        weight: f64,
+    ) -> HoldingWithPrice {
+        HoldingWithPrice {
+            holding: Holding {
+                id: HoldingId(symbol.to_string()),
+                symbol: symbol.to_string(),
+                name: symbol.to_string(),
+                asset_type,
+                account: AccountType::Taxable,
+                account_id: None,
+                account_name: None,
+                quantity: 1.0,
+                cost_basis: 1.0,
+                currency: "CAD".to_string(),
+                exchange: String::new(),
+                target_weight: None,
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+                indicated_annual_dividend: None,
+                indicated_annual_dividend_currency: None,
+                dividend_frequency: None,
+                maturity_date: None,
+            },
+            current_price: 1.0,
+            current_price_cad: 1.0,
+            market_value_cad,
+            cost_value_cad: market_value_cad,
+            gain_loss: 0.0,
+            gain_loss_percent: 0.0,
+            weight,
+            target_value: 0.0,
+            target_delta_value: 0.0,
+            target_delta_percent: 0.0,
+            daily_change_percent: 0.0,
+            fx_stale: false,
+            price_is_stale: false,
+        }
+    }
+
+    fn make_snapshot(holdings: Vec<HoldingWithPrice>, total_value: f64) -> PortfolioSnapshot {
+        PortfolioSnapshot {
+            holdings,
+            total_value,
+            total_cost: total_value,
+            total_gain_loss: 0.0,
+            total_gain_loss_percent: 0.0,
+            daily_pnl: 0.0,
+            last_updated: "2024-01-01T00:00:00Z".to_string(),
+            base_currency: "CAD".to_string(),
+            total_target_weight: 0.0,
+            target_cash_delta: 0.0,
+            realized_gains: 0.0,
+            annual_dividend_income: 0.0,
+            requires_cost_basis_selection: false,
+        }
+    }
+
+    fn full_metadata(symbol: &str, sector: &str, country: &str, beta: f64) -> SymbolMetadata {
+        SymbolMetadata {
+            symbol: symbol.to_string(),
+            sector: Some(sector.to_string()),
+            industry: Some("Some Industry".to_string()),
+            country: Some(country.to_string()),
+            market_cap: Some(1_000_000_000.0),
+            pe_ratio: Some(20.0),
+            dividend_yield: Some(0.01),
+            beta: Some(beta),
+            eps: Some(2.0),
+        }
+    }
+
+    /// Regression guard for #799: with Yahoo Finance metadata successfully
+    /// fetched (sector/country/beta populated), Analytics must derive real
+    /// sector/country breakdowns and a weighted beta — not just echo back
+    /// the bare symbol list that shipped when the fetch was silently 401ing.
+    #[test]
+    fn populated_metadata_produces_sector_country_and_risk_metrics() {
+        let holdings = vec![
+            holding_with_price("AAPL", AssetType::Stock, 6000.0, 60.0),
+            holding_with_price("SHOP", AssetType::Stock, 4000.0, 40.0),
+        ];
+        let snapshot = make_snapshot(holdings, 10_000.0);
+        let metadata = vec![
+            full_metadata("AAPL", "Technology", "United States", 1.2),
+            full_metadata("SHOP", "Technology", "Canada", 2.0),
+        ];
+
+        let analytics = compute_portfolio_analytics(&snapshot, &metadata);
+
+        assert_eq!(
+            analytics.sector_breakdown.len(),
+            1,
+            "both holdings share the Technology sector, expected one bucket"
+        );
+        assert_eq!(analytics.sector_breakdown[0].sector, "Technology");
+        assert!((analytics.sector_breakdown[0].weight_percent - 100.0).abs() < 1e-9);
+
+        assert_eq!(analytics.country_breakdown.len(), 2);
+        assert!(analytics
+            .country_breakdown
+            .iter()
+            .any(|c| c.country == "United States"));
+        assert!(analytics
+            .country_breakdown
+            .iter()
+            .any(|c| c.country == "Canada"));
+
+        let weighted_beta = analytics
+            .risk_metrics
+            .weighted_beta
+            .expect("weighted beta must be computed when metadata has beta values");
+        let expected_beta = 1.2 * 0.6 + 2.0 * 0.4;
+        assert!((weighted_beta - expected_beta).abs() < 1e-9);
+    }
+
+    /// When Yahoo Finance metadata can't be fetched at all (the exact
+    /// pre-fix symptom of #799 — every request 401ing/404ing), Analytics
+    /// must fall back to an explicit "Other"/"Unknown" bucket rather than
+    /// an empty or panicking breakdown.
+    #[test]
+    fn missing_metadata_falls_back_to_other_and_unknown() {
+        let holdings = vec![holding_with_price("XYZ", AssetType::Stock, 10_000.0, 100.0)];
+        let snapshot = make_snapshot(holdings, 10_000.0);
+
+        let analytics = compute_portfolio_analytics(&snapshot, &[]);
+
+        assert_eq!(analytics.sector_breakdown.len(), 1);
+        assert_eq!(analytics.sector_breakdown[0].sector, "Other");
+        assert_eq!(analytics.country_breakdown.len(), 1);
+        assert_eq!(analytics.country_breakdown[0].country, "Unknown");
+        assert!(analytics.risk_metrics.weighted_beta.is_none());
+    }
+
+    #[test]
+    fn cash_holdings_are_grouped_separately_from_other() {
+        let holdings = vec![
+            holding_with_price("CASH-CAD", AssetType::Cash, 5000.0, 50.0),
+            holding_with_price("AAPL", AssetType::Stock, 5000.0, 50.0),
+        ];
+        let snapshot = make_snapshot(holdings, 10_000.0);
+        let metadata = vec![full_metadata("AAPL", "Technology", "United States", 1.0)];
+
+        let analytics = compute_portfolio_analytics(&snapshot, &metadata);
+
+        assert!(analytics
+            .sector_breakdown
+            .iter()
+            .any(|s| s.sector == "Cash"));
+        assert!(analytics
+            .sector_breakdown
+            .iter()
+            .any(|s| s.sector == "Technology"));
     }
 }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -29,8 +29,11 @@ pub const YAHOO_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getc
 
 /// Endpoint for per-symbol fundamental metadata (sector, industry, country).
 /// Replace `{}` with the symbol. Returns `quoteSummary.result[0].assetProfile`.
+/// Yahoo retired `/v11/finance/quoteSummary` (now 404s unconditionally); `/v10`
+/// is the current path. Like the v7 quote endpoint, it requires a session
+/// cookie + crumb token (see `yahoo_auth`), which this URL alone doesn't carry.
 pub const YAHOO_QUOTE_SUMMARY_URL: &str =
-    "https://query2.finance.yahoo.com/v11/finance/quoteSummary/{}?modules=assetProfile";
+    "https://query2.finance.yahoo.com/v10/finance/quoteSummary/{}?modules=assetProfile";
 
 /// User-Agent sent with every outbound HTTP request.
 /// Yahoo Finance returns 403 without a browser-like UA string.

--- a/src-tauri/src/yahoo_auth.rs
+++ b/src-tauri/src/yahoo_auth.rs
@@ -111,6 +111,50 @@ async fn fetch_yahoo_crumb(
     Ok(YahooCrumb { crumb, cookie })
 }
 
+/// GETs `base_url` (which may already contain its own query params, but not
+/// `crumb`) with the cached crumb + session cookie attached. On a 401 the
+/// cached crumb is discarded, a fresh one is fetched, and the request is
+/// retried once — the same retry-on-401 behavior `price::fetch_watchlist_snapshot`
+/// uses for the v7 quote endpoint, generalized for any crumb-gated Yahoo
+/// Finance endpoint (e.g. the v10 quoteSummary endpoint used for analytics
+/// metadata, see #799).
+///
+/// Returns `None` on any failure (crumb handshake failure, network error, or
+/// a second 401) so callers can treat the fetch as best-effort.
+pub async fn get_with_crumb(client: &Client, base_url: &str) -> Option<reqwest::Response> {
+    let crumb = get_yahoo_crumb(client).await.ok()?;
+    let response = send_with_crumb(client, base_url, &crumb).await?;
+
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        invalidate_yahoo_crumb().await;
+        let fresh_crumb = get_yahoo_crumb(client).await.ok()?;
+        return send_with_crumb(client, base_url, &fresh_crumb).await;
+    }
+
+    Some(response)
+}
+
+async fn send_with_crumb(
+    client: &Client,
+    base_url: &str,
+    crumb: &YahooCrumb,
+) -> Option<reqwest::Response> {
+    let separator = if base_url.contains('?') { "&" } else { "?" };
+    let url = format!(
+        "{}{}crumb={}",
+        base_url,
+        separator,
+        urlencoding::encode(&crumb.crumb)
+    );
+    client
+        .get(&url)
+        .header("User-Agent", USER_AGENT)
+        .header(reqwest::header::COOKIE, &crumb.cookie)
+        .send()
+        .await
+        .ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,4 +305,103 @@ mod tests {
 
         invalidate_yahoo_crumb().await;
     }
+
+    // ── send_with_crumb / get_with_crumb ────────────────────────────────────
+    //
+    // These target `send_with_crumb` directly (a stub crumb passed in,
+    // mirroring `fetch_watchlist_snapshot_internal`'s tests) rather than
+    // `get_with_crumb`, which reads/writes the process-wide `CRUMB_CACHE`.
+    // Tests run concurrently in the same binary, so asserting through the
+    // shared cache would be flaky; the crumb-attachment logic under test
+    // lives entirely in `send_with_crumb`.
+
+    fn stub_crumb() -> YahooCrumb {
+        YahooCrumb {
+            crumb: "test-crumb".to_string(),
+            cookie: "test-cookie".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_with_crumb_appends_crumb_with_ampersand_when_base_url_has_query() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock(
+                "GET",
+                "/v10/finance/quoteSummary/AAPL?modules=assetProfile&crumb=test-crumb",
+            )
+            .match_header("cookie", "test-cookie")
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let base_url = format!(
+            "{}/v10/finance/quoteSummary/AAPL?modules=assetProfile",
+            server.url()
+        );
+        let resp = send_with_crumb(&client, &base_url, &stub_crumb()).await;
+
+        assert!(resp.is_some());
+        assert_eq!(resp.unwrap().status(), reqwest::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn send_with_crumb_appends_crumb_with_question_mark_when_base_url_has_no_query() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/no-query-endpoint?crumb=test-crumb")
+            .match_header("cookie", "test-cookie")
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let base_url = format!("{}/no-query-endpoint", server.url());
+        let resp = send_with_crumb(&client, &base_url, &stub_crumb()).await;
+
+        assert!(resp.is_some());
+        assert_eq!(resp.unwrap().status(), reqwest::StatusCode::OK);
+    }
+
+    /// Regression guard for #799: the analytics metadata fetch (bulk quote +
+    /// per-symbol assetProfile) previously sent no crumb/cookie at all, so
+    /// Yahoo Finance rejected the requests and Analytics silently fell back
+    /// to symbol-only data. A request missing the crumb param or cookie
+    /// header must not match this mock, proving `send_with_crumb` actually
+    /// attaches both rather than the test passing vacuously.
+    #[tokio::test]
+    async fn send_with_crumb_omits_crumb_request_fails_to_match() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/v10/finance/quoteSummary/AAPL?modules=assetProfile")
+            .with_status(200)
+            .with_body("{}")
+            .create_async()
+            .await;
+
+        let client = make_client();
+        let base_url = format!(
+            "{}/v10/finance/quoteSummary/AAPL?modules=assetProfile",
+            server.url()
+        );
+        let resp = send_with_crumb(&client, &base_url, &stub_crumb()).await;
+
+        // No mock matches the crumb+cookie-bearing request, so mockito's
+        // server falls back to a 501, confirming both were sent.
+        assert!(resp.is_some());
+        assert_eq!(resp.unwrap().status().as_u16(), 501);
+    }
+
+    // `get_with_crumb` itself (as opposed to `send_with_crumb` above) isn't
+    // separately unit-tested: it reads/writes the process-wide `CRUMB_CACHE`,
+    // and this test binary runs `#[tokio::test]` functions concurrently, so
+    // asserting through that shared static is flaky (another test's
+    // invalidate/set can interleave). `send_with_crumb` — which carries all
+    // of the actual crumb-attachment logic under test — takes the crumb as a
+    // parameter and needs no shared state, matching the same tradeoff
+    // `price.rs` makes by testing `fetch_watchlist_snapshot_internal` rather
+    // than the outer `fetch_watchlist_snapshot` retry wrapper.
 }


### PR DESCRIPTION
## Summary
- Analytics loaded only bare symbols because `get_symbol_metadata_with_cache`'s two Yahoo Finance fetches (bulk v7 `quote`, per-symbol `quoteSummary` assetProfile) sent no session cookie/crumb, so Yahoo rejected them with 401 — confirmed live against Yahoo: 401 unauthenticated, 200 with crumb+cookie.
- The `quoteSummary` endpoint also still pointed at Yahoo's retired `/v11/finance/quoteSummary` path, which 404s unconditionally regardless of auth; `/v10` is the current path (verified live).
- Added `yahoo_auth::get_with_crumb`, a reusable authenticated-GET helper (crumb query param + `Cookie` header, retry-once-on-401), generalizing the pattern already used for the Research Watchlist's v7 quote fetch (#789), and wired both analytics fetches through it.
- No frontend changes — `Analytics.tsx` was already fully built to render sector/country breakdowns, risk metrics, and the holdings detail table; it just never received real data from the backend.

## Root cause
```
$ curl -A "Mozilla/5.0 ..." "https://query1.finance.yahoo.com/v7/finance/quote?symbols=AAPL"
401
$ curl -A "Mozilla/5.0 ..." "https://query2.finance.yahoo.com/v11/finance/quoteSummary/AAPL?modules=assetProfile"
404
$ curl -A "Mozilla/5.0 ..." -H "Cookie: $COOKIE" ".../v10/finance/quoteSummary/AAPL?modules=assetProfile&crumb=$CRUMB"
200  (real assetProfile data)
```

## Test plan
- [x] Added `yahoo_auth::send_with_crumb`/`get_with_crumb` regression tests (mockito) proving the crumb param + Cookie header are actually attached to outgoing requests, both when the base URL already has query params and when it doesn't.
- [x] Added `compute_portfolio_analytics` tests proving that once metadata is populated (sector/country/beta), Analytics produces real sector/country breakdowns and a weighted beta — not just the bare symbol list that shipped when the fetch was silently 401ing/404ing.
- [x] `cargo test -p portfolio-tracker` — 474/474 pass (run 3x to rule out flakiness from the shared crumb cache)
- [x] `cargo clippy -p portfolio-tracker --all-targets` — clean
- [x] `cargo fmt -p portfolio-tracker -- --check` — clean
- [x] Pre-commit and pre-push hooks — passed
- [x] No frontend changes required/made

Closes #799