### PR TITLE
fix: update quoteSummary to v10 and add crumb auth (#799 follow-up)

### DIFF
--- a/src-tauri/src/commands/analytics.rs
+++ b/src-tauri/src/commands/analytics.rs
@@ -33,13 +33,35 @@ async fn fetch_asset_profile(
     let encoded_symbol = urlencoding::encode(symbol);
     let url = crate::config::YAHOO_QUOTE_SUMMARY_URL.replace("{}", &encoded_symbol);
 
+    // quoteSummary requires crumb+cookie auth (same as the v7 bulk quote endpoint).
+    // Retry once on 401 in case the cached crumb has gone stale.
     let json: Option<serde_json::Value> = async {
+        let crumb = crate::yahoo_auth::get_yahoo_crumb(client).await.ok()?;
+        let authed_url = format!("{}&crumb={}", url, urlencoding::encode(&crumb.crumb));
         let resp = client
-            .get(&url)
+            .get(&authed_url)
             .header("User-Agent", crate::config::USER_AGENT)
+            .header(reqwest::header::COOKIE, &crumb.cookie)
             .send()
             .await
             .ok()?;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            // Crumb may have expired — invalidate and retry once.
+            crate::yahoo_auth::invalidate_yahoo_crumb().await;
+            let fresh = crate::yahoo_auth::get_yahoo_crumb(client).await.ok()?;
+            let retry_url = format!("{}&crumb={}", url, urlencoding::encode(&fresh.crumb));
+            let retry_resp = client
+                .get(&retry_url)
+                .header("User-Agent", crate::config::USER_AGENT)
+                .header(reqwest::header::COOKIE, &fresh.cookie)
+                .send()
+                .await
+                .ok()?;
+            if !retry_resp.status().is_success() {
+                return None;
+            }
+            return retry_resp.json::<serde_json::Value>().await.ok();
+        }
         if !resp.status().is_success() {
             return None;
         }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -30,7 +30,7 @@ pub const YAHOO_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getc
 /// Endpoint for per-symbol fundamental metadata (sector, industry, country).
 /// Replace `{}` with the symbol. Returns `quoteSummary.result[0].assetProfile`.
 pub const YAHOO_QUOTE_SUMMARY_URL: &str =
-    "https://query2.finance.yahoo.com/v11/finance/quoteSummary/{}?modules=assetProfile";
+    "https://query2.finance.yahoo.com/v10/finance/quoteSummary/{}?modules=assetProfile";
 
 /// User-Agent sent with every outbound HTTP request.
 /// Yahoo Finance returns 403 without a browser-like UA string.


### PR DESCRIPTION
## Summary

Two issues left after PR #803 that kept sector, industry, and country blank in the Analytics tab:

**1. Wrong API version** — `YAHOO_QUOTE_SUMMARY_URL` pointed at \`/v11/finance/quoteSummary\` which Yahoo retired. Every request 404d unconditionally regardless of auth. Updated to \`/v10\`.

**2. No authentication** — \`fetch_asset_profile\` made the quoteSummary request without crumb+cookie. Wired in \`get_yahoo_crumb()\` with the same retry-once-on-401 pattern used for the v7 bulk quote fetch in #803.

The root cause was confirmed live (as noted in PR #805 which I incorrectly closed as a duplicate of #803):
\`\`\`
curl .../v11/finance/quoteSummary/AAPL?modules=assetProfile → 404
curl .../v10/finance/quoteSummary/AAPL?modules=assetProfile -H "Cookie: ..." → 200
\`\`\`

## Test plan
- [ ] Open Analytics tab — sector/country breakdown and risk metrics now populate
- [ ] 448 frontend + 480 backend tests pass